### PR TITLE
runtime: skip empty Guest console output lines

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1202,12 +1202,15 @@ func (cw *consoleWatcher) start(s *Sandbox) (err error) {
 
 	go func() {
 		for scanner.Scan() {
-			s.Logger().WithFields(logrus.Fields{
-				"console-protocol": cw.proto,
-				"console-url":      cw.consoleURL,
-				"sandbox":          s.id,
-				"vmconsole":        scanner.Text(),
-			}).Debug("reading guest console")
+			text := scanner.Text()
+			if text != "" {
+				s.Logger().WithFields(logrus.Fields{
+					"console-protocol": cw.proto,
+					"console-url":      cw.consoleURL,
+					"sandbox":          s.id,
+					"vmconsole":        text,
+				}).Debug("reading guest console")
+			}
 		}
 
 		if err := scanner.Err(); err != nil {


### PR DESCRIPTION
Skip logging empty lines of text from the Guest console output, if there are any such lines.

Without this change, the Guest console log from CLH + /dev/pts/0 has twice as many lines of text. Half of these lines are empty.

Fixes: #10737

Cherry-pick upstream commit 2e21f513756b4950ac203a0612b1d4c4071ea8a3