### PR TITLE
genpolicy: update policy samples

### DIFF
--- a/src/agent/samples/policy/yaml/webhook3/dns-test.yaml
+++ b/src/agent/samples/policy/yaml/webhook3/dns-test.yaml
@@ -70,9 +70,6 @@ spec:
   hostname: dns-querier-1
   nodeSelector:
     katacontainers.io/kata-runtime: "true"
-  overhead:
-    cpu: 250m
-    memory: 160Mi
   preemptionPolicy: PreemptLowerPriority
   priority: 0
   restartPolicy: Always

--- a/src/agent/samples/policy/yaml/webhook3/many-layers.yaml
+++ b/src/agent/samples/policy/yaml/webhook3/many-layers.yaml
@@ -75,9 +75,6 @@ items:
       hostname: dns-querier-1
       nodeSelector:
         katacontainers.io/kata-runtime: "true"
-      overhead:
-        cpu: 250m
-        memory: 160Mi
       preemptionPolicy: PreemptLowerPriority
       priority: 0
       restartPolicy: Always


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
The two samples define Pod overhead values. When testing these samples on clusters where different podOverhead values are defined by the respective runtime classes, the tests fail as the values need to match, see: /plugin/pkg/admission/runtimeclass/admission.go in the kubernetes GitHub repository. Hence, removing the overhead definitions.

Re-ran update_policy_samples.py. No change
###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
As stated, testing failed when using a runtimeClass with different podOverhead value.