### PR TITLE
Fix logging verbosity comment to accurately reflect clh behavior

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1433,11 +1433,10 @@ func (clh *cloudHypervisor) launchClh() error {
 	if clh.config.Debug {
 		// Cloud hypervisor log levels
 		// 'v' occurrences increase the level
-		//0 =>  Error
-		//1 =>  Warn
-		//2 =>  Info
-		//3 =>  Debug
-		//4+ => Trace
+		//0 =>  Warn
+		//1 =>  Info
+		//2 =>  Debug
+		//3+ => Trace
 		// Use Info, the CI runs with debug enabled
 		// a high level of logging increases the boot time
 		// and in a nested environment this could increase


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
The cloud-hypervisor's logging behavior is different than described in the CLH log levels comment in clh.go. This PR updates the comment to accurately reflect the behavior as implemented in cloud-hypervisor: https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/src/main.rs#L555 

A single -v filters at the 'Info' level, not 'Warn'. Info is the desired level of verbosity to not add too much noise to the output. 


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
No functional change. 
