### PR TITLE
Pull UVM package OPA from Mariner

### DIFF
--- a/src/agent/coco-opa.service
+++ b/src/agent/coco-opa.service
@@ -8,6 +8,6 @@ Documentation=https://github.com/confidential-containers
 StandardOutput=tty
 StandardError=tty
 Type=simple
-ExecStart=/usr/local/bin/opa run --server --disable-telemetry --addr 127.0.0.1:8181 --log-level info /coco_policy /coco_policy_data
+ExecStart=/usr/bin/opa run --server --disable-telemetry --addr 127.0.0.1:8181 --log-level info /coco_policy /coco_policy_data
 DynamicUser=yes
 RuntimeDirectory=coco-opa

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
@@ -5,6 +5,6 @@
 OS_NAME=cbl-mariner
 OS_VERSION=${OS_VERSION:-2.0}
 LIBC="gnu"
-PACKAGES="core-packages-base-image ca-certificates device-mapper"
+PACKAGES="core-packages-base-image ca-certificates device-mapper opa"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" systemd"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -641,21 +641,6 @@ EOF
 		ln -sf "/usr/lib/systemd/system/dbus.socket" "${ROOTFS_DIR}/etc/systemd/system/kata-containers.target.wants/dbus.socket"
 		chmod g+rx,o+x "${ROOTFS_DIR}"
 
-		open_policy_agent_url="$(get_package_version_from_kata_yaml externals.open-policy-agent.url)"
-		open_policy_agent_version="$(get_package_version_from_kata_yaml externals.open-policy-agent.version)"
-		info "Install Open Policy Agent"
-		OPA_DIR="${script_dir}/opa"
-		if [ ! -d "${OPA_DIR}" ] ; then
-			git clone --depth=1 "${open_policy_agent_url}" "$OPA_DIR"
-		fi
-		pushd "$OPA_DIR"
-		git fetch --depth=1 origin "${open_policy_agent_version}"
-		git checkout FETCH_HEAD
-		make build WASM_ENABLED=0
-		install -D -o root -g root -m 0755 opa_linux_amd64 -T "${ROOTFS_DIR}/usr/local/bin/opa"
-		popd
-
-		# TODO: clean-up OPA installation
 		samples_dir="${script_dir}/../../../src/agent/samples/policy/all-allowed"
 		cp "${samples_dir}/all-allowed.rego" "${ROOTFS_DIR}/coco_policy"
 		chmod 644 "${ROOTFS_DIR}/coco_policy"


### PR DESCRIPTION
Avoid pulling source code and building from upstream. Instead, install the OPA package from Mariner