### PR TITLE
drop mut for variables that are not mutated to enable build with rust 1.72.0

### DIFF
--- a/src/agent/src/signal.rs
+++ b/src/agent/src/signal.rs
@@ -57,7 +57,7 @@ async fn handle_sigchild(logger: Logger, sandbox: Arc<Mutex<Sandbox>>) -> Result
                 continue;
             }
 
-            let mut p = process.unwrap();
+            let p = process.unwrap();
 
             let ret: i32 = match wait_status {
                 WaitStatus::Exited(_, c) => c,

--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -470,8 +470,8 @@ impl Annotation {
         let u32_err = io::Error::new(io::ErrorKind::InvalidData, "parse u32 error".to_string());
         let u64_err = io::Error::new(io::ErrorKind::InvalidData, "parse u64 error".to_string());
         let i32_err = io::Error::new(io::ErrorKind::InvalidData, "parse i32 error".to_string());
-        let mut hv = config.hypervisor.get_mut(hypervisor_name).unwrap();
-        let mut ag = config.agent.get_mut(agent_name).unwrap();
+        let hv = config.hypervisor.get_mut(hypervisor_name).unwrap();
+        let ag = config.agent.get_mut(agent_name).unwrap();
         for (key, value) in &self.annotations {
             if hv.security_info.is_annotation_enabled(key) {
                 match key.as_str() {


### PR DESCRIPTION
- kata-types: drop mut for variables that are not mutated
- agent: drop mut from variable which is not mutated
