### PR TITLE
agent: shutdown vm on exit when agent is used as init process

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -23,8 +23,9 @@ use anyhow::{anyhow, Context, Result};
 use cfg_if::cfg_if;
 use clap::{AppSettings, Parser};
 use nix::fcntl::OFlag;
+use nix::sys::reboot::{reboot, RebootMode};
 use nix::sys::socket::{self, AddressFamily, SockFlag, SockType, VsockAddr};
-use nix::unistd::{self, dup, Pid};
+use nix::unistd::{self, dup, sync, Pid};
 use std::env;
 use std::ffi::OsStr;
 use std::fs::{self, File};
@@ -154,7 +155,7 @@ async fn create_logger_task(rfd: RawFd, vsock_port: u32, shutdown: Receiver<bool
     Ok(())
 }
 
-async fn real_main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn real_main(init_mode: bool) -> std::result::Result<(), Box<dyn std::error::Error>> {
     env::set_var("RUST_BACKTRACE", "full");
 
     // List of tasks that need to be stopped for a clean shutdown
@@ -167,7 +168,6 @@ async fn real_main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     let (shutdown_tx, shutdown_rx) = channel(true);
 
-    let init_mode = unistd::getpid() == Pid::from_raw(1);
     if init_mode {
         // dup a new file descriptor for this temporary logger writer,
         // since this logger would be dropped and it's writer would
@@ -306,7 +306,15 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .enable_all()
         .build()?;
 
-    rt.block_on(real_main())
+    let init_mode = unistd::getpid() == Pid::from_raw(1);
+    let result = rt.block_on(real_main(init_mode));
+
+    if init_mode {
+        sync();
+        let _ = reboot(RebootMode::RB_POWER_OFF);
+    }
+
+    result
 }
 
 #[instrument]


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
Linux kernel generates a panic when the init process exits. The kernel is booted with panic=1, hence this leads to a vm reboot.
When used as a service the kata-agent service has an ExecStop option which does a full sync and shuts down the vm. This patch mimicks this behavior when kata-agent is used as the init process.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=552636&view=ms.vss-test-web.build-test-results-tab