### PR TITLE
genpolicy: add topologySpreadConstraints support

### DIFF
--- a/src/agent/samples/policy/yaml/pod/pod-spark.yaml
+++ b/src/agent/samples/policy/yaml/pod/pod-spark.yaml
@@ -11,3 +11,15 @@ spec:
   containers:
     - name: spark
       image: "mcr.microsoft.com/mmlspark/spark2.4:v4_mini"
+  topologySpreadConstraints:
+    - maxSkew: 1
+      minDomains: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          kubernetes.azure.com/os-sku: Mariner
+      matchLabelKeys:
+        - pod-template-hash
+      nodeAffinityPolicy: Ignore
+      nodeTaintsPolicy: Ignore

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -76,6 +76,9 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hostNetwork: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    topologySpreadConstraints: Option<Vec<TopologySpreadConstraint>>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -437,6 +440,29 @@ struct Toleration {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct LocalObjectReference {
     name: String,
+}
+
+/// See Reference / Kubernetes API / Workload Resources / Pod.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct TopologySpreadConstraint {
+    maxSkew: i32,
+    topologyKey: String,
+    whenUnsatisfiable: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    labelSelector: Option<yaml::LabelSelector>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matchLabelKeys: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    minDomains: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nodeAffinityPolicy : Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nodeTaintsPolicy : Option<String>,
 }
 
 impl Container {


### PR DESCRIPTION
Allow genpolicy to process Pod YAML files including topologySpreadConstraints.