### PR TITLE
genpolicy: add --version flag

### DIFF
--- a/src/tools/genpolicy/.gitignore
+++ b/src/tools/genpolicy/.gitignore
@@ -1,1 +1,2 @@
 layers_cache
+src/version.rs

--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "genpolicy"
-version = "0.1.0"
+version = "3.2.0-azl0.genpolicy1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/tools/genpolicy/Cargo.toml
+++ b/src/tools/genpolicy/Cargo.toml
@@ -5,9 +5,10 @@
 
 [package]
 name = "genpolicy"
-version = "0.1.0"
+version = "3.2.0-azl0.genpolicy1"
 authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 # Logging.

--- a/src/tools/genpolicy/Makefile
+++ b/src/tools/genpolicy/Makefile
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 Intel Corporation
+# Portions Copyright (c) Microsoft Corporation.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -9,10 +10,24 @@ ifeq ($(ARCH), ppc64le)
      override ARCH = powerpc64le
  endif
 
+COMMIT_HASH := $(shell git rev-parse HEAD 2>/dev/null || true)
+# appends '-dirty' to the commit hash if there are uncommitted changes
+COMMIT_INFO := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_HASH}-dirty,${COMMIT_HASH})
+
+GENERATED_CODE = src/version.rs
+
+GENERATED_REPLACEMENTS= COMMIT_INFO
+GENERATED_FILES :=
+
+GENERATED_FILES += $(GENERATED_CODE)
+
+$(GENERATED_FILES): %: %.in
+	sed $(foreach r,$(GENERATED_REPLACEMENTS),-e 's|@$r@|$($r)|g') "$<" > "$@"
+
 .DEFAULT_GOAL := default
 default: build
 
-build:
+build: $(GENERATED_FILES)
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
 
 static-checks-build:
@@ -20,16 +35,17 @@ static-checks-build:
 
 clean:
 	cargo clean
+	rm -f $(GENERATED_FILES)
 
 vendor:
 	cargo vendor
 
 test:
 
-install:
+install: $(GENERATED_FILES)
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path .
 
-check: standard_rust_check
+check:  $(GENERATED_CODE) standard_rust_check
 
 .PHONY: \
 	build \

--- a/src/tools/genpolicy/src/main.rs
+++ b/src/tools/genpolicy/src/main.rs
@@ -29,6 +29,7 @@ mod settings;
 mod stateful_set;
 mod utils;
 mod verity;
+mod version;
 mod volume;
 mod yaml;
 
@@ -36,6 +37,16 @@ mod yaml;
 async fn main() {
     env_logger::init();
     let config = utils::Config::new();
+
+    if config.version {
+        println!(
+            "Kata Containers policy tool (Rust): id: {}, version: {}, commit: {}",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            version::COMMIT_INFO
+        );
+        return;
+    }
 
     debug!("Creating policy from yaml, settings, and rules.rego files...");
     let mut policy = policy::AgentPolicy::from_files(&config).await.unwrap();

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -75,6 +75,9 @@ struct CommandLineOptions {
         require_equals= true
     )]
     containerd_socket_path: Option<String>,
+
+    #[clap(short, long, help = "Print version information and exit")]
+    version: bool,
 }
 
 /// Application configuration, derived from on command line parameters.
@@ -91,6 +94,7 @@ pub struct Config {
     pub raw_out: bool,
     pub base64_out: bool,
     pub containerd_socket_path: Option<String>,
+    pub version: bool,
 }
 
 impl Config {
@@ -118,6 +122,7 @@ impl Config {
             raw_out: args.raw_out,
             base64_out: args.base64_out,
             containerd_socket_path: args.containerd_socket_path,
+            version: args.version,
         }
     }
 }

--- a/src/tools/genpolicy/src/version.rs.in
+++ b/src/tools/genpolicy/src/version.rs.in
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 Intel Corporation
+// Portions Copyright (c) Microsoft Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//
+// WARNING: This file is auto-generated - DO NOT EDIT!
+//
+
+#![allow(dead_code)]
+pub const COMMIT_INFO: &str = "@COMMIT_INFO@";


### PR DESCRIPTION
Add a --version flag to the genpolicy tool that prints the current version

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
Add --version flag

`
$ target/debug/genpolicy -v

Kata Containers policy tool (Rust): id: genpolicy, version: 3.2.0-azl0.genpolicy1, commit: ffc72e513cee8b5686df20c04abf5cec77de8236
`

dev: instead of `cargo build`, we'd use `LIBC=gnu BUILD_TYPE= make` (`cargo build` still works, but you'll need to use `LIBC=gnu BUILD_TYPE= make` the first time at least to generate version.rs and not get a compile error)

release: instead of `cargo build --release`, we'd use `LIBC=gnu make` (Here we'll want to stick to `LIBC=gnu make` as this will embed the correct commit information to release binary)

Make build method is incompatible on Windows. For Windows releases:
- set `src/version.rs` with correct commit info
- `cargo build --release`