### PR TITLE
reduce the memory usage for the guest image

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -298,6 +298,12 @@ block_device_driver = "virtio-blk"
 # set to a non zero value.
 #disk_rate_limiter_ops_one_time_burst = 0
 
+# If false and nvdimm is supported, use nvdimm device to plug guest image.
+# Otherwise virtio-block device is used.
+#
+# Default is false
+disable_image_nvdimm = true
+
 [agent.@PROJECT_TYPE@]
 # If enabled, make the agent display debug-level messages.
 # (default: disabled)

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1121,6 +1121,7 @@ func newClhHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		FileBackedMemRootList:          h.FileBackedMemRootList,
 		Debug:                          h.Debug,
 		DisableNestingChecks:           h.DisableNestingChecks,
+		DisableImageNvdimm:             h.DisableImageNvdimm,
 		BlockDeviceDriver:              blockDriver,
 		BlockDeviceCacheSet:            h.BlockDeviceCacheSet,
 		BlockDeviceCacheDirect:         h.BlockDeviceCacheDirect,

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -492,6 +492,11 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 	clh.ctx = newCtx
 	defer span.End()
 
+	clh.Logger().
+		WithField("DisableImageNvdimm", hypervisorConfig.DisableImageNvdimm).
+		WithField("ConfidentialGuest", hypervisorConfig.ConfidentialGuest).
+		Info("CreateVM")
+
 	if err := clh.setConfig(hypervisorConfig); err != nil {
 		return err
 	}
@@ -578,7 +583,9 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 	// Set initial amount of cpu's for the virtual machine
 	clh.vmconfig.Cpus = chclient.NewCpusConfig(int32(clh.config.NumVCPUs()), int32(clh.config.DefaultMaxVCPUs))
 
-	params, err := GetKernelRootParams(hypervisorConfig.RootfsType, clh.config.ConfidentialGuest, false)
+	disableNvdimm := (clh.config.DisableImageNvdimm || clh.config.ConfidentialGuest)
+	enableDax := false
+	params, err := GetKernelRootParams(hypervisorConfig.RootfsType, disableNvdimm, enableDax)
 	if err != nil {
 		return err
 	}
@@ -621,7 +628,7 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 	}
 
 	if assetType == types.ImageAsset {
-		if clh.config.ConfidentialGuest {
+		if disableNvdimm {
 			disk := chclient.NewDiskConfig(assetPath)
 			disk.SetReadonly(true)
 

--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -12,6 +12,7 @@ set -o pipefail
 
 DOCKER_RUNTIME=${DOCKER_RUNTIME:-runc}
 MEASURED_ROOTFS=${MEASURED_ROOTFS:-no}
+IMAGE_SIZE_ALIGNMENT_MB=${IMAGE_SIZE_ALIGNMENT_MB:-2}
 
 #For cross build
 CROSS_BUILD=${CROSS_BUILD:-false}
@@ -74,9 +75,6 @@ readonly -a systemd_files=(
 AGENT_INIT=${AGENT_INIT:-no}
 SELINUX=${SELINUX:-no}
 SELINUXFS="/sys/fs/selinux"
-
-# Align image to 128M
-readonly mem_boundary_mb=128
 
 # shellcheck source=../scripts/lib.sh
 source "${lib_file}"
@@ -327,9 +325,9 @@ calculate_img_size() {
 		img_size="$((img_size + root_free_space_mb))"
 	fi
 
-	remaining="$((img_size % mem_boundary_mb))"
+	remaining="$((img_size % ${IMAGE_SIZE_ALIGNMENT_MB}))"
 	if [ "${remaining}" != "0" ]; then
-		img_size=$((img_size + mem_boundary_mb - remaining))
+		img_size=$((img_size + ${IMAGE_SIZE_ALIGNMENT_MB} - remaining))
 	fi
 
 	echo "${img_size}"


### PR DESCRIPTION
Reduce the memory usage for the guest image by:
1. Using a smaller guest image size.
2. Using virtio-blk instead of pmem for the guest image.
