### PR TITLE
adding print-policy and outraw options to genpolicy tool

### DIFF
--- a/src/tools/genpolicy/src/main.rs
+++ b/src/tools/genpolicy/src/main.rs
@@ -50,6 +50,12 @@ struct CommandLineOptions {
 
     #[clap(short, long)]
     silent_unsupported_fields: bool,
+
+    #[clap(short, long)]
+    raw_out: bool,
+
+    #[clap(short, long)]
+    base64_out: bool,
 }
 
 #[tokio::main]
@@ -70,6 +76,8 @@ async fn main() {
         args.output_policy_file,
         &config_map_files,
         args.silent_unsupported_fields,
+        args.raw_out,
+        args.base64_out,
     );
 
     debug!("Creating policy from yaml, infra data and rules files...");

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -204,6 +204,9 @@ impl AgentPolicy {
         let mut yaml_string = String::new();
         for i in 0..self.resources.len() {
             let policy = self.resources[i].generate_policy(self);
+            if self.config.base64_out {
+                println!("{}", policy);
+            }
             yaml_string += &self.resources[i].serialize(&policy);
         }
 
@@ -244,6 +247,9 @@ impl AgentPolicy {
         let policy = self.rules.clone() + "\npolicy_data := " + &json_data;
         if let Some(file_name) = &self.config.output_policy_file {
             policy::export_decoded_policy(&policy, &file_name);
+        }
+        if self.config.raw_out {
+            policy::base64_out(&policy);
         }
         general_purpose::STANDARD.encode(policy.as_bytes())
     }
@@ -528,6 +534,12 @@ pub fn export_decoded_policy(policy: &str, file_name: &str) {
         .unwrap();
     f.write_all(policy.as_bytes()).unwrap();
     f.flush().map_err(|e| anyhow!(e)).unwrap();
+}
+
+pub fn base64_out(policy: &str) {
+    std::io::stdout()
+        .write_all(policy.as_bytes())
+        .unwrap();
 }
 
 fn substitute_env_variables(env: &mut Vec<String>) {

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub config_map_files: Option<Vec<String>>,
 
     pub silent_unsupported_fields: bool,
+    pub raw_out: bool,
+    pub base64_out: bool,
 }
 
 impl Config {
@@ -26,6 +28,8 @@ impl Config {
         output_policy_file: Option<String>,
         config_map_files: &Vec<String>,
         silent_unsupported_fields: bool,
+        raw_out: bool,
+        base64_out: bool,
     ) -> Self {
         let mut input_path = ".".to_string();
         if let Some(path) = input_files_path {
@@ -51,6 +55,8 @@ impl Config {
             output_policy_file,
             config_map_files: cm_files,
             silent_unsupported_fields,
+            raw_out,
+            base64_out,
         }
     }
 }


### PR DESCRIPTION
Discussed with Dan about adding these two options to have feature parity with the `az confcom acipolicygen` tooling. If it needs to be refactored into some other form, please let me know

Usage in printing base64 policy to stdout:
`genpolicy -y pod.yaml --base64-out`
Usage in printing decoded policy to stdout:
`genpolicy -y pod.yaml --raw-out`

thanks!