### PR TITLE
runtime: improved memory overhead management

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1963,11 +1963,6 @@ func checkHypervisorConfig(config vc.HypervisorConfig) error {
 	}
 
 	memSizeMB := int64(config.MemorySize)
-
-	if memSizeMB == 0 {
-		return errors.New("VM memory cannot be zero")
-	}
-
 	mb := int64(1024 * 1024)
 
 	for _, image := range images {

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -82,7 +82,7 @@ const (
 	vSockLogsPort = 1025
 
 	// MinHypervisorMemory is the minimum memory required for a VM.
-	MinHypervisorMemory = 64
+	MinHypervisorMemory = 0
 
 	defaultMsize9p = 8192
 

--- a/tools/osbuilder/node-builder/azure-linux/package_build.sh
+++ b/tools/osbuilder/node-builder/azure-linux/package_build.sh
@@ -21,7 +21,7 @@ source "${common_file}"
 
 # these options ensure we produce the proper CLH config file
 runtime_make_flags="SKIP_GO_VERSION_CHECK=1 QEMUCMD= FCCMD= ACRNCMD= STRATOVIRTCMD= DEFAULT_HYPERVISOR=cloud-hypervisor
-	DEFMEMSZ=256 DEFSTATICSANDBOXWORKLOADMEM=1792 DEFVIRTIOFSDAEMON=${VIRTIOFSD_BINARY_LOCATION} PREFIX=${INSTALL_PATH_PREFIX}"
+	DEFMEMSZ=0 DEFSTATICSANDBOXWORKLOADMEM=512 DEFVIRTIOFSDAEMON=${VIRTIOFSD_BINARY_LOCATION} PREFIX=${INSTALL_PATH_PREFIX}"
 
 # - for vanilla Kata we use the kernel binary. For ConfPods we use IGVM, so no need to provide kernel path.
 # - for vanilla Kata we explicitly set DEFSTATICRESOURCEMGMT_CLH. For ConfPods,


### PR DESCRIPTION
After these changes:

1. The value of the K8s runtime class memory overhead:
   - Covers the memory usage from all the Host-side components (mainly the Kata Shim and the VMM).
   - Doesn't include the memory usage from any Guest-side components.

2. The value of a pod memory limit specified by the user:
   - Is equal to the memory size of the Pod VM.
   - Includes the memory usage from all the Guest-side components (mainly user's workload, the Guest kernel, and the Kata Agent)
   - Doesn't include the memory usage from any Host-side components.
