### PR TITLE
rootfs: add back coreutils to mariner's image

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -28,7 +28,6 @@ build_rootfs()
 		"bridge-utils" \
 		"bzip2" \
 		"chkconfig" \
-		"coreutils" \
 		"cracklib-dicts" \
 		"curl" \
 		"curl-libs" \


### PR DESCRIPTION
Useful for debugging.