### PR TITLE
agent-ctl: Refactor CopyFile handler.

### DIFF
--- a/src/tools/agent-ctl/src/types.rs
+++ b/src/tools/agent-ctl/src/types.rs
@@ -20,3 +20,10 @@ pub struct Config {
     pub ignore_errors: bool,
     pub no_auto_values: bool,
 }
+
+// CopyFile input struct
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CopyFileInput {
+    pub src: String,
+    pub dest: String,
+}

--- a/src/tools/agent-ctl/src/utils.rs
+++ b/src/tools/agent-ctl/src/utils.rs
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::types::{Config, Options};
+use crate::types::{Config, CopyFileInput, Options};
 use anyhow::{anyhow, Result};
 use oci::{
     Linux as ociLinux, Mount as ociMount, Process as ociProcess, Root as ociRoot, Spec as ociSpec,
 };
+use protocols::agent::CopyFileRequest;
 use protocols::oci::{
     Box as ttrpcBox, Linux as ttrpcLinux, LinuxBlockIO as ttrpcLinuxBlockIO,
     LinuxCPU as ttrpcLinuxCPU, LinuxCapabilities as ttrpcLinuxCapabilities,
@@ -26,7 +27,8 @@ use rand::Rng;
 use serde::de::DeserializeOwned;
 use slog::{debug, warn};
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{self, File};
+use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -819,4 +821,37 @@ pub fn make_request<T: Default + DeserializeOwned>(args: &str) -> Result<T> {
         // are not handled by this functionz.
         _ => Ok(Default::default()),
     }
+}
+
+pub fn make_copy_file_request(input: &CopyFileInput) -> Result<CopyFileRequest> {
+    // create dir mode permissions
+    // Dir mode | 750
+    let perms = 0o20000000750;
+
+    let src_meta: fs::Metadata = fs::symlink_metadata(&input.src)?;
+
+    let mut req = CopyFileRequest::default();
+
+    req.set_path(input.dest.clone());
+    req.set_dir_mode(perms);
+    req.set_file_mode(src_meta.mode());
+    req.set_uid(src_meta.uid() as i32);
+    req.set_gid(src_meta.gid() as i32);
+    req.set_offset(0);
+    req.set_file_size(0);
+
+    if src_meta.is_symlink() {
+        match fs::read_link(&input.src)?.into_os_string().into_string() {
+            Ok(path) => {
+                req.set_data(path.into_bytes());
+            }
+            Err(_) => {
+                return Err(anyhow!("failed to read link for {}", input.src));
+            }
+        }
+    } else if src_meta.is_file() {
+        req.set_file_size(src_meta.size() as i64);
+    }
+
+    Ok(req)
 }


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
In the existing implementation for the CopyFile subcommand,
- cmd line argument list is too long, including various metadata information.
- in case of a regular file, passing the actual data as bytes stream adds to the size and complexity of the input.
- the copy request will fail when the file size exceeds that of the allowed ttrpc max data length limit of 4Mb.

This change refactors the CopyFile handler and modifies the input to a known 'source' 'destination' syntax.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local build