### PR TITLE
Update caching mechanism to allow for concurrent genpolicy runs

### DIFF
--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -360,6 +360,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +479,7 @@ dependencies = [
  "docker_credential",
  "env_logger",
  "flate2",
+ "fs2",
  "generic-array",
  "log",
  "oci",

--- a/src/tools/genpolicy/Cargo.toml
+++ b/src/tools/genpolicy/Cargo.toml
@@ -50,3 +50,4 @@ sha2 = "0.10.6"
 tarindex = { path = "../../tardev-snapshotter/tarindex" }
 tempfile = "3.5.0"
 zerocopy = "0.6.1"
+fs2 = "0.4.3"


### PR DESCRIPTION
This is not a requirement of the tool itself but of the `katapolicygen` python wrapper used in [confcom](https://github.com/Azure/azure-cli-extensions/blob/main/src/confcom/azext_confcom/kata_proxy.py) for writing tests that run in parallel. Previously the `layers_cache` folder would be concurrently written to and deleted depending on the settings of the tests, resulting in errors.

This PR proposes using temp folders instead of `layers_cache` and keeping the layer hashes in a central `policy.json` file that doesn't get deleted after running the tool instead of the `.verity` files nested in `layers_cache`. Because of the use of temporary folders, the cleanup process is a little nicer too.

Let me know if anything should be changed, thanks!