### PR TITLE
adding debug mode

### DIFF
--- a/src/tools/genpolicy/src/main.rs
+++ b/src/tools/genpolicy/src/main.rs
@@ -53,6 +53,9 @@ struct CommandLineOptions {
 
     #[clap(short, long)]
     base64_out: bool,
+
+    #[clap(short, long)]
+    debug_mode: bool,
 }
 
 #[tokio::main]
@@ -74,6 +77,7 @@ async fn main() {
         args.silent_unsupported_fields,
         args.raw_out,
         args.base64_out,
+        args.debug_mode,
     );
 
     debug!("Creating policy from yaml, infra data and rules files...");

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -408,9 +408,22 @@ impl AgentPolicy {
             ));
         }
 
+        // enable debug mode if specified by the user
+        let mut request_defaults = self.infra_policy.request_defaults.clone();
+        if self.config.debug_mode {
+            // append to array /bin/bash and /bin/sh
+            let mut exec_commands = request_defaults.ExecProcessRequest.commands.clone();
+            exec_commands.push("/bin/bash".to_string());
+            exec_commands.push("/bin/sh".to_string());
+            // allow logging and put allowed commands back in
+            request_defaults.ExecProcessRequest.commands = exec_commands;
+            request_defaults.ReadStreamRequest = true;
+            request_defaults.WriteStreamRequest = true;
+        }
+
         let policy_data = policy::PolicyData {
             containers: policy_containers,
-            request_defaults: self.infra_policy.request_defaults.clone(),
+            request_defaults: request_defaults,
             common: self.infra_policy.common.clone(),
         };
 

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub silent_unsupported_fields: bool,
     pub raw_out: bool,
     pub base64_out: bool,
+    pub debug_mode: bool,
 }
 
 impl Config {
@@ -28,6 +29,7 @@ impl Config {
         silent_unsupported_fields: bool,
         raw_out: bool,
         base64_out: bool,
+        debug_mode: bool,
     ) -> Self {
         let mut input_path = ".".to_string();
         if let Some(path) = input_files_path {
@@ -54,6 +56,7 @@ impl Config {
             silent_unsupported_fields,
             raw_out,
             base64_out,
+            debug_mode,
         }
     }
 }


### PR DESCRIPTION
For feature parity with Confidential ACI and ease of debugging, we should include a debug mode that enables logging and exec-ing into containers within a pod. The `confcom` wrapper ideally has no knowledge of implementation of genpolicy for better decoupling. Thanks!