### PR TITLE
rootfs: add back ps to mariner's rootfs

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -68,7 +68,6 @@ build_rootfs()
 		"openssl" \
 		"pinentry" \
 		"pcre" \
-		"procps-ng" \
 		"rpm" \
 		"rpm-libs" \
 		"sed" \


### PR DESCRIPTION
Useful for debugging.