### PR TITLE
Adapt code for vanilla Kata

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -275,7 +275,7 @@ DEFBINDMOUNTS := []
 DEFSERVICEOFFLOAD ?= false
 
 # SNP
-DEFSNPGUEST ?= true
+DEFSNPGUEST ?= false
 # Based on SEV Secure Nested Paging Firmware ABI Specification section 4.3
 # unspecified or == 0 --> 0x30000 i.e. Bit#17 is '1' and Bit#16 is '1' (SMT is allowed)
 DEFSNPGUESTPOLICY ?= 0x30000

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -40,7 +40,7 @@ rootfs_type=@DEFROOTFSTYPE@
 # * Intel TDX
 #
 # Default false
-confidential_guest = true
+#confidential_guest = true
 
 # Enable running clh VMM as a non-root user.
 # By default clh VMM run as root. When this is set to true, clh VMM process runs as

--- a/src/runtime/pkg/resourcecontrol/cgroups.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups.go
@@ -60,6 +60,7 @@ func sandboxDevices() []specs.LinuxDeviceCgroup {
 		"/dev/zero",
 		"/dev/urandom",
 		"/dev/console",
+		"/dev/ptmx",
 	}
 
 	// Processes running in a device-cgroup are constrained, they have acccess

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -33,7 +33,7 @@ AGENT_POLICY_FILE=${AGENT_POLICY_FILE:-"allow-all.rego"}
 lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"
 
-agent_policy_file="$(readlink -f "${script_dir}/../../../src/kata-opa/${AGENT_POLICY_FILE}")"
+[ "${AGENT_POLICY}" == "yes" ] && agent_policy_file="$(readlink -f "${script_dir}/../../../src/kata-opa/${AGENT_POLICY_FILE}")"
 
 #For cross build
 CROSS_BUILD=${CROSS_BUILD:-false}
@@ -330,7 +330,7 @@ check_env_variables()
 
 	[ -n "${KERNEL_MODULES_DIR}" ] && [ ! -d "${KERNEL_MODULES_DIR}" ] && die "KERNEL_MODULES_DIR defined but is not an existing directory"
 
-	[ ! -f "${agent_policy_file}" ] && die "agent policy file not found in '${agent_policy_file}'"
+	[ "${AGENT_POLICY}" == "yes" ] && [ ! -f "${agent_policy_file}" ] && die "agent policy file not found in '${agent_policy_file}'"
 
 	[ -n "${OSBUILDER_VERSION}" ] || die "need osbuilder version"
 }


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
Turns out we can start vanilla Kata pods pretty much out of the box with msft-main. This PR just tweaks the vanilla config file and patches the runtime to unblock the debug console. I'm surprised we still need the runtime change, but I've verified the debug console doesn't work without that patch.

See microsoft/CBL-Mariner#6942 for specs changes.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
* Local building and running incl. with new virtiofsd
* See microsoft/CBL-Mariner#6942 for conformance results