### PR TITLE
Add support to handle SMB mounts

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -51,6 +51,7 @@ pub const DRIVER_VFIO_PCI_TYPE: &str = "vfio-pci";
 pub const DRIVER_VFIO_AP_TYPE: &str = "vfio-ap";
 pub const DRIVER_OVERLAYFS_TYPE: &str = "overlayfs";
 pub const FS_TYPE_HUGETLB: &str = "hugetlbfs";
+pub const DRIVER_SMB_TYPE: &str =  "smb";
 
 cfg_if! {
     if #[cfg(target_arch = "s390x")] {

--- a/src/agent/src/storage/fs_handler.rs
+++ b/src/agent/src/storage/fs_handler.rs
@@ -90,3 +90,19 @@ impl StorageHandler for VirtioFsHandler {
         new_device(path)
     }
 }
+
+#[derive(Debug)]
+pub struct SMBHandler {}
+
+#[async_trait::async_trait]
+impl StorageHandler for SMBHandler {
+    #[instrument]
+    async fn create_device(
+        &self,
+        storage: Storage,
+        ctx: &mut StorageContext,
+    ) -> Result<Arc<dyn StorageDevice>> {
+        let path = common_storage_handler(ctx.logger, &storage)?;
+        new_device(path)
+    }
+}

--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -25,12 +25,12 @@ use zerocopy::AsBytes;
 use self::bind_watcher_handler::BindWatcherHandler;
 use self::block_handler::{PmemHandler, ScsiHandler, VirtioBlkMmioHandler, VirtioBlkPciHandler};
 use self::ephemeral_handler::EphemeralHandler;
-use self::fs_handler::{OverlayfsHandler, Virtio9pHandler, VirtioFsHandler};
+use self::fs_handler::{OverlayfsHandler, Virtio9pHandler, VirtioFsHandler, SMBHandler};
 use self::local_handler::LocalHandler;
 use crate::device::{
     DRIVER_9P_TYPE, DRIVER_BLK_MMIO_TYPE, DRIVER_BLK_PCI_TYPE, DRIVER_EPHEMERAL_TYPE,
     DRIVER_LOCAL_TYPE, DRIVER_NVDIMM_TYPE, DRIVER_OVERLAYFS_TYPE, DRIVER_SCSI_TYPE,
-    DRIVER_VIRTIOFS_TYPE, DRIVER_WATCHABLE_BIND_TYPE,
+    DRIVER_VIRTIOFS_TYPE, DRIVER_WATCHABLE_BIND_TYPE, DRIVER_SMB_TYPE,
 };
 use crate::mount::{baremount, is_mounted, remove_mounts};
 use crate::sandbox::Sandbox;
@@ -136,6 +136,7 @@ lazy_static! {
     pub static ref STORAGE_HANDLERS: StorageHandlerManager<Arc<dyn StorageHandler>> = {
         let mut manager: StorageHandlerManager<Arc<dyn StorageHandler>> = StorageHandlerManager::new();
         manager.add_handler(DRIVER_9P_TYPE, Arc::new(Virtio9pHandler{})).unwrap();
+        manager.add_handler(DRIVER_SMB_TYPE, Arc::new(SMBHandler{})).unwrap();
         #[cfg(target_arch = "s390x")]
         manager.add_handler(crate::device::DRIVER_BLK_CCW_TYPE, Arc::new(self::block_handler::VirtioBlkCcwHandler{})).unwrap();
         manager.add_handler(DRIVER_BLK_MMIO_TYPE, Arc::new(VirtioBlkMmioHandler{})).unwrap();

--- a/src/runtime/pkg/direct-volume/utils.go
+++ b/src/runtime/pkg/direct-volume/utils.go
@@ -19,6 +19,7 @@ const (
 
 	FSGroupMetadataKey             = "fsGroup"
 	FSGroupChangePolicyMetadataKey = "fsGroupChangePolicy"
+	SensitiveMountOptions          = "sensitiveMountOptions"
 )
 
 // FSGroupChangePolicy holds policies that will be used for applying fsGroup to a volume.

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -656,6 +656,8 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 						continue
 					}
 					c.mounts[i].FSGroupChangePolicy = volume.FSGroupChangePolicy(value)
+				case volume.SensitiveMountOptions:
+					c.mounts[i].Options = append(c.mounts[i].Options, value)
 				default:
 					c.Logger().Warnf("Ignoring unsupported direct-assignd volume metadata key: %s, value: %s", key, value)
 				}

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -98,6 +98,7 @@ var (
 	typeVirtioFS                     = "virtiofs"
 	typeOverlayFS                    = "overlay"
 	kata9pDevType                    = "9p"
+	smbDevType                       = "smb"
 	kataMmioBlkDevType               = "mmioblk"
 	kataBlkDevType                   = "blk"
 	kataBlkCCWDevType                = "blk-ccw"
@@ -1337,6 +1338,12 @@ func (k *kataAgent) createContainer(ctx context.Context, sandbox *Sandbox, c *Co
 
 	ctrStorages = append(ctrStorages, volumeStorages...)
 
+	smbStorages, err := k.handleSMBMounts(c, ociSpec)
+	if err != nil {
+		return nil, err
+	}
+	ctrStorages = append(ctrStorages, smbStorages...)
+
 	// Layer storage objects are prepended to the list so that they come _before_ the
 	// rootfs because the rootfs depends on them (it's an overlay of the layers).
 	ctrStorages = append(layerStorages, ctrStorages...)
@@ -1660,6 +1667,60 @@ func (k *kataAgent) createBlkStorageObject(c *Container, m Mount) (*grpc.Storage
 	}
 
 	return vol, err
+}
+
+// handleSMBMounts will create a unique destination mountpoint in the guest for each volume in the
+// given container and will update the OCI spec to utilize this mount point as the new source for the
+// container volume. The container mount structure is updated to store the guest destination mountpoint.
+func (k *kataAgent) handleSMBMounts(c *Container, spec *specs.Spec) ([]*grpc.Storage, error) {
+	var volumeStorages []*grpc.Storage
+	for i, m := range c.mounts {
+		// Handle only cifs type of mounts
+		if m.Type != "cifs" {
+			continue
+		}
+		// Create Storage
+		vol, err := k.createSMBVolumeObject(c, m)
+		if vol == nil || err != nil {
+			return nil, err
+		}
+
+		// Each device will be mounted at a unique location within the VM only once. Mounting
+		// to the container specific location is handled within the OCI spec. Let's ensure that
+		// the storage mount point is unique for each device. This is then utilized as the source
+		filename := b64.URLEncoding.EncodeToString([]byte(vol.Source))
+		path := filepath.Join(kataGuestSandboxStorageDir(), filename)
+
+		// Update applicable OCI mount source
+		for idx, ociMount := range spec.Mounts {
+			if ociMount.Destination != vol.MountPoint {
+				continue
+			}
+			k.Logger().WithFields(logrus.Fields{
+				"original-source": ociMount.Source,
+				"new-source":      path,
+			}).Debug("Replacing OCI mount source")
+			spec.Mounts[idx].Source = path
+			break
+		}
+
+		// Update storage mountpoint, and save guest device mount path to container mount struct:
+		vol.MountPoint = path
+		c.mounts[i].GuestDeviceMount = path
+		volumeStorages = append(volumeStorages, vol)
+	}
+	return volumeStorages, nil
+}
+
+func (k *kataAgent) createSMBVolumeObject(c *Container, m Mount) (*grpc.Storage, error) {
+	vol := &grpc.Storage{}
+	vol.Source = m.Source
+	vol.MountPoint = m.Destination
+	vol.Fstype = m.Type
+	vol.Options = m.Options
+	// Todo: replace this with Confidential Data Hub driver
+	vol.Driver = smbDevType // This handler as of now calls a default storage handler in kata agent that does a baremount with these options
+	return vol, nil
 }
 
 // handleBlkOCIMounts will create a unique destination mountpoint in the guest for each volume in the


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [ ] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Ensured the tool still builds on Windows
- [ ] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
This PR handles parsing of mount objects in pod OCI spec to filter out SMB/CIFS mounts and create appropriate volume object for the same, having _target path_ set to a path inside pod VM (i.e guest UVM). The changes, further modify the container mount objects to bind-mount to the _target path_.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->

###### Links to CVEs  <!-- optional -->
<!-- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
