### PR TITLE
chore: bump genpolicy version

### DIFF
--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "genpolicy"
-version = "3.2.0-azl3.genpolicy2"
+version = "3.2.0-azl3.genpolicy3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/tools/genpolicy/Cargo.toml
+++ b/src/tools/genpolicy/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "genpolicy"
-version = "3.2.0-azl3.genpolicy2"
+version = "3.2.0-azl3.genpolicy3"
 authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

Bump genpolicy version to 3.2.0-azl3.genpolicy3

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
