### PR TITLE
tools: Remove cgroupv1 kernel parameters for kata

### DIFF
--- a/tools/osbuilder/node-builder/azure-linux/package_build.sh
+++ b/tools/osbuilder/node-builder/azure-linux/package_build.sh
@@ -60,7 +60,7 @@ if [ "${CONF_PODS}" == "yes" ]; then
 	make ${runtime_make_flags}
 else
 	# cannot add the kernelparams in initial assignment, quotation issue
-	make ${runtime_make_flags} KERNELPARAMS="systemd.legacy_systemd_cgroup_controller=yes systemd.unified_cgroup_hierarchy=0"
+	make ${runtime_make_flags} KERNELPARAMS=""
 fi
 popd
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
Remove cgroupv1 kernel parameters for kata

###### Test Methodology
Conformance test result: [585964](https://dev.azure.com/mariner-org/mariner/_build/results?buildId=585964&view=results)