### PR TITLE
genpolicy: bump release version

### DIFF
--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "genpolicy"
-version = "3.2.0-azl0.genpolicy1"
+version = "3.2.0-azl1.genpolicy0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/tools/genpolicy/Cargo.toml
+++ b/src/tools/genpolicy/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "genpolicy"
-version = "3.2.0-azl0.genpolicy1"
+version = "3.2.0-azl1.genpolicy0"
 authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Bump release version to 3.2.0-azl1.genpolicy0

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->

###### Links to CVEs  <!-- optional -->
<!-- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
