### PR TITLE
virtcontainers: update sev_snp param serialization

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -463,7 +463,7 @@ func (clh *cloudHypervisor) enableProtection() error {
 		if clh.vmconfig.Platform == nil {
 			clh.vmconfig.Platform = chclient.NewPlatformConfig()
 		}
-		clh.vmconfig.Platform.SetSnp(true)
+		clh.vmconfig.Platform.SetSevSnp(true)
 
 		if len(clh.config.PolicyHash) > 0 {
 			clh.vmconfig.Payload.SetHostData(clh.config.PolicyHash)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -642,8 +642,8 @@ components:
             - oem_strings
             - oem_strings
             tdx: false
-            snp: false
             serial_number: serial_number
+            sev_snp: false
             uuid: uuid
           tpm:
             socket: socket
@@ -664,10 +664,10 @@ components:
           iommu: false
           payload:
             cmdline: cmdline
-            kernel: kernel
-            initramfs: initramfs
             igvm: igvm
+            kernel: kernel
             host_data: host_data
+            initramfs: initramfs
             firmware: firmware
           serial:
             mode: "false"
@@ -801,10 +801,10 @@ components:
       description: Payloads to boot in guest
       example:
         cmdline: cmdline
-        kernel: kernel
-        initramfs: initramfs
         igvm: igvm
+        kernel: kernel
         host_data: host_data
+        initramfs: initramfs
         firmware: firmware
       properties:
         firmware:
@@ -1023,8 +1023,8 @@ components:
           - oem_strings
           - oem_strings
           tdx: false
-          snp: false
           serial_number: serial_number
+          sev_snp: false
           uuid: uuid
         tpm:
           socket: socket
@@ -1045,10 +1045,10 @@ components:
         iommu: false
         payload:
           cmdline: cmdline
-          kernel: kernel
-          initramfs: initramfs
           igvm: igvm
+          kernel: kernel
           host_data: host_data
+          initramfs: initramfs
           firmware: firmware
         serial:
           mode: "false"
@@ -1262,8 +1262,8 @@ components:
         - oem_strings
         - oem_strings
         tdx: false
-        snp: false
         serial_number: serial_number
+        sev_snp: false
         uuid: uuid
       properties:
         num_pci_segments:
@@ -1285,7 +1285,7 @@ components:
         tdx:
           default: false
           type: boolean
-        snp:
+        sev_snp:
           default: false
           type: boolean
       type: object

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PayloadConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PayloadConfig.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Firmware** | Pointer to **string** |  | [optional]
-**Kernel** | Pointer to **string** |  | [optional]
-**Cmdline** | Pointer to **string** |  | [optional]
-**Initramfs** | Pointer to **string** |  | [optional]
-**Igvm** | Pointer to **string** |  | [optional]
-**HostData** | Pointer to **string** |  | [optional]
+**Firmware** | Pointer to **string** |  | [optional] 
+**Kernel** | Pointer to **string** |  | [optional] 
+**Cmdline** | Pointer to **string** |  | [optional] 
+**Initramfs** | Pointer to **string** |  | [optional] 
+**Igvm** | Pointer to **string** |  | [optional] 
+**HostData** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -179,6 +179,7 @@ SetHostData sets HostData field to given value.
 `func (o *PayloadConfig) HasHostData() bool`
 
 HasHostData returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PlatformConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PlatformConfig.md
@@ -4,13 +4,13 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**NumPciSegments** | Pointer to **int32** |  | [optional]
-**IommuSegments** | Pointer to **[]int32** |  | [optional]
-**SerialNumber** | Pointer to **string** |  | [optional]
-**Uuid** | Pointer to **string** |  | [optional]
-**OemStrings** | Pointer to **[]string** |  | [optional]
+**NumPciSegments** | Pointer to **int32** |  | [optional] 
+**IommuSegments** | Pointer to **[]int32** |  | [optional] 
+**SerialNumber** | Pointer to **string** |  | [optional] 
+**Uuid** | Pointer to **string** |  | [optional] 
+**OemStrings** | Pointer to **[]string** |  | [optional] 
 **Tdx** | Pointer to **bool** |  | [optional] [default to false]
-**Snp** | Pointer to **bool** |  | [optional] [default to false]
+**SevSnp** | Pointer to **bool** |  | [optional] [default to false]
 
 ## Methods
 
@@ -181,30 +181,31 @@ SetTdx sets Tdx field to given value.
 
 HasTdx returns a boolean if a field has been set.
 
-### GetSnp
+### GetSevSnp
 
-`func (o *PlatformConfig) GetSnp() bool`
+`func (o *PlatformConfig) GetSevSnp() bool`
 
-GetSnp returns the Snp field if non-nil, zero value otherwise.
+GetSevSnp returns the SevSnp field if non-nil, zero value otherwise.
 
-### GetSnpOk
+### GetSevSnpOk
 
-`func (o *PlatformConfig) GetSnpOk() (*bool, bool)`
+`func (o *PlatformConfig) GetSevSnpOk() (*bool, bool)`
 
-GetSnpOk returns a tuple with the Snp field if it's non-nil, zero value otherwise
+GetSevSnpOk returns a tuple with the SevSnp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
-### SetSnp
+### SetSevSnp
 
-`func (o *PlatformConfig) SetSnp(v bool)`
+`func (o *PlatformConfig) SetSevSnp(v bool)`
 
-SetSnp sets Snp field to given value.
+SetSevSnp sets SevSnp field to given value.
 
-### HasSnp
+### HasSevSnp
 
-`func (o *PlatformConfig) HasSnp() bool`
+`func (o *PlatformConfig) HasSevSnp() bool`
 
-HasSnp returns a boolean if a field has been set.
+HasSevSnp returns a boolean if a field has been set.
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_payload_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_payload_config.go
@@ -41,70 +41,6 @@ func NewPayloadConfigWithDefaults() *PayloadConfig {
 	return &this
 }
 
-// GetIgvm returns the Igvm field value if set, zero value otherwise.
-func (o *PayloadConfig) GetIgvm() string {
-	if o == nil || o.Igvm == nil {
-		var ret string
-		return ret
-	}
-	return *o.Igvm
-}
-
-// GetIgvmOk returns a tuple with the Igvm field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *PayloadConfig) GetIgvmOk() (*string, bool) {
-	if o == nil || o.Igvm == nil {
-		return nil, false
-	}
-	return o.Igvm, true
-}
-
-// HasIgvm returns a boolean if a field has been set.
-func (o *PayloadConfig) HasIgvm() bool {
-	if o != nil && o.Igvm != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetIgvm gets a reference to the given string and assigns it to the Igvm field.
-func (o *PayloadConfig) SetIgvm(v string) {
-	o.Igvm = &v
-}
-
-// GetHostData returns the HostData field value if set, zero value otherwise.
-func (o *PayloadConfig) GetHostData() string {
-	if o == nil || o.HostData == nil {
-		var ret string
-		return ret
-	}
-	return *o.HostData
-}
-
-// GetHostDataOk returns a tuple with the HostData field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *PayloadConfig) GetHostDataOk() (*string, bool) {
-	if o == nil || o.HostData == nil {
-		return nil, false
-	}
-	return o.HostData, true
-}
-
-// HasHostData returns a boolean if a field has been set.
-func (o *PayloadConfig) HasHostData() bool {
-	if o != nil && o.HostData != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHostData gets a reference to the given string and assigns it to the HostData field.
-func (o *PayloadConfig) SetHostData(v string) {
-	o.HostData = &v
-}
-
 // GetFirmware returns the Firmware field value if set, zero value otherwise.
 func (o *PayloadConfig) GetFirmware() string {
 	if o == nil || o.Firmware == nil {
@@ -233,14 +169,72 @@ func (o *PayloadConfig) SetInitramfs(v string) {
 	o.Initramfs = &v
 }
 
+// GetIgvm returns the Igvm field value if set, zero value otherwise.
+func (o *PayloadConfig) GetIgvm() string {
+	if o == nil || o.Igvm == nil {
+		var ret string
+		return ret
+	}
+	return *o.Igvm
+}
+
+// GetIgvmOk returns a tuple with the Igvm field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PayloadConfig) GetIgvmOk() (*string, bool) {
+	if o == nil || o.Igvm == nil {
+		return nil, false
+	}
+	return o.Igvm, true
+}
+
+// HasIgvm returns a boolean if a field has been set.
+func (o *PayloadConfig) HasIgvm() bool {
+	if o != nil && o.Igvm != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIgvm gets a reference to the given string and assigns it to the Igvm field.
+func (o *PayloadConfig) SetIgvm(v string) {
+	o.Igvm = &v
+}
+
+// GetHostData returns the HostData field value if set, zero value otherwise.
+func (o *PayloadConfig) GetHostData() string {
+	if o == nil || o.HostData == nil {
+		var ret string
+		return ret
+	}
+	return *o.HostData
+}
+
+// GetHostDataOk returns a tuple with the HostData field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PayloadConfig) GetHostDataOk() (*string, bool) {
+	if o == nil || o.HostData == nil {
+		return nil, false
+	}
+	return o.HostData, true
+}
+
+// HasHostData returns a boolean if a field has been set.
+func (o *PayloadConfig) HasHostData() bool {
+	if o != nil && o.HostData != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHostData gets a reference to the given string and assigns it to the HostData field.
+func (o *PayloadConfig) SetHostData(v string) {
+	o.HostData = &v
+}
+
 func (o PayloadConfig) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-	if o.Igvm != nil {
-		toSerialize["igvm"] = o.Igvm
-	}
-	if o.HostData != nil {
-		toSerialize["host_data"] = o.HostData
-	}
 	if o.Firmware != nil {
 		toSerialize["firmware"] = o.Firmware
 	}
@@ -252,6 +246,12 @@ func (o PayloadConfig) MarshalJSON() ([]byte, error) {
 	}
 	if o.Initramfs != nil {
 		toSerialize["initramfs"] = o.Initramfs
+	}
+	if o.Igvm != nil {
+		toSerialize["igvm"] = o.Igvm
+	}
+	if o.HostData != nil {
+		toSerialize["host_data"] = o.HostData
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_platform_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_platform_config.go
@@ -22,7 +22,7 @@ type PlatformConfig struct {
 	Uuid           *string   `json:"uuid,omitempty"`
 	OemStrings     *[]string `json:"oem_strings,omitempty"`
 	Tdx            *bool     `json:"tdx,omitempty"`
-	Snp            *bool     `json:"snp,omitempty"`
+	SevSnp         *bool     `json:"sev_snp,omitempty"`
 }
 
 // NewPlatformConfig instantiates a new PlatformConfig object
@@ -33,8 +33,8 @@ func NewPlatformConfig() *PlatformConfig {
 	this := PlatformConfig{}
 	var tdx bool = false
 	this.Tdx = &tdx
-	var snp bool = false
-	this.Snp = &snp
+	var sevSnp bool = false
+	this.SevSnp = &sevSnp
 	return &this
 }
 
@@ -45,8 +45,8 @@ func NewPlatformConfigWithDefaults() *PlatformConfig {
 	this := PlatformConfig{}
 	var tdx bool = false
 	this.Tdx = &tdx
-	var snp bool = false
-	this.Snp = &snp
+	var sevSnp bool = false
+	this.SevSnp = &sevSnp
 	return &this
 }
 
@@ -242,36 +242,36 @@ func (o *PlatformConfig) SetTdx(v bool) {
 	o.Tdx = &v
 }
 
-// GetSnp returns the Snp field value if set, zero value otherwise.
-func (o *PlatformConfig) GetSnp() bool {
-	if o == nil || o.Snp == nil {
+// GetSevSnp returns the SevSnp field value if set, zero value otherwise.
+func (o *PlatformConfig) GetSevSnp() bool {
+	if o == nil || o.SevSnp == nil {
 		var ret bool
 		return ret
 	}
-	return *o.Snp
+	return *o.SevSnp
 }
 
-// GetSnpOk returns a tuple with the Snp field value if set, nil otherwise
+// GetSevSnpOk returns a tuple with the SevSnp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *PlatformConfig) GetSnpOk() (*bool, bool) {
-	if o == nil || o.Snp == nil {
+func (o *PlatformConfig) GetSevSnpOk() (*bool, bool) {
+	if o == nil || o.SevSnp == nil {
 		return nil, false
 	}
-	return o.Snp, true
+	return o.SevSnp, true
 }
 
-// HasSnp returns a boolean if a field has been set.
-func (o *PlatformConfig) HasSnp() bool {
-	if o != nil && o.Snp != nil {
+// HasSevSnp returns a boolean if a field has been set.
+func (o *PlatformConfig) HasSevSnp() bool {
+	if o != nil && o.SevSnp != nil {
 		return true
 	}
 
 	return false
 }
 
-// SetSnp gets a reference to the given bool and assigns it to the Snp field.
-func (o *PlatformConfig) SetSnp(v bool) {
-	o.Snp = &v
+// SetSevSnp gets a reference to the given bool and assigns it to the SevSnp field.
+func (o *PlatformConfig) SetSevSnp(v bool) {
+	o.SevSnp = &v
 }
 
 func (o PlatformConfig) MarshalJSON() ([]byte, error) {
@@ -294,8 +294,8 @@ func (o PlatformConfig) MarshalJSON() ([]byte, error) {
 	if o.Tdx != nil {
 		toSerialize["tdx"] = o.Tdx
 	}
-	if o.Snp != nil {
-		toSerialize["snp"] = o.Snp
+	if o.SevSnp != nil {
+		toSerialize["sev_snp"] = o.SevSnp
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -671,7 +671,7 @@ components:
         tdx:
           type: boolean
           default: false
-        snp:
+        sev_snp:
           type: boolean
           default: false
 


### PR DESCRIPTION
Update sev_snp param serialization to make it
match against cloud-hypervisor v38.0.72.

See https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5628/file s#diff-c235a65d9dfdc1392f1c9546df912679bbdd74138316a04d9cfd53ef8fe1f907R 527

###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

Update plataform config param from `sev` to `sev_snp`

This was done by updating cloud-hypervisor.yaml and running `make generate-client-code && make go-fmt`

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
