### PR TITLE
genpolicy: add crate-scoped integration test

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -102,7 +102,7 @@ jobs:
           ./tests/install_rust.sh
           echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
       - name: Install protobuf-compiler
-        if: ${{ matrix.command == 'make check' && matrix.component == 'genpolicy' }}
+        if: ${{ matrix.command != 'make vendor' && (matrix.component == 'agent' || matrix.component == 'genpolicy' || matrix.component == 'agent-ctl') }}
         run: sudo apt-get -y install protobuf-compiler
       - name: Install musl-tools
         if: ${{ matrix.component != 'runtime' }}

--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -278,7 +278,7 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -311,8 +311,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbd55a5b186b60273ed7361d18d566ede8d66db962bafd702dd4db7fd30f23f"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "tokio",
  "tonic",
  "tonic-build 0.9.2",
@@ -361,6 +361,17 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -446,6 +457,12 @@ dependencies = [
  "redox_syscall",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
@@ -590,10 +607,13 @@ dependencies = [
  "fs2",
  "generic-array",
  "k8s-cri",
+ "libz-ng-sys",
  "log",
  "oci",
  "oci-distribution",
  "openssl",
+ "protocols",
+ "regorus",
  "serde",
  "serde-transcode",
  "serde_ignored",
@@ -655,6 +675,15 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -899,7 +928,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1ac03a0ee89d53fc350989682a56915a4f93fe7b51801a1066cb3caeb2a23f"
 dependencies = [
- "prost",
+ "prost 0.11.9",
  "serde",
  "tonic",
  "tonic-build 0.8.4",
@@ -958,6 +987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,10 +1046,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.18"
+name = "nix"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1120,6 +1171,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.2+3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1187,7 @@ checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1139,11 +1200,21 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset 0.2.0",
+ "indexmap 1.9.3",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 2.2.3",
 ]
 
@@ -1212,12 +1283,40 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+dependencies = [
+ "bytes",
+ "prost-derive 0.8.0",
+]
+
+[[package]]
+name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph 0.5.1",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -1227,19 +1326,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "lazy_static",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.6.4",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1257,11 +1369,99 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+dependencies = [
+ "bytes",
+ "prost 0.8.0",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55bad9126f378a853655831eb7363b7b01b81d19f8cb1218861086ca4a1a61e"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf 2.28.0",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd418ac3c91caa4032d37cb80ff0d44e2ebe637b2fb243b6234bf89cdac4901"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf 3.2.0",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d39b14605eaa1f6a340aec7f320b34064feb26c93aec35d6a9a2272a8ddfa49"
+dependencies = [
+ "anyhow",
+ "indexmap 1.9.3",
+ "log",
+ "protobuf 3.2.0",
+ "protobuf-support",
+ "tempfile",
+ "thiserror",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d4d7b8601c814cfb36bcebb79f0e61e45e1e93640cf778837833bbed05c372"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "protocols"
+version = "0.1.0"
+dependencies = [
+ "oci",
+ "protobuf 3.2.0",
+ "serde",
+ "serde_json",
+ "ttrpc",
+ "ttrpc-codegen",
 ]
 
 [[package]]
@@ -1340,6 +1540,20 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "regorus"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843c3d97f07e3b5ac0955d53ad0af4c91fe4a4f8525843ece5bf014f27829b73"
+dependencies = [
+ "anyhow",
+ "lazy_static",
+ "regex",
+ "scientific",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "reqwest"
@@ -1430,6 +1644,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "scientific"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a4b339a8de779ecb098a772ecbba2ace74e23ed959a5b4f30631d8bf1799a8"
+dependencies = [
+ "scientific-macro",
+]
+
+[[package]]
+name = "scientific-macro"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ee4885492bb655bfa05d039cd9163eb8fe9f79ddebf00ca23a1637510c2fd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1794,7 +2028,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.11.9",
  "tokio",
  "tokio-stream",
  "tower",
@@ -1811,7 +2045,7 @@ checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.11.9",
  "quote",
  "syn 1.0.109",
 ]
@@ -1824,7 +2058,7 @@ checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.11.9",
  "quote",
  "syn 1.0.109",
 ]
@@ -1900,6 +2134,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttrpc"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e8a0d78bb5368d438ba1fd2622573b8db49fbae4a438ac41351f3095c6598d"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "nix",
+ "protobuf 3.2.0",
+ "protobuf-codegen 3.2.0",
+ "thiserror",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ttrpc-codegen"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d7f7631d7a9ebed715a47cd4cb6072cbc7ae1d4ec01598971bbec0024340c2"
+dependencies = [
+ "protobuf 2.28.0",
+ "protobuf-codegen 3.2.0",
+ "protobuf-support",
+ "ttrpc-compiler",
+]
+
+[[package]]
+name = "ttrpc-compiler"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0672eb06e5663ad190c7b93b2973f5d730259859b62e4e3381301a12a7441107"
+dependencies = [
+ "derive-new",
+ "prost 0.8.0",
+ "prost-build 0.8.0",
+ "prost-types 0.8.0",
+ "protobuf 2.28.0",
+ "protobuf-codegen 2.28.0",
+ "tempfile",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,6 +2211,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "url"

--- a/src/tools/genpolicy/Cargo.toml
+++ b/src/tools/genpolicy/Cargo.toml
@@ -40,8 +40,9 @@ anyhow = "1.0.32"
 async-trait = "0.1.68"
 docker_credential = "1.3.1"
 flate2 = { version = "1.0.26", features = ["zlib-ng"], default-features = false }
+libz-ng-sys = "1.1.15" # force newer version that compiles on ppc64le
 oci-distribution = { version = "0.10.0" }
-openssl = { version = "0.10.54" }
+openssl = { version = "0.10.54", features = ["vendored"] }
 serde_ignored = "0.1.7"
 serde_json = "1.0.39"
 serde-transcode = "1.1.1"
@@ -49,6 +50,9 @@ tokio = {version = "1.33.0", features = ["rt-multi-thread"]}
 
 # OCI container specs.
 oci = { path = "../../libs/oci" }
+
+# Kata Agent protocol.
+protocols = { path = "../../libs/protocols", features = ["with-serde"] }
 
 # dm-verity root hash support
 generic-array = "0.14.6"
@@ -62,3 +66,6 @@ tonic = "0.9.2"
 tower = "0.4.13"
 [target.'cfg(target_os = "linux")'.dependencies]
 containerd-client = "0.4.0"
+
+[dev-dependencies]
+regorus = { version = "0.2.6", default-features = false, features = ["arc", "regex"]}

--- a/src/tools/genpolicy/Makefile
+++ b/src/tools/genpolicy/Makefile
@@ -40,7 +40,9 @@ clean:
 vendor:
 	cargo vendor
 
-test:
+# todo: --target $(TRIPLE) doesn't work
+test: $(GENERATED_FILES)
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS --deny warnings)" cargo test --all-targets --all-features
 
 install: $(GENERATED_FILES)
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path .

--- a/src/tools/genpolicy/tests/main.rs
+++ b/src/tools/genpolicy/tests/main.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 Edgeless Systems GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::any;
+use std::fs::{self, File};
+use std::path;
+use std::process::Command;
+use std::str;
+
+use protocols::agent::CreateSandboxRequest;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct TestCase<T> {
+    description: String,
+    allowed: bool,
+    request: T,
+}
+
+/// Run tests from the given directory.
+/// The directory is searched under `src/tools/genpolicy/tests/testdata`, and
+/// it must contain a `resources.yaml` file as well as a `testcases.json` file.
+/// The resources must produce a policy when fed into genpolicy, so there
+/// should be exactly one entry with a PodSpec. The test case file must contain
+/// a JSON list of [TestCase] instances appropriate for `T`.
+fn runtests<T>(test_case_dir: &str)
+where
+    T: DeserializeOwned + Serialize,
+{
+    // Prepare temp dir for running genpolicy.
+
+    let workdir = path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(test_case_dir);
+    fs::create_dir_all(&workdir)
+        .expect("should be able to create directories under CARGO_TARGET_TMPDIR");
+
+    let genpolicy_dir = path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    for base in ["rules.rego", "genpolicy-settings.json"] {
+        fs::copy(genpolicy_dir.join(base), workdir.join(base))
+            .expect("copying files around should not fail");
+    }
+
+    let test_data = genpolicy_dir.join("tests/testdata").join(test_case_dir);
+    fs::copy(test_data.join("pod.yaml"), workdir.join("pod.yaml"))
+        .expect("copying files around should not fail");
+
+    // Run the command and return the generated policy.
+
+    let output = Command::new(env!("CARGO_BIN_EXE_genpolicy"))
+        .current_dir(workdir)
+        .args(["-u", "-r", "-y", "pod.yaml"])
+        .output()
+        .expect("executing the genpolicy command should not fail");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "genpolicy failed: {}",
+        str::from_utf8(output.stderr.as_slice()).expect("genpolicy should return status code 0")
+    );
+    let policy = str::from_utf8(output.stdout.as_slice())
+        .unwrap()
+        .to_string();
+
+    // Set up the policy engine.
+
+    let mut pol = regorus::Engine::new();
+    pol.add_policy("policy.rego".to_string(), policy).unwrap();
+
+    // Run through the test cases and evaluate the canned requests.
+
+    let case_file =
+        File::open(test_data.join("testcases.json")).expect("test case file should open");
+    let test_cases: Vec<TestCase<T>> =
+        serde_json::from_reader(case_file).expect("test case file should parse");
+
+    for test_case in test_cases {
+        println!("\n== case: {} ==\n", test_case.description);
+
+        let v = serde_json::to_value(&test_case.request).unwrap();
+        pol.set_input(v.into());
+        let query = format!(
+            "data.agent_policy.{}",
+            any::type_name::<T>().split("::").last().unwrap()
+        );
+        assert_eq!(test_case.allowed, pol.eval_deny_query(query, true));
+    }
+}
+
+// todo: fix this test
+// CopyFileRequest need to go through is_allowed_copy_file(), so request gets transformed to PolicyCopyFileRequest,
+// and requests get allowed or blocked as expected
+// #[test]
+// fn test_copyfile() {
+//     runtests::<CopyFileRequest>("copyfile");
+// }
+
+#[test]
+fn test_create_sandbox() {
+    runtests::<CreateSandboxRequest>("createsandbox");
+}

--- a/src/tools/genpolicy/tests/testdata/copyfile/pod.yaml
+++ b/src/tools/genpolicy/tests/testdata/copyfile/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+  - name: dummy
+    image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db

--- a/src/tools/genpolicy/tests/testdata/copyfile/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/copyfile/testcases.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "copy initiated by k8s mount",
+    "allowed": true,
+    "request": {
+      "path": "/run/kata-containers/shared/containers/81e5f43bc8599c5661e66f959ac28df5bfb30da23c5d583f2dcc6f9e0c5186dc-ce23cfeb91e75aaa-resolv.conf"
+    }
+  },
+  {
+    "description": "attempt to copy outside of container root",
+    "allowed": false,
+    "request": {
+      "path": "/etc/ssl/cert.pem"
+    }
+  }
+]

--- a/src/tools/genpolicy/tests/testdata/createsandbox/pod.yaml
+++ b/src/tools/genpolicy/tests/testdata/createsandbox/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+  - name: dummy
+    image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db

--- a/src/tools/genpolicy/tests/testdata/createsandbox/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/createsandbox/testcases.json
@@ -1,0 +1,9 @@
+[
+  {
+    "description": "no pidns",
+    "allowed": true,
+    "request": {
+      "sandbox_pidns": false
+    }
+  }
+]

--- a/tools/packaging/static-build/tools/Dockerfile
+++ b/tools/packaging/static-build/tools/Dockerfile
@@ -19,5 +19,6 @@ RUN apk --no-cache add \
         openssl-libs-static \
         make \
         musl-dev \
+        perl \
         protoc && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

The goal of this PR is to add a testing framework for policy. Compared with current ways of testing policy changes, these tests run fast and are self-contained, so no cluster is needed to run the tests. We also expect to improve test coverage by being able to test very specific request inputs that should be allowed or denied by the policy.

Cherry pick from https://github.com/kata-containers/kata-containers/pull/10068

These tests will:
- Take a pod yaml, generate it's policy, and set it in the regorus engine for testing
- Go through a list of requests and test if it's allowed or not against that policy

Same as upstream PR, the initial set of test cases is mostly for illustration and will be expanded incrementally.

We are also modifying the genpolicy makefile such that `make test` runs these tests. And our CI is already wired to run `make test` for genpolicy. So these tests will run automatically on every PR and will be required to pass before merging. See test methodology below.

It is worth noting currently these requests are not going through the agent. So, there's some requests we can't test currently such as CreateContainerRequest, which require state handling from the agent, or CopyFileRequest, which the agent transforms to a PolicyCopyFileRequest. I'll address that by down streaming https://github.com/kata-containers/kata-containers/pull/10613 in a separate PR. This change will make the request go through the agent.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->

required `make test` for genpolicy passing https://github.com/microsoft/kata-containers/actions/runs/13397404971/job/37419817822?pr=309#step:11:445