### PR TITLE
genpolicy: add missing cache improvements

### DIFF
--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -438,7 +438,7 @@ async fn create_decompressed_layer_file(
     Ok(())
 }
 
-fn get_verity_hash_value(path: &Path) -> Result<String> {
+pub fn get_verity_hash_value(path: &Path) -> Result<String> {
     info!("Calculating dm-verity root hash");
     let mut file = std::fs::File::open(path)?;
     let size = file.seek(std::io::SeekFrom::End(0))?;


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

Add missing cache improvements specifically missing in containerd pull. I'm not sure how I missed this: It was already using layers-cache.json and it produces the exact same cache after using these changes.

These improvements are already included in https://github.com/kata-containers/kata-containers/pull/9530 and based on https://github.com/microsoft/kata-containers/pull/113

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
https://dev.azure.com/mariner-org/mariner/_build/results?buildId=555763&view=results
