### PR TITLE
rootfs: delete some of the mariner packages

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -22,5 +22,41 @@ build_rootfs()
 	info "install packages for rootfs"
 	$DNF install ${EXTRA_PKGS} ${PACKAGES}
 
+	# Reduce the image size, for faster TEE memory measurement.
+	local MARINER_REMOVED_PACKAGES=( \
+		"bash" \
+		"cracklib-dicts" \
+		"curl" \
+		"curl-libs" \
+		"gmp" \
+		"gnupg2" \
+		"iproute" \
+		"krb5" \
+		"libdb" \
+		"libtool" \
+		"libxml2" \
+		"libssh2" \
+		"openldap" \
+		"openssh-clients" \
+		"openssl" \
+		"pcre" \
+		"procps-ng" \
+		"rpm" \
+		"rpm-libs" \
+		"shadow-utils" \
+		"sqlite-libs" \
+		"slang" \
+		"sudo" \
+		"tar" \
+		"tzdata" \
+		"zstd-libs" \
+	)
+
+	for MARINER_REMOVED_PACKAGE in ${MARINER_REMOVED_PACKAGES[@]}
+	do
+		info "removing package ${MARINER_REMOVED_PACKAGE}"
+		rpm -e "${MARINER_REMOVED_PACKAGE}" --nodeps --root=${ROOTFS_DIR}
+	done
+
 	rm -rf ${ROOTFS_DIR}/usr/share/{bash-completion,cracklib,doc,info,locale,man,misc,pixmaps,terminfo,zoneinfo,zsh}
 }

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -28,15 +28,19 @@ build_rootfs()
 		"cracklib-dicts" \
 		"curl" \
 		"curl-libs" \
+		"cyrus-sasl-lib" \
 		"gmp" \
 		"gnupg2" \
 		"iproute" \
 		"krb5" \
+		"libarchive" \
 		"libdb" \
 		"libksba" \
 		"libtool" \
 		"libxml2" \
+		"libsolv" \
 		"libssh2" \
+		"lua-libs" \
 		"nghttp2" \
 		"npth" \
 		"openldap" \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -25,6 +25,7 @@ build_rootfs()
 	# Reduce the image size, for faster TEE memory measurement.
 	local MARINER_REMOVED_PACKAGES=( \
 		"bash" \
+		"bc" \
 		"bridge-utils" \
 		"bzip2" \
 		"chkconfig" \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -31,6 +31,7 @@ build_rootfs()
 		"cyrus-sasl-lib" \
 		"e2fsprogs" \
 		"expat" \
+		"findutils" \
 		"gmp" \
 		"gnupg2" \
 		"gpgme" \
@@ -49,6 +50,7 @@ build_rootfs()
 		"libuv" \
 		"lua-libs" \
 		"mariner-rpm-macros" \
+		"ncurses" \
 		"nghttp2" \
 		"nettle" \
 		"npth" \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -25,6 +25,8 @@ build_rootfs()
 	# Reduce the image size, for faster TEE memory measurement.
 	local MARINER_REMOVED_PACKAGES=( \
 		"bash" \
+		"bzip2" \
+		"chkconfig" \
 		"coreutils" \
 		"cracklib-dicts" \
 		"curl" \
@@ -36,6 +38,7 @@ build_rootfs()
 		"gmp" \
 		"gnupg2" \
 		"gpgme" \
+		"grep" \
 		"gzip" \
 		"iana-etc" \
 		"iproute" \
@@ -44,17 +47,18 @@ build_rootfs()
 		"libassuan" \
 		"libdb" \
 		"libksba" \
-		"libtool" \
-		"libxml2" \
+		"libpwquality" \
 		"libsolv" \
 		"libssh2" \
+		"libtool" \
 		"libuv" \
-		"libpwquality" \
+		"libxml2" \
 		"lua-libs" \
 		"mariner-rpm-macros" \
 		"ncurses" \
 		"nghttp2" \
 		"nettle" \
+		"newt" \
 		"npth" \
 		"openldap" \
 		"openssh-clients" \
@@ -62,8 +66,10 @@ build_rootfs()
 		"pinentry" \
 		"pcre" \
 		"procps-ng" \
+		"readline" \
 		"rpm" \
 		"rpm-libs" \
+		"sed" \
 		"shadow-utils" \
 		"sqlite-libs" \
 		"slang" \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -25,6 +25,7 @@ build_rootfs()
 	# Reduce the image size, for faster TEE memory measurement.
 	local MARINER_REMOVED_PACKAGES=( \
 		"bash" \
+		"bridge-utils" \
 		"bzip2" \
 		"chkconfig" \
 		"coreutils" \
@@ -34,7 +35,9 @@ build_rootfs()
 		"cyrus-sasl-lib" \
 		"e2fsprogs" \
 		"expat" \
+		"file" \
 		"findutils" \
+		"gdbm" \
 		"gmp" \
 		"gnupg2" \
 		"gpgme" \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -42,6 +42,7 @@ build_rootfs()
 		"gzip" \
 		"iana-etc" \
 		"iproute" \
+		"iputils" \
 		"krb5" \
 		"libarchive" \
 		"libassuan" \
@@ -57,6 +58,7 @@ build_rootfs()
 		"mariner-rpm-macros" \
 		"ncurses" \
 		"nghttp2" \
+		"net-tools" \
 		"nettle" \
 		"newt" \
 		"npth" \
@@ -76,6 +78,7 @@ build_rootfs()
 		"sudo" \
 		"tar" \
 		"tzdata" \
+		"xz" \
 		"zstd-libs" \
 	)
 

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -25,6 +25,7 @@ build_rootfs()
 	# Reduce the image size, for faster TEE memory measurement.
 	local MARINER_REMOVED_PACKAGES=( \
 		"bash" \
+		"coreutils" \
 		"cracklib-dicts" \
 		"curl" \
 		"curl-libs" \
@@ -48,6 +49,7 @@ build_rootfs()
 		"libsolv" \
 		"libssh2" \
 		"libuv" \
+		"libpwquality" \
 		"lua-libs" \
 		"mariner-rpm-macros" \
 		"ncurses" \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -33,12 +33,16 @@ build_rootfs()
 		"iproute" \
 		"krb5" \
 		"libdb" \
+		"libksba" \
 		"libtool" \
 		"libxml2" \
 		"libssh2" \
+		"nghttp2" \
+		"npth" \
 		"openldap" \
 		"openssh-clients" \
 		"openssl" \
+		"pinentry" \
 		"pcre" \
 		"procps-ng" \
 		"rpm" \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -30,12 +30,16 @@ build_rootfs()
 		"curl-libs" \
 		"cyrus-sasl-lib" \
 		"e2fsprogs" \
+		"expat" \
 		"gmp" \
 		"gnupg2" \
+		"gpgme" \
+		"gzip" \
 		"iana-etc" \
 		"iproute" \
 		"krb5" \
 		"libarchive" \
+		"libassuan" \
 		"libdb" \
 		"libksba" \
 		"libtool" \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -29,8 +29,10 @@ build_rootfs()
 		"curl" \
 		"curl-libs" \
 		"cyrus-sasl-lib" \
+		"e2fsprogs" \
 		"gmp" \
 		"gnupg2" \
+		"iana-etc" \
 		"iproute" \
 		"krb5" \
 		"libarchive" \
@@ -40,8 +42,11 @@ build_rootfs()
 		"libxml2" \
 		"libsolv" \
 		"libssh2" \
+		"libuv" \
 		"lua-libs" \
+		"mariner-rpm-macros" \
 		"nghttp2" \
+		"nettle" \
 		"npth" \
 		"openldap" \
 		"openssh-clients" \


### PR DESCRIPTION
Delete some of the mariner packages from the Guest image, for faster
TEE memory measurement.

Signed-off-by: Dan Mihai <dmihai@microsoft.com>
