### PR TITLE
node-builder: introduce SHIM_REDEPLOY_CONFIG

### DIFF
--- a/tools/osbuilder/node-builder/azure-linux/Makefile
+++ b/tools/osbuilder/node-builder/azure-linux/Makefile
@@ -4,6 +4,8 @@
 #
 BUILD_TYPE := release
 
+export SHIM_REDEPLOY_CONFIG := yes
+
 ifeq ($(BUILD_TYPE),debug)
 	export AGENT_BUILD_TYPE := debug
 	export AGENT_POLICY_FILE := allow-all.rego

--- a/tools/osbuilder/node-builder/azure-linux/README.md
+++ b/tools/osbuilder/node-builder/azure-linux/README.md
@@ -150,6 +150,8 @@ Notes:
 
 ## Debug build
 
+This section describes how to build and deploy in debug mode.
+
 `make all-confpods` takes the following variables:
 
  * `AGENT_BUILD_TYPE`: Specify `release` (default) to build the agent in
@@ -177,6 +179,26 @@ config with `BUILD_TYPE=debug`:
 
 ```shell
 sudo make BUILD_TYPE=debug SHIM_USE_DEBUG_CONFIG=no all-confpods deploy-confpods
+```
+
+### Prevent redeploying the shim configuration
+
+If you're manually modifying the shim configuration directly on the host
+during development and you don't want to redeploy and overwrite that
+file each time you redeploy binaries, you can separately specify the
+`SHIM_REDEPLOY_CONFIG` (default `yes`):
+
+```shell
+sudo make SHIM_REDEPLOY_CONFIG=no all-confpods deploy-confpods
+```
+
+Note that this variable is independent from the other variables
+mentioned above. So if you want to avoid redeploying the shim
+configuration AND build in debug mode, you have to use the following
+command:
+
+```shell
+sudo make BUILD_TYPE=debug SHIM_REDEPLOY_CONFIG=no all-confpods deploy-confpods
 ```
 
 # Run Kata (Confidential) Containers

--- a/tools/osbuilder/node-builder/azure-linux/package_install.sh
+++ b/tools/osbuilder/node-builder/azure-linux/package_install.sh
@@ -12,6 +12,7 @@ set -o errtrace
 
 CONF_PODS=${CONF_PODS:-no}
 PREFIX=${PREFIX:-}
+SHIM_REDEPLOY_CONFIG=${SHIM_REDEPLOY_CONFIG:-yes}
 SHIM_USE_DEBUG_CONFIG=${SHIM_USE_DEBUG_CONFIG:-no}
 START_SERVICES=${START_SERVICES:-yes}
 
@@ -38,8 +39,12 @@ if [ "${CONF_PODS}" == "yes" ]; then
 	mkdir -p ${PREFIX}/usr/lib/systemd/system/
 	cp -a --backup=numbered src/tardev-snapshotter/tardev-snapshotter.service ${PREFIX}/usr/lib/systemd/system/
 
-	echo "Installing SNP shim debug configuration"
-	cp -a --backup=numbered src/runtime/config/"${SHIM_DBG_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}"/"${SHIM_DBG_CONFIG_INST_FILE_NAME}"
+	if [ "${SHIM_REDEPLOY_CONFIG}" == "yes" ]; then
+		echo "Installing SNP shim debug configuration"
+		cp -a --backup=numbered src/runtime/config/"${SHIM_DBG_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}"/"${SHIM_DBG_CONFIG_INST_FILE_NAME}"
+	else
+		echo "Skipping installation of SNP shim debug configuration"
+	fi
 
 	if [ "${SHIM_USE_DEBUG_CONFIG}" == "yes" ]; then
 		# We simply override the release config with the debug config,
@@ -59,9 +64,14 @@ cp -a --backup=numbered src/runtime/kata-runtime "${PREFIX}/${DEBUGGING_BINARIES
 chmod +x src/runtime/data/kata-collect-data.sh
 cp -a --backup=numbered src/runtime/data/kata-collect-data.sh "${PREFIX}/${DEBUGGING_BINARIES_PATH}"
 
-echo "Installing shim binary and configuration"
+echo "Installing shim binary"
 cp -a --backup=numbered src/runtime/containerd-shim-kata-v2 "${PREFIX}/${SHIM_BINARIES_PATH}"/"${SHIM_BINARY_NAME}"
 
-cp -a --backup=numbered src/runtime/config/"${SHIM_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}/${SHIM_CONFIG_INST_FILE_NAME}"
+if [ "${SHIM_REDEPLOY_CONFIG}" == "yes" ]; then
+	echo "Installing shim configuration"
+	cp -a --backup=numbered src/runtime/config/"${SHIM_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}/${SHIM_CONFIG_INST_FILE_NAME}"
+else
+	echo "Skipping installation of shim configuration"
+fi
 
 popd


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
See commit.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
NOT tested by me yet.