### PR TITLE
genpolicy: add support for PodDisruptionBudget spec

### DIFF
--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -189,6 +189,7 @@ pub fn new_k8s_resource(
         | "Namespace"
         | "PersistentVolume"
         | "PersistentVolumeClaim"
+        | "PodDisruptionBudget"
         | "PriorityClass"
         | "ResourceQuota"
         | "RoleBinding"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
Modified yaml.rs to prevent panic when genpolicy is called for a PodDisruptionBudget spec.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
https://microsoft.visualstudio.com/OS/_workitems/edit/48139280/

###### Links to CVEs  <!-- optional -->
<!-- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
_**Pipeline e2e tests:**_ https://dev.azure.com/mariner-org/mariner/_build/results?buildId=493910&view=results
**_Local test:_**
Spec:
![image](https://github.com/microsoft/kata-containers/assets/36061892/b59ce86b-41c6-43da-bb16-b031ccc5ebd4)
Before:
![image](https://github.com/microsoft/kata-containers/assets/36061892/583a30e0-d734-4401-a59b-3ffeaee98e04)
After:
![image](https://github.com/microsoft/kata-containers/assets/36061892/586df0de-0b0b-4089-bd97-5addbebedea8)

