### PR TITLE
samples: use 256Mi pod memory limit

### DIFF
--- a/src/agent/samples/policy/yaml/webhook/webhook-pod4.yaml
+++ b/src/agent/samples/policy/yaml/webhook/webhook-pod4.yaml
@@ -71,7 +71,7 @@ spec:
       resources:
         limits:
           cpu: 1250m
-          memory: 64Mi
+          memory: 256Mi
         requests:
           cpu: 250m
           memory: 32Mi

--- a/src/agent/samples/policy/yaml/webhook2/webhook-pod10.yaml
+++ b/src/agent/samples/policy/yaml/webhook2/webhook-pod10.yaml
@@ -75,7 +75,7 @@ spec:
       resources:
         limits:
           cpu: 1250m
-          memory: 64Mi
+          memory: 256Mi
         requests:
           cpu: 250m
           memory: 32Mi


### PR DESCRIPTION
64Mi limit is insufficient after the changes from c7b8ee92025ee6c468a94c233994d6f9b6a00cf5. The lowest supported memory limit is 192Mi.
