### PR TITLE
policy: bypass empty response from OPA

### DIFF
--- a/src/agent/src/policy.rs
+++ b/src/agent/src/policy.rs
@@ -211,10 +211,20 @@ impl AgentPolicy {
                     Ok(resp.result)
                 }
                 Err(_) => {
-                    warn!(
-                        sl!(),
-                        "policy: endpoint {} not found in policy. Returning false.", ep,
-                    );
+                    if self.allow_failures {
+                        warn!(
+                            sl!(),
+                            "policy: POST {} undefined response <{}>. Ignoring error!",
+                            ep,
+                            http_response
+                        );
+                        return Ok(true);
+                    } else {
+                        warn!(
+                            sl!(),
+                            "policy: POST {} undefined response <{}>.", ep, http_response
+                        );
+                    }
                     Ok(false)
                 }
             }


### PR DESCRIPTION
When a request cannot be evaluated to true, OPA can return an empty response. It doesn't respond with "response = false" unless a default value of false has been defined.

Handle empty responses the same way as "response = false", thus allowing users to bypass those responses by using
AllowRequestsFailingPolicy := true.