### PR TITLE
runtime: Remove unused VMM options for mem alloc

### DIFF
--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -353,11 +353,6 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 # - When running single containers using a tool like ctr, container sizing information will be available.
 static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT_FC@
 
-# If set, the runtime will use the value as the default workload memory in MB for the sandbox when no workload memory request is passed
-# down to the shim via the OCI when static sandbox resource management is enabled. With this, we ensure that workloads have a proper
-# default amount of memory available within the sandbox.
-static_sandbox_default_workload_mem=@DEFSTATICSANDBOXWORKLOADMEM@
-
 # If enabled, the runtime will not create Kubernetes emptyDir mounts on the guest filesystem. Instead, emptyDir mounts will
 # be created on the host and shared via virtio-fs. This is potentially slower, but allows sharing of files from host to guest.
 disable_guest_empty_dir=@DEFDISABLEGUESTEMPTYDIR@

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -650,11 +650,6 @@ sandbox_cgroup_only=@DEFSANDBOXCGROUPONLY@
 # - When running single containers using a tool like ctr, container sizing information will be available.
 static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT@
 
-# If set, the runtime will use the value as the default workload memory in MB for the sandbox when no workload memory request is passed
-# down to the shim via the OCI when static sandbox resource management is enabled. With this, we ensure that workloads have a proper
-# default amount of memory available within the sandbox.
-static_sandbox_default_workload_mem=@DEFSTATICSANDBOXWORKLOADMEM@
-
 # If specified, sandbox_bind_mounts identifieds host paths to be mounted (ro) into the sandboxes shared path.
 # This is only valid if filesystem sharing is utilized. The provided path(s) will be bindmounted into the shared fs directory.
 # If defaults are utilized, these mounts should be available in the guest at `/run/kata-containers/shared/containers/sandbox-mounts`


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
- We only ever tested the fork changes for changed memory allocation behavior with CLH+MSHV
- Remove these options as we don't use QEMU/FC

###### Test Methodology
N/A