### PR TITLE
ci: install libdevmapper for agent static checks

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ matrix.component != 'runtime' }}
         run: sudo apt-get -y install musl-tools
       - name: Install devicemapper
-        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
+        if: ${{ (matrix.command == 'make check' || matrix.command == 'make test') && matrix.component == 'agent' }}
         run: sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
         if: ${{ matrix.command != 'make vendor'  &&  matrix.command != 'make check' &&  matrix.install-libseccomp == 'yes' }}


### PR DESCRIPTION
Install libdevmapper for agent make test check.

###### Merge Checklist  <!-- REQUIRED -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [ ] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
Install device mapper for agent static build checks for both make check & make test.
This fixes the `libdevicemapper.h` not found when compiling devicemapper-sys crate.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
