### PR TITLE
runtime: use 10 PCI segments for the Guest

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -464,6 +464,8 @@ func (clh *cloudHypervisor) enableProtection() error {
 			clh.vmconfig.Payload.SetHostData(snpZeroHostData)
 		}
 
+		clh.vmconfig.Platform.SetNumPciSegments(10)
+
 		return nil
 
 	default:


### PR DESCRIPTION
There are 10 segments in the ACPI tables, and CLH works better when it uses all of them.