### PR TITLE
Cherry-pick upstream PR #9825: osbuilder: allow rootfs builds w/o git or version file deps

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -15,7 +15,7 @@ PROJECT_COMPONENT = kata-agent
 TARGET = $(PROJECT_COMPONENT)
 
 VERSION_FILE := ./VERSION
-VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+VERSION := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
 COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -355,7 +355,7 @@ SOURCES := \
   Cargo.toml
 
 VERSION_FILE := ./VERSION
-VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+VERSION := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
 COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)

--- a/src/tools/kata-ctl/Makefile
+++ b/src/tools/kata-ctl/Makefile
@@ -13,7 +13,7 @@ TARGET = $(PROJECT_COMPONENT)
 INSTALL_PATH = $(HOME)/.cargo
 
 VERSION_FILE := ./VERSION
-export VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+export VERSION := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
 COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
 COMMIT_NO_SHORT := $(shell git rev-parse --short HEAD 2>/dev/null || true)
 export COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})

--- a/src/tools/log-parser/Makefile
+++ b/src/tools/log-parser/Makefile
@@ -7,9 +7,10 @@
 TARGET = kata-log-parser
 SOURCES = $(shell find . 2>&1 | grep -E '.*\.go$$')
 
-VERSION := ${shell cat ./VERSION}
-COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
-COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
+VERSION_FILE := ./VERSION
+VERSION := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
+COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 
 BINDIR := $(GOPATH)/bin
 DESTTARGET := $(abspath $(BINDIR)/$(TARGET))

--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -31,9 +31,9 @@ TARGET_IGVM_DEBUG_MSMT:= $(IGVM_BUILD_DEST)/igvm-debug-measurement.cose
 TARGET_IGVM_LOG       := $(IGVM_BUILD_DEST)/igvm.log
 
 VERSION_FILE   := ./VERSION
-VERSION        := $(shell grep -v ^\# $(VERSION_FILE))
-COMMIT_NO      := $(shell git rev-parse HEAD 2> /dev/null || true)
-COMMIT         := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
+VERSION        := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
+COMMIT_NO      := $(shell git rev-parse HEAD 2>/dev/null || true)
+COMMIT         := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
 ifeq ($(filter $(BUILD_METHOD),$(BUILD_METHOD_LIST)),)

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -372,12 +372,6 @@ build_rootfs_distro()
 		mkdir -p ${ROOTFS_DIR}
 	fi
 
-	# need to detect rustc's version too?
-	detect_rust_version ||
-		die "Could not detect the required rust version for AGENT_VERSION='${AGENT_VERSION:-main}'."
-
-	echo "Required rust version: $RUST_VERSION"
-
 	if [ "${SELINUX}" == "yes" ]; then
 		if [ "${AGENT_INIT}" == "yes" ]; then
 			die "Guest SELinux with the agent init is not supported yet"

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -181,7 +181,8 @@ create_summary_file()
 	[ "$AGENT_INIT" = yes ] && agent="${init}"
 
 	local -r agentdir="${script_dir}/../../../"
-	local -r agent_version=$(cat ${agentdir}/VERSION)
+	local agent_version=$(cat ${agentdir}/VERSION 2> /dev/null)
+	[ -z "$agent_version" ] && agent_version="unknown"
 
 	cat >"$file"<<-EOF
 	---

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -224,14 +224,23 @@ generate_dockerfile()
 
 	[ -n "${http_proxy:-}" ] && readonly set_proxy="RUN sed -i '$ a proxy="${http_proxy:-}"' /etc/dnf/dnf.conf /etc/yum.conf; true"
 
-	# Rust agent
-	readonly install_rust="
+	# Only install Rust if agent needs to be built
+	local install_rust=""
+
+	if [ ! -z "${AGENT_SOURCE_BIN}" ] ; then
+		if [ "$RUST_VERSION" == "null" ]; then
+			detect_rust_version || \
+				die "Could not detect the required rust version for AGENT_VERSION='${AGENT_VERSION:-main}'."
+		fi
+		install_rust="
 ENV http_proxy=${http_proxy:-}
 ENV https_proxy=${http_proxy:-}
 RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSLf | \
     sh -s -- -y --default-toolchain ${RUST_VERSION} -t ${rustarch}-unknown-linux-${LIBC}
 RUN . /root/.cargo/env; cargo install cargo-when
 "
+	fi
+
 	pushd "${dir}"
 
 	sed \


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Ensured the tool still builds on Windows
- [X] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
Cherry-picking changes made upstream. Will help make progress with: https://github.com/microsoft/kata-containers/pull/204

###### Test Methodology
Upstream CI
