### PR TITLE
overlay: use nix::mount for OverlayFS to overcome mounting limitations

### DIFF
--- a/src/overlay/Cargo.lock
+++ b/src/overlay/Cargo.lock
@@ -209,6 +209,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "clap",
+ "nix",
  "tempfile",
 ]
 
@@ -223,6 +224,27 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "once_cell"

--- a/src/overlay/Cargo.toml
+++ b/src/overlay/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 clap = { version = "4.3.2", features = ["derive"] }
 base64 = "0.21.2"
 tempfile = "3.3.0"
+nix = "0.24.2"


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
In overlay, Replaces mount(8) with nix::mount to address limitations in handling multiple lowerdir entries for OverlayFS, ensuring compatibility with updated mount API behaviors.

###### Test Methodology
 - Manual validation using AKS cluster
 - conformance test: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=712133&view=results
 - performance test: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=711484&view=results
