### PR TITLE
tardev: enable feature(impl_trait_in_assoc_type) to fix build with rust 1.72.0

### DIFF
--- a/src/tardev-snapshotter/src/main.rs
+++ b/src/tardev-snapshotter/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use containerd_snapshots::server;
 use log::{error, info, warn};


### PR DESCRIPTION
Rust 1.72.0 build fails if we do not explicity enable feature
`feature(impl_trait_in_assoc_type)`

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>
