### PR TITLE
samples: introduce incomplete_init category

### DIFF
--- a/src/tools/genpolicy/policy_samples.json
+++ b/src/tools/genpolicy/policy_samples.json
@@ -29,9 +29,6 @@
                 "kubernetes/fixtures/replication.yaml",
                 "kubernetes/fixtures2/rc-service.yaml",
                 "kubernetes/fixtures2/valid-pod.yaml",
-                "kubernetes/incomplete-init/cassandra-statefulset.yaml",
-                "kubernetes/incomplete-init/controller.yaml",
-                "kubernetes/incomplete-init/cockroachdb-statefulset.yaml",
                 "pod/pod-exec.yaml",
                 "pod/pod-lifecycle.yaml",
                 "pod/pod-one-container.yaml",
@@ -45,6 +42,11 @@
                 "secrets/azure-file-secrets.yaml",
                 "stateful-set/web.yaml",
                 "stateful-set/web2.yaml"
+        ],
+        "incomplete_init": [
+                "kubernetes/incomplete-init/cassandra-statefulset.yaml",
+                "kubernetes/incomplete-init/controller.yaml",
+                "kubernetes/incomplete-init/cockroachdb-statefulset.yaml"
         ],
         "silently_ignored": [
                 "webhook/webhook-pod1.yaml",

--- a/src/tools/genpolicy/update_policy_samples.py
+++ b/src/tools/genpolicy/update_policy_samples.py
@@ -14,6 +14,7 @@ with open('policy_samples.json') as f:
     samples = json.load(f)
 
 default_yamls = samples["default"]
+incomplete_init = samples["incomplete_init"]
 silently_ignored = samples["silently_ignored"]
 no_policy = samples["no_policy"]
 needs_containerd_pull = samples["needs_containerd_pull"]
@@ -42,7 +43,7 @@ def timeRunCmd(arg):
         print("\n".join(log))
 
 # check we can access all files we are about to update
-for file in default_yamls + silently_ignored + no_policy:
+for file in default_yamls + incomplete_init + silently_ignored + no_policy:
     filepath = os.path.join(file_base_path, file)
     if not os.path.exists(filepath):
         sys.exit(f"filepath does not exists: {filepath}")
@@ -65,7 +66,7 @@ total_start = time.time()
 with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
     futures = []
 
-    for file in default_yamls + no_policy + needs_containerd_pull:
+    for file in default_yamls + incomplete_init + no_policy + needs_containerd_pull:
         rego_file = "/tmp/" + Path(os.path.basename(file)).stem + "-rego.txt"
         cmd = f"{genpolicy_path} -r -d -u -y {os.path.join(file_base_path, file)} > {rego_file}"
         futures.append(executor.submit(timeRunCmd, cmd))


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
Add the new category for tests we want to run genpolicy against, but not run them in deployments (as the name suggests, we cannot run those).
###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Ran `update_policy_samples.py` and observed that the `incomplete_init` samples would still be processed