### PR TITLE
genpolicy: add priorityClassName as a field in PodSpec interface

### DIFF
--- a/src/agent/samples/policy/yaml/pod/pod-ubuntu.yaml
+++ b/src/agent/samples/policy/yaml/pod/pod-ubuntu.yaml
@@ -1,4 +1,11 @@
 ---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000
+globalDefault: false
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -18,3 +25,4 @@ spec:
       args:
         - while true; echo hi; do sleep 30; done;
   runtimeClassName: kata-cc
+  priorityClassName: high-priority

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -91,6 +91,9 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     securityContext: Option<PodSecurityContext>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    priorityClassName: Option<String>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adds priorityClassName as a field in PodSpec interface.
This change allows generation of policy for pods specifying priority classes, which currently fails.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->

###### Links to CVEs  <!-- optional -->
<!-- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Generated a policy for pod having priorityClassName and created the pod on K8s with kata-cc runtime.
