### PR TITLE
agent: Make /dev/sev-guest available to containers

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -149,7 +149,7 @@ lazy_static! {
     };
 
     pub static ref DEFAULT_DEVICES: Vec<LinuxDevice> = {
-        vec![
+        let mut devices = vec![
             LinuxDevice {
                 path: "/dev/null".to_string(),
                 r#type: "c".to_string(),
@@ -204,7 +204,23 @@ lazy_static! {
                 uid: Some(0xffffffff),
                 gid: Some(0xffffffff),
             },
-        ]
+        ];
+        
+        let sev_guest_path = "/dev/sev-guest";
+        if let Ok(sev_guest_attr) = fs::metadata(sev_guest_path) {
+            let sev_guest_devid = sev_guest_attr.rdev();
+            devices.push(LinuxDevice {
+                path: sev_guest_path.to_string(),
+                r#type: "c".to_string(),
+                major: stat::major(sev_guest_devid) as i64,
+                minor: stat::minor(sev_guest_devid) as i64,
+                file_mode: Some(0o666),
+                uid: Some(sev_guest_attr.uid()),
+                gid: Some(sev_guest_attr.gid()),
+            });
+        };
+
+        devices
     };
 
     pub static ref SYSTEMD_CGROUP_PATH_FORMAT:Regex = Regex::new(r"^[\w\-.]*:[\w\-.]*:[\w\-.]*$").unwrap();


### PR DESCRIPTION
This makes it so that any container has access to `/dev/sev-guest` out of the box with no privileges required.

Since `/dev/sev-guest` isn't available yet, I've validated this change using `/dev/cpu_dma_latency` (original chmod 600) by:

 1. Verifying that the device is present in the container.
 2. Verifying that reading from the device from a container yields the same result as from the VM context.