### PR TITLE
docs: Add more limitations for AKS-CC storage

### DIFF
--- a/docs/how-to/how-to-enable-storage-in-confidential-pods.md
+++ b/docs/how-to/how-to-enable-storage-in-confidential-pods.md
@@ -127,6 +127,8 @@ cc-managed-csi-premium cc.disk.csi.azure.com Delete WaitForFirstConsumer true 35
  * [`volumeMode:
    Block`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)
    is not supported.
+ * Specifying `securityContext.runAsUser` or `securityContext.fsGroup`
+   in the pod spec is not supported.
 
 ### Quick testing
 
@@ -388,6 +390,8 @@ cc-local-csi   cc.local.csi.azure.com   Delete          WaitForFirstConsumer   t
  * [`volumeMode:
    Block`](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)
    has not been tested.
+ * Specifying `securityContext.runAsUser` or `securityContext.fsGroup`
+   in the pod spec is not supported.
 
 ### Notes
 


### PR DESCRIPTION
Updates our docs to mention a limitation related to securityContext. I've reproed this locally for local storage, and Azure Disk is most likely affected too as the transport is the same.

###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
See commit. Internal bug: https://microsoft.visualstudio.com/OS/_workitems/edit/53880968