### PR TITLE
tools: Align AGENT_POLICY_FILE check in rootfs-builder with upstream

### DIFF
--- a/tools/osbuilder/node-builder/azure-linux/uvm_build.sh
+++ b/tools/osbuilder/node-builder/azure-linux/uvm_build.sh
@@ -17,6 +17,8 @@ IGVM_SVN=${IGVM_SVN:-0}
 script_dir="$(dirname $(readlink -f $0))"
 repo_dir="${script_dir}/../../../../"
 
+agent_policy_file_abs="${repo_dir}/src/kata-opa/${AGENT_POLICY_FILE}"
+
 common_file="common.sh"
 source "${common_file}"
 
@@ -24,7 +26,7 @@ source "${common_file}"
 rootfs_make_flags="AGENT_SOURCE_BIN=${AGENT_INSTALL_DIR}/usr/bin/kata-agent"
 
 if [ "${CONF_PODS}" == "yes" ]; then
-	rootfs_make_flags+=" AGENT_POLICY=yes CONF_GUEST=yes AGENT_POLICY_FILE=${AGENT_POLICY_FILE}"
+	rootfs_make_flags+=" AGENT_POLICY=yes CONF_GUEST=yes AGENT_POLICY_FILE=${agent_policy_file_abs}"
 fi
 
 if [ "${CONF_PODS}" == "yes" ]; then

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -32,7 +32,9 @@ AGENT_POLICY=${AGENT_POLICY:-no}
 lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"
 
-agent_policy_file="$(readlink -f -v "${AGENT_POLICY_FILE:-"${script_dir}/../../../src/kata-opa/allow-all.rego"}")"
+if [[ "${AGENT_POLICY}" == "yes" ]]; then
+	agent_policy_file="$(readlink -f -v "${AGENT_POLICY_FILE:-"${script_dir}/../../../src/kata-opa/allow-all.rego"}")"
+fi
 
 #For cross build
 CROSS_BUILD=${CROSS_BUILD:-false}
@@ -329,7 +331,9 @@ check_env_variables()
 
 	[ -n "${KERNEL_MODULES_DIR}" ] && [ ! -d "${KERNEL_MODULES_DIR}" ] && die "KERNEL_MODULES_DIR defined but is not an existing directory"
 
-	[ ! -f "${agent_policy_file}" ] && die "agent policy file not found in '${agent_policy_file}'"
+	if [[ "${AGENT_POLICY}" == "yes" ]]; then
+		[ ! -f "${agent_policy_file}" ] && die "agent policy file not found in '${agent_policy_file}'"
+	fi
 
 	[ -n "${OSBUILDER_VERSION}" ] || die "need osbuilder version"
 }
@@ -651,7 +655,7 @@ EOF
 		chmod g+rx,o+x "${ROOTFS_DIR}"
 	fi
 
-	if [ "${AGENT_POLICY}" == "yes" ]; then
+	if [[ "${AGENT_POLICY}" == "yes" ]]; then
 		# Install default settings for the kata-opa service.
 		local opa_settings_dir="/etc/kata-opa"
 		local policy_file_name="$(basename ${agent_policy_file})"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -33,7 +33,7 @@ AGENT_POLICY_FILE=${AGENT_POLICY_FILE:-"allow-all.rego"}
 lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"
 
-[ "${AGENT_POLICY}" == "yes" ] && agent_policy_file="$(readlink -f "${script_dir}/../../../src/kata-opa/${AGENT_POLICY_FILE}")"
+agent_policy_file="$(readlink -f "${script_dir}/../../../src/kata-opa/${AGENT_POLICY_FILE}")"
 
 #For cross build
 CROSS_BUILD=${CROSS_BUILD:-false}
@@ -330,7 +330,7 @@ check_env_variables()
 
 	[ -n "${KERNEL_MODULES_DIR}" ] && [ ! -d "${KERNEL_MODULES_DIR}" ] && die "KERNEL_MODULES_DIR defined but is not an existing directory"
 
-	[ "${AGENT_POLICY}" == "yes" ] && [ ! -f "${agent_policy_file}" ] && die "agent policy file not found in '${agent_policy_file}'"
+	[ ! -f "${agent_policy_file}" ] && die "agent policy file not found in '${agent_policy_file}'"
 
 	[ -n "${OSBUILDER_VERSION}" ] || die "need osbuilder version"
 }

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -28,12 +28,11 @@ LIBC=${LIBC:-musl}
 SECCOMP=${SECCOMP:-"yes"}
 SELINUX=${SELINUX:-"no"}
 AGENT_POLICY=${AGENT_POLICY:-no}
-AGENT_POLICY_FILE=${AGENT_POLICY_FILE:-"allow-all.rego"}
 
 lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"
 
-agent_policy_file="$(readlink -f "${script_dir}/../../../src/kata-opa/${AGENT_POLICY_FILE}")"
+agent_policy_file="$(readlink -f -v "${AGENT_POLICY_FILE:-"${script_dir}/../../../src/kata-opa/allow-all.rego"}")"
 
 #For cross build
 CROSS_BUILD=${CROSS_BUILD:-false}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
- Revert the initial check PR introduced in fork: https://github.com/microsoft/kata-containers/commit/6f4a49c9b40c975654d7629986595b8cfc80b9a0
- Consume two upstream commits that achieve the same:
  - https://github.com/kata-containers/kata-containers/commit/b7a184a0d8d6931ab0cfa76a97ed137500cb7e53
  - https://github.com/kata-containers/kata-containers/pull/10389/files
###### Test Methodology
Internal CI, package/image build and AKS image tests