### PR TITLE
Enable Confidential Guest by Default in Non-SEV-SNP CC Handler Configuration

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -39,8 +39,8 @@ rootfs_type=@DEFROOTFSTYPE@
 # Supported TEEs:
 # * Intel TDX
 #
-# Default false
-# confidential_guest = true
+# Default true
+confidential_guest = true
 
 # Enable running clh VMM as a non-root user.
 # By default clh VMM run as root. When this is set to true, clh VMM process runs as

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -39,7 +39,7 @@ rootfs_type=@DEFROOTFSTYPE@
 # Supported TEEs:
 # * Intel TDX
 #
-# Default true
+# Default false
 confidential_guest = true
 
 # Enable running clh VMM as a non-root user.


### PR DESCRIPTION
**Overview**
This pull request addresses a specific scenario within the Kata-Containers configurations where the sev_snp_guest is NOT set. The proposed change focuses on updating the default value of the `confidential_guest` property to `true` in [configuration-clh.toml.in](https://github.com/microsoft/kata-containers/blob/328e44092ef6ac9df192c567bcd9f5421016603d/src/runtime/config/configuration-clh.toml.in#L43C9-L43C9) file. This adjustment aims to facilitate the use of kernel and Kata-CC initrd by default, allowing smoother execution of confidential_guest paths when sev_snp_guest is absent.

**Changes Made**
Modified the targeted [configuration file](https://github.com/microsoft/kata-containers/blob/328e44092ef6ac9df192c567bcd9f5421016603d/src/runtime/config/configuration-clh.toml.in#L43C9-L43C9) to set `confidential_guest=true` as the default value, specifically for scenarios where sev_snp_guest is not set.

**Testing**
The testing procedure outlined in this pull request involves verifying the updated configuration:

- Confirmation of confidential_guest=true as the default in the specific configuration file.
- Validation of successful pod instantiation under this configuration to ensure seamless functionality.
For detailed testing procedures, please refer to the [Test CC handler without SEV SNP enabled - Overview](https://dev.azure.com/mariner-org/mariner/_wiki/wikis/mariner.wiki/2609/Test-CC-handler-without-SEV-SNP-enabled) document.
