### PR TITLE
tools: Enable setting IGVM SVN

### DIFF
--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -9,6 +9,7 @@ ROOTFS_BUILDER := $(MK_DIR)/rootfs-builder/rootfs.sh
 INITRD_BUILDER := $(MK_DIR)/initrd-builder/initrd_builder.sh
 IMAGE_BUILDER  := $(MK_DIR)/image-builder/image_builder.sh
 IGVM_BUILDER   := $(MK_DIR)/igvm-builder/igvm_builder.sh
+IGVM_SVN       ?= 0
 
 DISTRO                ?= ubuntu
 BUILD_METHOD          := distro
@@ -165,7 +166,7 @@ $(DRACUT_OVERLAY_DIR):
 
 .PHONY: igvm
 igvm: $(TARGET_IMAGE)
-	$(IGVM_BUILDER) -o $(IGVM_BUILD_DEST) -s 0
+	$(IGVM_BUILDER) -o $(IGVM_BUILD_DEST) -s $(IGVM_SVN)
 
 .PHONY: test
 test:

--- a/tools/osbuilder/node-builder/azure-linux/README.md
+++ b/tools/osbuilder/node-builder/azure-linux/README.md
@@ -145,6 +145,7 @@ The `all[-confpods]` target runs the targets `package[-confpods]` and `uvm[-conf
 Notes:
   - To retrieve more detailed build output, prefix the make commands with `DEBUG=1`.
   - To build for Azure Linux 3, prefix the make commands that build artifacts with `OS_VERSION=3.0`
+  - To build an IGVM file for CondPods with a non-default SVN of 0, prefix the `make uvm-confpods` command with `IGVM_SVN=<number>`
   - For build and deployment of both Kata and Kata-CC artifacts, first run the `make all` and `make deploy` commands to build and install the Kata Containers for AKS components followed by `make clean`, and then run `make all-confpods` and `make deploy-confpods` to build and install the Confidential Containers for AKS components - or vice versa (using `make clean-confpods`).
 
 # Run Kata (Confidential) Containers

--- a/tools/osbuilder/node-builder/azure-linux/uvm_build.sh
+++ b/tools/osbuilder/node-builder/azure-linux/uvm_build.sh
@@ -11,6 +11,7 @@ set -o errtrace
 [ -n "$DEBUG" ] && set -x
 
 CONF_PODS=${CONF_PODS:-no}
+IGVM_SVN=${IGVM_SVN:-0}
 
 script_dir="$(dirname $(readlink -f $0))"
 repo_dir="${script_dir}/../../../../"
@@ -63,7 +64,7 @@ if [ "${CONF_PODS}" == "yes" ]; then
 	echo "Building IGVM and UVM measurement files"
 	pushd tools/osbuilder
 	sudo chmod o+r root_hash.txt
-	sudo make igvm DISTRO=cbl-mariner
+	sudo make igvm DISTRO=cbl-mariner IGVM_SVN=${IGVM_SVN}
 	popd
 else
 	echo "Creating initrd based on rootfs"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
Allow setting SVN parameter for IGVM build scripting

###### Test Methodology
Ran `IGVM_SVN=10 make all-confpods`. This yields the following:
```
...
/home/azureuser/kata-containers/tools/osbuilder/igvm-builder/igvm_builder.sh -o /home/azureuser/kata-containers/tools/osbuilder -s 10
IGVM builder script
-- OUT_DIR -> /home/azureuser/kata-containers/tools/osbuilder
-- SVN -> 10
-- DISTRO -> azure-linux
-- MODE -> build
igvm_lib.sh file found. Loading content
Reading Kata image dm_verity root hash information from root_hash file
igvm_lib.sh file found. Loading content
Building (debug) IGVM files and creating their reference measurement files
{'x-ms-sevsnpvm-guestsvn': '10', 'x-ms-sevsnpvm-launchmeasurement': '2785583f67d6a72a4e3f4ac3945ca6ee10bf59d2b12d865e5e16f1dc2b4e9db5a99e22eeb6f2fd8277fc6e4747369557'}
{'x-ms-sevsnpvm-guestsvn': '10', 'x-ms-sevsnpvm-launchmeasurement': '7dd8dfccfc094dd3311ab286346f96fcb2176e7212be70bf3a5104855adc9a578e6eb6507dccaa5ceff45514e0062d54'}

...
```
