### PR TITLE
samples: remove failing sample

### DIFF
--- a/src/tools/genpolicy/policy_samples.json
+++ b/src/tools/genpolicy/policy_samples.json
@@ -46,8 +46,7 @@
         ],
         "incomplete_init": [
                 "kubernetes/incomplete-init/cassandra-statefulset.yaml",
-                "kubernetes/incomplete-init/controller.yaml",
-                "kubernetes/incomplete-init/cockroachdb-statefulset.yaml"
+                "kubernetes/incomplete-init/controller.yaml"
         ],
         "silently_ignored": [
                 "webhook/webhook-pod1.yaml",


### PR DESCRIPTION
remove kubernetes/incomplete-init/cockroachdb-statefulset.yaml until we can investigate why it fails with -d option. See https://microsoft.visualstudio.com/OS/_workitems/edit/53281267

###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

Remove failing sample `kubernetes/incomplete-init/cockroachdb-statefulset.yaml` until we can investigate why it fails with `-d` option.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
