### PR TITLE
agent: add back rego error logs

### DIFF
--- a/src/agent/src/policy.rs
+++ b/src/agent/src/policy.rs
@@ -251,11 +251,6 @@ impl AgentPolicy {
             }
         };
 
-        let prints = match self.engine.take_prints() {
-            Ok(p) => p.join(" "),
-            Err(e) => format!("Failed to get policy log: {e}"),
-        };
-
         if !allow {
             self.log_request(ep, &prints).await;
             if self.allow_failures {


### PR DESCRIPTION

###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

The aim of this PR is to fix a regression introduced in https://github.com/microsoft/kata-containers/pull/273/files#diff-84f120758564e7adf93c69772f22eb04eaefcde3d30c01ddbe5a906f1611233d where rego error logs were no longer available after that change.

take_prints takes and clear prints per https://github.com/microsoft/regorus/blob/748c11cfa1319c808977194c1657e0fd866269be/src/engine.rs#L848 
Add back error logs by not calling take_prints twice.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
tested locally: rego error logs are again printed as expected
