### PR TITLE
agent: fix the AllowRequestsFailingPolicy functionality

### DIFF
--- a/src/agent/src/policy.rs
+++ b/src/agent/src/policy.rs
@@ -152,11 +152,7 @@ impl AgentPolicy {
         }
 
         self.engine.add_policy_from_file(default_policy_file)?;
-        self.engine.set_input_json("{}")?;
-        self.allow_failures = match self.allow_request("AllowRequestsFailingPolicy", "{}").await {
-            Ok((allowed, _prints)) => allowed,
-            Err(_) => false,
-        };
+        self.update_allow_failures_flag().await?;
         Ok(())
     }
 
@@ -168,8 +164,18 @@ impl AgentPolicy {
         let query = format!("data.agent_policy.{ep}");
         self.engine.set_input_json(ep_input)?;
 
-        let mut allow = self.engine.eval_bool_query(query, false)?;
+        let mut allow = match self.engine.eval_bool_query(query, false) {
+            Ok(a) => a,
+            Err(e) => {
+                if !self.allow_failures {
+                    return Err(e);
+                }
+                false
+            }
+        };
+
         if !allow && self.allow_failures {
+            warn!(sl!(), "policy: ignoring error for {ep}");
             allow = true;
         }
 
@@ -187,6 +193,7 @@ impl AgentPolicy {
         self.engine = Self::new_engine();
         self.engine
             .add_policy("agent_policy".to_string(), policy.to_string())?;
+        self.update_allow_failures_flag().await?;
         Ok(())
     }
 
@@ -212,6 +219,22 @@ impl AgentPolicy {
                 }
             }
         }
+    }
+
+    async fn update_allow_failures_flag(&mut self) -> Result<()> {
+        self.allow_failures = match self.allow_request("AllowRequestsFailingPolicy", "{}").await {
+            Ok((allowed, _prints)) => {
+                if allowed {
+                    warn!(
+                        sl!(),
+                        "policy: AllowRequestsFailingPolicy is enabled - will ignore errors"
+                    );
+                }
+                allowed
+            }
+            Err(_) => false,
+        };
+        Ok(())
     }
 }
 

--- a/tests/integration/kubernetes/k8s-exec-rejected.bats
+++ b/tests/integration/kubernetes/k8s-exec-rejected.bats
@@ -31,6 +31,28 @@ setup() {
 	kubectl exec "$pod_name" -- date 2>&1 | grep "ExecProcessRequest is blocked by policy"
 }
 
+@test "AllowRequestsFailingPolicy := true" {
+	# Add to the YAML file a policy using just AllowRequestsFailingPolicy := true. Evaluating the rules
+	# for any Kata Agent request will return false, but AllowRequestsFailingPolicy := true will allow
+	# those request to be executed.
+	#
+	# Warning: this is an insecure policy that shouldn't be used when protecting the confidentiality
+	#          of a pod is important. However, this policy could be useful while debugging a pod.
+	policy_text=$(printf "package agent_policy\ndefault AllowRequestsFailingPolicy := true")
+	policy_base64=$(echo "${policy_text}" | base64 -w 0 -)
+
+	yq -i \
+		".metadata.annotations.\"io.katacontainers.config.agent.policy\" = \"${policy_base64}\"" \
+		"${pod_yaml}"
+
+	# Create the pod
+	kubectl create -f "${pod_yaml}"
+
+	# Wait for pod to start
+	echo "timeout=${timeout}"
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+}
+
 teardown() {
 	# Debugging information
 	kubectl describe "pod/$pod_name"


### PR DESCRIPTION
1. Use the new value of AllowRequestsFailingPolicy after setting up a new Policy. Before this change, the only way to enable AllowRequestsFailingPolicy was to change the default Policy file, built into the Guest rootfs image.

2. Ignore errors returned by regorus while evaluating Policy rules, if AllowRequestsFailingPolicy was enabled. For example, trying to evaluate the UpdateInterfaceRequest rules using a policy that didn't define any UpdateInterfaceRequest rules results in a "not found" error from regorus. Allow AllowRequestsFailingPolicy := true to bypass that error.

3. Add simple CI test for AllowRequestsFailingPolicy.

These changes are restoring functionality that was broken recently by commmit 11f78ae7010bd0b262b10939960b9fa6ea2b3b51.
