### PR TITLE
tarfs reliability fixes

### DIFF
--- a/src/tarfs/tarfs.c
+++ b/src/tarfs/tarfs.c
@@ -131,7 +131,7 @@ static int tarfs_readdir(struct file *file, struct dir_context *ctx)
 				break;
 			}
 
-			name_buffer = kmalloc(disk_len, GFP_KERNEL);
+			name_buffer = kmalloc(disk_len, GFP_NOFS);
 			if (!name_buffer) {
 				ret = -ENOMEM;
 				break;
@@ -457,7 +457,7 @@ static struct inode *tarfs_alloc_inode(struct super_block *sb)
 {
 	struct tarfs_inode_info *info;
 
-        info = alloc_inode_sb(sb, tarfs_inode_cachep, GFP_KERNEL);
+        info = alloc_inode_sb(sb, tarfs_inode_cachep, GFP_NOFS);
         if (!info)
                 return NULL;
 

--- a/src/tarfs/tarfs.c
+++ b/src/tarfs/tarfs.c
@@ -523,7 +523,7 @@ static int tarfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	sb->s_xattr = xattr_handlers;
 
 	scount = bdev_nr_sectors(sb->s_bdev);
-	if (!scount)
+	if (scount < TARFS_BSIZE / SECTOR_SIZE)
 		return -ENXIO;
 
 	state = kmalloc(sizeof(*state), GFP_KERNEL);

--- a/src/tarfs/tarfs.c
+++ b/src/tarfs/tarfs.c
@@ -179,8 +179,11 @@ static int tarfs_readpage(struct file *file, struct page *page)
 	int ret;
 
 	buf = kmap_local_page(page);
-	if (!buf)
+	if (!buf) {
+		SetPageError(page);
+		unlock_page(page);
 		return -ENOMEM;
+	}
 
 	offset = page_offset(page);
 	size = i_size_read(inode);

--- a/src/tarfs/tarfs.c
+++ b/src/tarfs/tarfs.c
@@ -339,15 +339,20 @@ discard:
 	return ERR_PTR(ret);
 }
 
-static int tarfs_strcmp(struct super_block *sb, unsigned long pos,
-			    const char *str, size_t size)
+static int tarfs_strcmp(struct super_block *sb, u64 pos, const char *str,
+			size_t size)
 {
 	struct buffer_head *bh;
 	unsigned long offset;
 	size_t segment;
 	bool matched;
+	const struct tarfs_state *state = sb->s_fs_info;
 
-	/* compare string up to a block at a time. */
+	/* If the string doesn't fit in the data size, it doesn't match. */
+	if (pos + size < pos || pos + size > state->data_size)
+		return 0;
+
+	/* Compare string up to a block at a time. */
 	while (size) {
 		offset = pos & (TARFS_BSIZE - 1);
 		segment = min_t(size_t, size, TARFS_BSIZE - offset);

--- a/src/tarfs/tarfs.c
+++ b/src/tarfs/tarfs.c
@@ -335,7 +335,7 @@ static struct inode *tarfs_iget(struct super_block *sb, u64 ino)
 	return inode;
 
 discard:
-	discard_new_inode(inode);
+	iget_failed(inode);
 	return ERR_PTR(ret);
 }
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
Fixes related to rarely exercised paths like failure or partial failure paths, tiny block devices (e.g., size of a single sector), corrupted images, etc.

Upstreaming to kata-containers is not necessary because we are hosting this in a different repo. 

###### Test Methodology
Built the kernel module locally in 5.15 and 6.1 kernels, booted an image with busybox, loaded the module, mounted a tarfs file system and used it.