### PR TITLE
github: add `upstream-missing` label to PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,13 +7,14 @@ Feel free to delete sections of the template which do not apply to your PR, or a
 <!-- You can set them now ([x]) or set them later using the Github UI -->
 <!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
 - [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
-- [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
+  - [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
 - [ ] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
 - [ ] genPolicy only: Ensured the tool still builds on Windows
 - [ ] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
+- [ ] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 
 
 ###### Summary <!-- REQUIRED -->
-<!-- Quick explanation of the changes. -->
+<!-- Quick explanation of WHAT changed and WHY. -->
 
 ###### Associated issues  <!-- optional -->
 <!-- Link to Github issues if possible. -->


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-needed` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
I've created 3 new PR labels our repo:

 * `upstream-missing`: PRs that are yet to be upstreamed.
 * `upstream-not-needed`: PRs that won't be merged upstream.
 * `upstream-merged`: PRs that have been merged upstream.

To facilitate tracking, from now on each PR should be initially tagged as `upstream-missing` or `upstream-not-needed`.

If a PR is created with `upstream-not-needed`, its description should explain why it won't be upstreamed unless it's directly obvious.

When a change is merged upstream, the PR label should be changed to `upstream-merged` and a comment should be added linking to the upstream PR.
