### PR TITLE
Avoid removing zstd-libs from the UVM

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/rootfs_lib.sh
@@ -78,7 +78,6 @@ build_rootfs()
 		"tar" \
 		"tzdata" \
 		"xz" \
-		"zstd-libs" \
 	)
 
 	for MARINER_REMOVED_PACKAGE in ${MARINER_REMOVED_PACKAGES[@]}


### PR DESCRIPTION
This library is now a requirement in the UVM due to recent CBL-Mariner systemd changes