### PR TITLE
policy: ignore optional metadata uid field

### DIFF
--- a/src/agent/samples/policy/yaml/pod/pod-one-container.yaml
+++ b/src/agent/samples/policy/yaml/pod/pod-one-container.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: one-container
+  uid: one-container-uid
   labels:
     run: busybox
   annotations:

--- a/src/tools/genpolicy/src/obj_meta.rs
+++ b/src/tools/genpolicy/src/obj_meta.rs
@@ -26,6 +26,9 @@ pub struct ObjectMeta {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
 }
 
 impl ObjectMeta {


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

This prevents a deserialization error when uid is specified.
Cherry pick from https://github.com/kata-containers/kata-containers/commit/711d12e5db8caa757fafc587f809b4e901cb91a5

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->

test run: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=688524&view=results