### PR TITLE
ci: add check for policy samples 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,12 @@
-<!--
-COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-Feel free to delete sections of the template which do not apply to your PR, or add additional details
--->
-
 ###### Merge Checklist  <!-- REQUIRED -->
-<!-- You can set them now ([x]) or set them later using the Github UI -->
-<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
 - [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
   - [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
 - [ ] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
 - [ ] genPolicy only: Ensured the tool still builds on Windows
-- [ ] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
-- [ ] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 
+- [ ] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 
 
 ###### Summary <!-- REQUIRED -->
 <!-- Quick explanation of WHAT changed and WHY. -->
-
-###### Associated issues  <!-- optional -->
-<!-- Link to Github issues if possible. -->
-
-###### Links to CVEs  <!-- optional -->
-<!-- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX -->
 
 ###### Test Methodology
 <!-- How was this test validated? i.e. local build, pipeline build etc. -->

--- a/.github/workflows/check-samples.yaml
+++ b/.github/workflows/check-samples.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) Microsoft Corporation.
+
+name: Check policy samples
+
+on:
+  pull_request:
+
+jobs:
+  check-policy-samples:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Install yq
+      env:
+        INSTALL_IN_GOPATH: false
+      run: |
+        ./ci/install_yq.sh
+
+    - name: Install Rust
+      run: |
+        ./tests/install_rust.sh
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Install protobuf-compiler
+      run: |
+        sudo apt-get -y install protobuf-compiler
+
+    - name: Configure containerd
+      run: |
+        sudo containerd config default | sudo dd of=/etc/containerd/config.toml
+        sudo systemctl restart containerd
+        sudo systemctl is-active containerd
+
+    - name: Update policy samples
+      working-directory: ./src/tools/genpolicy
+      run: |
+        python3 update_policy_samples.py
+
+    - name: Show diff
+      run: |
+        git diff
+
+    - name: Check policy samples
+      run: |
+        git diff-files --exit-code


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

```
This adds a GitHub Action workflow to check that the policy samples have
been updated with each PR. We'll add it as a required check to catch
policy errors earlier in the dev process.

I also tweaked the update script to have better error handling, and I
simplified the PR template to make it more readable.
```