### PR TITLE
getting rid of output policy file flag

### DIFF
--- a/src/tools/genpolicy/src/main.rs
+++ b/src/tools/genpolicy/src/main.rs
@@ -40,9 +40,6 @@ struct CommandLineOptions {
     input_files_path: Option<String>,
 
     #[clap(short, long)]
-    output_policy_file: Option<String>,
-
-    #[clap(short, long)]
     config_map_file: Option<String>,
 
     #[clap(short, long)]
@@ -73,7 +70,6 @@ async fn main() {
         args.use_cached_files,
         args.yaml_file,
         args.input_files_path,
-        args.output_policy_file,
         &config_map_files,
         args.silent_unsupported_fields,
         args.raw_out,

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -18,7 +18,7 @@ use crate::utils;
 use crate::volume;
 use crate::yaml;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use base64::{engine::general_purpose, Engine as _};
 use log::debug;
 use oci::*;
@@ -245,9 +245,6 @@ impl AgentPolicy {
 
         let json_data = serde_json::to_string_pretty(&policy_data).unwrap();
         let policy = self.rules.clone() + "\npolicy_data := " + &json_data;
-        if let Some(file_name) = &self.config.output_policy_file {
-            policy::export_decoded_policy(&policy, &file_name);
-        }
         if self.config.raw_out {
             policy::base64_out(&policy);
         }
@@ -521,19 +518,6 @@ fn name_to_hash(name: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(name);
     format!("{:x}", hasher.finalize())
-}
-
-/// Creates a text file including the Rego rules and data.
-pub fn export_decoded_policy(policy: &str, file_name: &str) {
-    let mut f = std::fs::OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .create(true)
-        .open(file_name)
-        .map_err(|e| anyhow!(e))
-        .unwrap();
-    f.write_all(policy.as_bytes()).unwrap();
-    f.flush().map_err(|e| anyhow!(e)).unwrap();
 }
 
 pub fn base64_out(policy: &str) {

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -12,7 +12,6 @@ pub struct Config {
     pub yaml_file: Option<String>,
     pub rules_file: String,
     pub infra_data_file: String,
-    pub output_policy_file: Option<String>,
     pub config_map_files: Option<Vec<String>>,
 
     pub silent_unsupported_fields: bool,
@@ -25,7 +24,6 @@ impl Config {
         use_cache: bool,
         yaml_file: Option<String>,
         input_files_path: Option<String>,
-        output_policy_file: Option<String>,
         config_map_files: &Vec<String>,
         silent_unsupported_fields: bool,
         raw_out: bool,
@@ -52,7 +50,6 @@ impl Config {
             yaml_file,
             rules_file,
             infra_data_file,
-            output_policy_file,
             config_map_files: cm_files,
             silent_unsupported_fields,
             raw_out,


### PR DESCRIPTION
In favor of printing to stdout and redirecting to a file as discussed with Dan. This is to have similar interfaces to the [`acipolicygen` tool](https://github.com/Azure/azure-cli-extensions/blob/22ec9b8dadb87dfb4e816357634dc0a7e7ebb771/src/confcom/azext_confcom/_params.py#L24)