### PR TITLE
ci: cherry-pick relaxed commit check from upstream

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -86,17 +86,6 @@ jobs:
         error: 'Body line too long (max 150)'
         post_error: ${{ env.error_msg }}
 
-    - name: Check Fixes
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
-      uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '\s*Fixes\s*:?\s*(#\d+|github\.com\/kata-containers\/[a-z-.]*#\d+)|^\s*release\s*:'
-        flags: 'i'
-        error: 'No "Fixes" found'
-        post_error: ${{ env.error_msg }}
-        one_pass_all_pass: 'true'
-
     - name: Check Subsystem
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1

--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -62,11 +62,10 @@ jobs:
             grep -v "^\#"  |\
             cut -d';' -f3 || true)
 
-          # PR doesn't have any linked issues
-          # (it should, but maybe a new user forgot to add a "Fixes: #XXX" commit).
+          # PR doesn't have any linked issues, handle it only if it exists
           [ -z "$linked_issue_urls" ] && {
-            echo "::error::No linked issues for PR $pr"
-            exit 1
+            echo "::warning::No linked issues for PR $pr"
+            exit 0
           }
 
           project_name="Issue backlog"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
- [x] The `upstream-missing` label (or `upstream-not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

Upstream recently removed the requirement for commit messages to have the `Fixes: #XXX` line. Cherry-picking that change so that we can make the commit check required in our fork.