### PR TITLE
genpolicy: require definition for image volume mounts

### DIFF
--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -98,16 +98,14 @@ impl yaml::K8sResource for DaemonSet {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                persistent_volume_claims,
-                container,
-                settings,
-                volumes,
-            )
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            persistent_volume_claims,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -96,16 +96,14 @@ impl yaml::K8sResource for Deployment {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                persistent_volume_claims,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            persistent_volume_claims,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -70,16 +70,14 @@ impl yaml::K8sResource for Job {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                persistent_volume_claims,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            persistent_volume_claims,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -836,16 +836,14 @@ impl yaml::K8sResource for Pod {
         container: &Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                persistent_volume_claims,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            persistent_volume_claims,
+            container,
+            settings,
+            &self.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -20,6 +20,7 @@ use oci_distribution::client::{linux_amd64_resolver, ClientConfig};
 use oci_distribution::{manifest, secrets::RegistryAuth, Client, Reference};
 use serde::{Deserialize, Serialize};
 use sha2::{digest::typenum::Unsigned, digest::OutputSizeUser, Sha256};
+use std::collections::BTreeMap;
 use std::fs::OpenOptions;
 use std::io::BufWriter;
 use std::{io, io::Seek, io::Write, path::Path};
@@ -28,6 +29,7 @@ use tokio::io::AsyncWriteExt;
 /// Container image properties obtained from an OCI repository.
 #[derive(Clone, Debug, Default)]
 pub struct Container {
+    pub image: String,
     pub config_layer: DockerConfigLayer,
     pub image_layers: Vec<ImageLayer>,
 }
@@ -36,19 +38,20 @@ pub struct Container {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct DockerConfigLayer {
     architecture: String,
-    config: DockerImageConfig,
+    pub config: DockerImageConfig,
     pub rootfs: DockerRootfs,
 }
 
-/// Image config properties.
+/// See: https://docs.docker.com/reference/dockerfile/.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-struct DockerImageConfig {
+pub struct DockerImageConfig {
     User: Option<String>,
     Tty: Option<bool>,
     Env: Option<Vec<String>>,
     Cmd: Option<Vec<String>>,
     WorkingDir: Option<String>,
     Entrypoint: Option<Vec<String>>,
+    pub Volumes: Option<BTreeMap<String, DockerVolumeHostDirectory>>,
 }
 
 /// Container rootfs information.
@@ -65,11 +68,21 @@ pub struct ImageLayer {
     pub verity_hash: String,
 }
 
+/// See https://docs.docker.com/reference/dockerfile/#volume.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DockerVolumeHostDirectory {
+    // This struct is empty because, according to the documentation:
+    // "The VOLUME instruction does not support specifying a host-dir
+    // parameter. You must specify the mountpoint when you create or
+    // run the container."
+}
+
 impl Container {
     pub async fn new(use_cached_files: bool, image: &str) -> Result<Self> {
         info!("============================================");
-        info!("Pulling manifest and config for {:?}", image);
-        let reference: Reference = image.to_string().parse().unwrap();
+        info!("Pulling manifest and config for {image}");
+        let image_string = image.to_string();
+        let reference: Reference = image_string.parse().unwrap();
         let auth = build_auth(&reference);
 
         let mut client = Client::new(ClientConfig {
@@ -94,6 +107,8 @@ impl Container {
 
                 let config_layer: DockerConfigLayer =
                     serde_json::from_str(&config_layer_str).unwrap();
+                debug!("config_layer: {:?}", &config_layer);
+
                 let image_layers = get_image_layers(
                     use_cached_files,
                     &mut client,
@@ -105,6 +120,7 @@ impl Container {
                 .unwrap();
 
                 Ok(Container {
+                    image: image_string,
                     config_layer,
                     image_layers,
                 })

--- a/src/tools/genpolicy/src/registry_containerd.rs
+++ b/src/tools/genpolicy/src/registry_containerd.rs
@@ -46,7 +46,8 @@ impl Container {
         let ctrd_client = containerd_client::Client::from(containerd_channel.clone());
         let k8_cri_image_client = ImageServiceClient::new(containerd_channel);
 
-        let image_ref: Reference = image.to_string().parse().unwrap();
+        let image_str = image.to_string();
+        let image_ref: Reference = image_str.parse().unwrap();
 
         info!("Pulling image: {:?}", image_ref);
 
@@ -62,6 +63,7 @@ impl Container {
             get_image_layers(use_cached_files, &manifest, &config_layer, &ctrd_client).await?;
 
         Ok(Container {
+            image: image_str,
             config_layer,
             image_layers,
         })

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -68,16 +68,14 @@ impl yaml::K8sResource for ReplicaSet {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                persistent_volume_claims,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            persistent_volume_claims,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -70,16 +70,14 @@ impl yaml::K8sResource for ReplicationController {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                persistent_volume_claims,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            persistent_volume_claims,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -118,16 +118,14 @@ impl yaml::K8sResource for StatefulSet {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                persistent_volume_claims,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            persistent_volume_claims,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
 
         // Example:
         //


### PR DESCRIPTION
Docker container images can define the destination of volume mounts without also defining the source of these mounts. Reject such images if the genpolicy input YAML doesn't define the corresponding mount source information. Mount sources are required to generate a reasonable confidential containers policy.

<I plan to port these changes into Upstream first, but sharing them here just in case anyone has feedback before we get to Upstream>
