### PR TITLE
Add support to build enable dm-verity protected images

### DIFF
--- a/src/runtime/config/configuration-clh-snp.toml.in
+++ b/src/runtime/config/configuration-clh-snp.toml.in
@@ -14,6 +14,7 @@
 [hypervisor.clh]
 path = "@CLHSNPPATH@"
 igvm = "@IGVMPATH@"
+image = "@IMAGEPATH@"
 
 # rootfs filesystem type:
 #   - ext4 (default)

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -581,7 +581,7 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 	clh.vmconfig.Rng = chclient.NewRngConfig(clh.config.EntropySource)
 
 	// set the initial root/boot disk of hypervisor
-	imagePath := "/kata-containers.img"
+	imagePath, err := clh.config.ImageAssetPath()
 	if err != nil {
 		return err
 	}

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -581,7 +581,7 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 	clh.vmconfig.Rng = chclient.NewRngConfig(clh.config.EntropySource)
 
 	// set the initial root/boot disk of hypervisor
-	imagePath, err := clh.config.ImageAssetPath()
+	imagePath := "/kata-containers.img"
 	if err != nil {
 		return err
 	}

--- a/src/runtime/virtcontainers/hypervisor_config_linux.go
+++ b/src/runtime/virtcontainers/hypervisor_config_linux.go
@@ -30,8 +30,8 @@ func validateHypervisorConfig(conf *HypervisorConfig) error {
 		return fmt.Errorf("Missing image, initrd, and igvm path")
 	} else if conf.ImagePath != "" && conf.InitrdPath != "" {
 		return fmt.Errorf("Image and initrd path cannot be both set")
-	} else if conf.IgvmPath != "" && (conf.ImagePath != "" || conf.InitrdPath != "") {
-		return fmt.Errorf("Igvm and image or initrd path cannot be both set")
+	} else if conf.IgvmPath != "" && conf.InitrdPath != "" {
+		return fmt.Errorf("Igvm and initrd path cannot be both set")
 	}
 
 	if err := conf.CheckTemplateConfig(); err != nil {


### PR DESCRIPTION
- Add image build macro to change partition format for kernel's "dm-mod.create" command
- Allow for igvm + image usecase in kata shim