### PR TITLE
ci: Fix agent static checks

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -104,6 +104,9 @@ jobs:
       - name: Install musl-tools
         if: ${{ matrix.component != 'runtime' }}
         run: sudo apt-get -y install musl-tools
+      - name: Install devicemapper
+        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
+        run: sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
         if: ${{ matrix.command != 'make vendor'  &&  matrix.command != 'make check' &&  matrix.install-libseccomp == 'yes' }}
         run: |

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -206,7 +206,7 @@ lazy_static! {
                 gid: Some(0xffffffff),
             },
         ];
-        
+
         let sev_guest_path = "/dev/sev-guest";
         if let Ok(sev_guest_attr) = fs::metadata(sev_guest_path) {
             let sev_guest_devid = sev_guest_attr.rdev();

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -149,7 +149,7 @@ where
 pub fn pcipath_to_sysfs(root_bus_sysfs: &str, pcipath: &pci::Path) -> Result<String> {
     // Support up to 10 PCI segments.
     let mut bus = "000[0-9]:00".to_string();
-    
+
     let mut relpath = String::new();
 
     for i in 0..pcipath.len() {

--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -322,7 +322,7 @@ pub(crate) fn common_storage_handler(logger: &Logger, storage: &Storage) -> Resu
     let dm = devicemapper::DM::new()?;
     let name = devicemapper::DmName::new(fname)?;
     let opts = devicemapper::DmOptions::default().set_flags(devicemapper::DmFlags::DM_READONLY);
-    dm.device_create(&name, None, opts)
+    dm.device_create(name, None, opts)
         .context("Unable to create dm device")?;
 
     let id = devicemapper::DevId::Name(name);


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
This is to make the agent static checks pass so that we can use them as a PR gate - see https://github.com/microsoft/kata-containers/actions/runs/7730187184/job/21075045370?pr=154

Note that because of a GH limitation, this change won't be reflected in the checks of this PR (but I was able to validate the 2nd commit locally). We'll have to first merge this PR and then monitor any subsequent PRs to validate this change.