### PR TITLE
node-builder: Use Azure Linux 3 as default path

### DIFF
--- a/tools/osbuilder/node-builder/azure-linux/common.sh
+++ b/tools/osbuilder/node-builder/azure-linux/common.sh
@@ -8,9 +8,9 @@ script_dir="$(dirname $(readlink -f $0))"
 lib_file="${script_dir}/../../scripts/lib.sh"
 source "${lib_file}"
 
-OS_VERSION=${OS_VERSION:-2.0}
+OS_VERSION=$(sort -r /etc/*-release | gawk 'match($0, /^(VERSION_ID=(.*))$/, a) { print toupper(a[2] a[3]); exit }' | tr -d '"')
 
-([[ "${OS_VERSION}" == "2.0" ]] || [[ "${OS_VERSION}" == "3.0" ]]) || die "OS_VERSION: must equal 2.0 (default) or 3.0"
+([[ "${OS_VERSION}" == "2.0" ]] || [[ "${OS_VERSION}" == "3.0" ]]) || die "OS_VERSION: value '${OS_VERSION}' must equal 3.0 (default) or 2.0"
 
 if [ "${CONF_PODS}" == "yes" ]; then
 	INSTALL_PATH_PREFIX="/opt/confidential-containers"

--- a/tools/osbuilder/node-builder/azure-linux/uvm_build.sh
+++ b/tools/osbuilder/node-builder/azure-linux/uvm_build.sh
@@ -23,7 +23,7 @@ common_file="common.sh"
 source "${common_file}"
 
 # This ensures that a pre-built agent binary is being injected into the rootfs
-rootfs_make_flags="AGENT_SOURCE_BIN=${AGENT_INSTALL_DIR}/usr/bin/kata-agent"
+rootfs_make_flags="AGENT_SOURCE_BIN=${AGENT_INSTALL_DIR}/usr/bin/kata-agent OS_VERSION=${OS_VERSION}"
 
 if [ "${CONF_PODS}" == "yes" ]; then
 	rootfs_make_flags+=" AGENT_POLICY=yes CONF_GUEST=yes AGENT_POLICY_FILE=${agent_policy_file_abs}"

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 OS_NAME=cbl-mariner
-OS_VERSION=${OS_VERSION:-2.0}
+OS_VERSION=${OS_VERSION:-3.0}
 LIBC="gnu"
 PACKAGES="kata-packages-uvm"
 [ "$CONF_GUEST" = yes ] && PACKAGES+=" kata-packages-uvm-coco"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
Change recipe to assume Azure Linux 3 as the build path.
Sustain instructions to be able to build on Azure Linux 2 as production AKS nodes are on Azure Linux 2.

###### Test Methodology
- Manual: Following the recipe on AzL2, deploying pods.