### PR TITLE
runtime: Fix make test for virtcontainers.

### DIFF
--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -492,7 +492,7 @@ func TestClhCreateVM(t *testing.T) {
 		{config0, false, true},
 		{config1, false, true},
 		{config2, false, true},
-		{config3, true, false},
+		{config3, false, false},
 		{config4, false, true},
 		{config5, false, true},
 	}

--- a/src/runtime/virtcontainers/hypervisor_test.go
+++ b/src/runtime/virtcontainers/hypervisor_test.go
@@ -481,6 +481,7 @@ func TestAssetPath(t *testing.T) {
 
 		KernelPath: "/" + "io.katacontainers.config.hypervisor.kernel",
 
+		IgvmPath:  "/" + "io.katacontainers.config.hypervisor.igvm",
 		ImagePath:  "/" + "io.katacontainers.config.hypervisor.image",
 		InitrdPath: "/" + "io.katacontainers.config.hypervisor.initrd",
 


### PR DESCRIPTION
This commit fixes make test for virtcontainers. It fixes:
a. hypervisor_test::TestAssetPath by adding igvm asset path.
b. clh_test::TestCreateVM by setting testData expectError to false for ConfidentialGuest test config.
This is needed because we have allowed noneProtection for test purposes for Confidential configuration.

###### Merge Checklist  <!-- REQUIRED -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [ ] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
Fix `make test` for src/runtime/virtcontainers.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local run tests:
go test --run TestAssetPath
go test --run TestClhCreateVm
