### PR TITLE
Cameronbaird/hyp loglevel

### DIFF
--- a/src/runtime/config/configuration-clh-snp.toml.in
+++ b/src/runtime/config/configuration-clh-snp.toml.in
@@ -195,6 +195,11 @@ block_device_driver = "virtio-blk"
 # Default false
 #enable_debug = true
 
+# This option specifies the loglevel of the hypervisor
+#
+# Default 1
+#hypervisor_loglevel = 1
+
 # Path to OCI hook binaries in the *guest rootfs*.
 # This does not affect host-side hooks which must instead be added to
 # the OCI spec passed to the runtime.

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -205,6 +205,11 @@ block_device_driver = "virtio-blk"
 # Default false
 #enable_debug = true
 
+# This option specifies the loglevel of the hypervisor
+#
+# Default 1
+#hypervisor_loglevel = 1
+
 # Enable hot-plugging of VFIO devices to a root-port.
 # The default setting is  "no-port"
 #hot_plug_vfio = "root-port"

--- a/src/runtime/pkg/katautils/config-settings.go.in
+++ b/src/runtime/pkg/katautils/config-settings.go.in
@@ -63,6 +63,7 @@ const defaultVCPUCount uint32 = 0
 const defaultMaxVCPUCount uint32 = 0
 const defaultMemSize uint32 = 2048 // MiB
 const defaultMemSlots uint32 = 10
+const defaultHypervisorLoglevel uint32 = 1
 const defaultMemOffset uint64 = 0 // MiB
 const defaultVirtioMem bool = false
 const defaultBridgesCount uint32 = 1

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -58,6 +58,9 @@ const (
 	// the maximum amount of PCI bridges that can be cold plugged in a VM
 	maxPCIBridges uint32 = 5
 
+	// the maximum valid loglevel for the hypervisor
+	maxHypervisorLoglevel uint32 = 3
+
 	errInvalidHypervisorPrefix = "configuration file contains invalid hypervisor section"
 )
 
@@ -130,6 +133,7 @@ type hypervisor struct {
 	NetRateLimiterBwOneTimeBurst   int64                     `toml:"net_rate_limiter_bw_one_time_burst"`
 	NetRateLimiterOpsMaxRate       int64                     `toml:"net_rate_limiter_ops_max_rate"`
 	NetRateLimiterOpsOneTimeBurst  int64                     `toml:"net_rate_limiter_ops_one_time_burst"`
+	HypervisorLoglevel             uint32                    `toml:"hypervisor_loglevel"`
 	VirtioFSCacheSize              uint32                    `toml:"virtio_fs_cache_size"`
 	VirtioFSQueueSize              uint32                    `toml:"virtio_fs_queue_size"`
 	DefaultMaxVCPUs                uint32                    `toml:"default_maxvcpus"`
@@ -498,6 +502,14 @@ func (h hypervisor) defaultBridges() uint32 {
 	}
 
 	return h.DefaultBridges
+}
+
+func (h hypervisor) defaultHypervisorLoglevel() uint32 {
+	if h.HypervisorLoglevel > maxHypervisorLoglevel {
+		return maxHypervisorLoglevel
+	}
+
+	return h.HypervisorLoglevel
 }
 
 func (h hypervisor) defaultVirtioFSCache() string {
@@ -906,6 +918,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		SharedFS:                sharedFS,
 		VirtioFSDaemon:          h.VirtioFSDaemon,
 		VirtioFSDaemonList:      h.VirtioFSDaemonList,
+		HypervisorLoglevel:      h.defaultHypervisorLoglevel(),
 		VirtioFSCacheSize:       h.VirtioFSCacheSize,
 		VirtioFSCache:           h.defaultVirtioFSCache(),
 		VirtioFSQueueSize:       h.VirtioFSQueueSize,
@@ -1114,6 +1127,7 @@ func newClhHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		SharedFS:                       sharedFS,
 		VirtioFSDaemon:                 h.VirtioFSDaemon,
 		VirtioFSDaemonList:             h.VirtioFSDaemonList,
+		HypervisorLoglevel:             h.defaultHypervisorLoglevel(),
 		VirtioFSCacheSize:              h.VirtioFSCacheSize,
 		VirtioFSCache:                  h.VirtioFSCache,
 		MemPrealloc:                    h.MemPrealloc,
@@ -1268,6 +1282,7 @@ func newStratovirtHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		SharedFS:              sharedFS,
 		VirtioFSDaemon:        h.VirtioFSDaemon,
 		VirtioFSDaemonList:    h.VirtioFSDaemonList,
+		HypervisorLoglevel:    h.defaultHypervisorLoglevel(),
 		VirtioFSCacheSize:     h.VirtioFSCacheSize,
 		VirtioFSCache:         h.defaultVirtioFSCache(),
 		VirtioFSExtraArgs:     h.VirtioFSExtraArgs,
@@ -1487,6 +1502,7 @@ func GetDefaultHypervisorConfig() vc.HypervisorConfig {
 		GuestHookPath:            defaultGuestHookPath,
 		VhostUserStorePath:       defaultVhostUserStorePath,
 		VhostUserDeviceReconnect: defaultVhostUserDeviceReconnect,
+		HypervisorLoglevel:       defaultHypervisorLoglevel,
 		VirtioFSCache:            defaultVirtioFSCacheMode,
 		DisableImageNvdimm:       defaultDisableImageNvdimm,
 		RxRateLimiterMaxRate:     defaultRxRateLimiterMaxRate,

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -563,6 +563,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		Msize9p:               defaultMsize9p,
 		GuestHookPath:         defaultGuestHookPath,
 		VhostUserStorePath:    defaultVhostUserStorePath,
+		HypervisorLoglevel:    defaultHypervisorLoglevel,
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 		BlockDeviceAIO:        defaultBlockDeviceAIO,
 		DisableGuestSeLinux:   defaultDisableGuestSeLinux,

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1446,7 +1446,7 @@ func (clh *cloudHypervisor) launchClh() error {
 	}
 
 	args := []string{cscAPIsocket, clh.state.apiSocket}
-	if clh.config.Debug {
+	if clh.config.Debug && clh.config.HypervisorLoglevel > 0 {
 		// Cloud hypervisor log levels
 		// 'v' occurrences increase the level
 		//0 =>  Warn
@@ -1466,7 +1466,8 @@ func (clh *cloudHypervisor) launchClh() error {
 		// output. For further details, see the discussion on:
 		//
 		//   https://github.com/kata-containers/kata-containers/pull/2751
-		args = append(args, "-v")
+		verbosityString := fmt.Sprintf("-%s", strings.Repeat("v", int(clh.config.HypervisorLoglevel)))
+		args = append(args, verbosityString)
 	}
 
 	// Enable the `seccomp` feature from Cloud Hypervisor by default

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -608,6 +608,10 @@ type HypervisorConfig struct {
 	// enable debug output where available.
 	Debug bool
 
+	// HypervisorLoglevel determines the level of logging emitted
+	// from the hypervisor. Accepts values 0-3.
+	HypervisorLoglevel uint32
+
 	// MemPrealloc specifies if the memory should be pre-allocated
 	MemPrealloc bool
 


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [ ] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
Introduce new config, hypervisor_debug_level, which allows the user to specify the verbosity of the hypervisor.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Built and deployed on an AKS kata cluster. Set the new config param to 3 and saw that the verbosity increased for clh:
![image](https://github.com/user-attachments/assets/056219e5-5f7d-4f4a-8a55-db5a2a122800)

