### PR TITLE
pr_template: remove genpolicy windows support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,6 @@
 - [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
   - [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
 - [ ] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
-- [ ] genPolicy only: Ensured the tool still builds on Windows
 - [ ] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 
 
 ###### Summary <!-- REQUIRED -->


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Ensured the tool still builds on Windows
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

pr_template: remove genpolicy windows support
check from PR template

We don't support genpolicy for windows as of 3.2.0.azl1.genpolicy1

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
n/a