### PR TITLE
node-builder: Fix SHIM_USE_DEBUG_CONFIG behavior

### DIFF
--- a/tools/osbuilder/node-builder/azure-linux/README.md
+++ b/tools/osbuilder/node-builder/azure-linux/README.md
@@ -180,7 +180,8 @@ This section describes how to build and deploy in debug mode.
  * `SHIM_USE_DEBUG_CONFIG`: Specify `no` (default) to use the production
    configuration, or `yes` to use the debug configuration (all debug
    logging enabled). In this case you'll want to enable debug logging
-   in containerd as well.
+   in containerd as well. Note that this variable has no effect if
+   `SHIM_REDEPLOY_CONFIG=no`.
 
 In general, you can specify the debug configuration for all the above
 variables by using `BUILD_TYPE=debug` as such:

--- a/tools/osbuilder/node-builder/azure-linux/package_install.sh
+++ b/tools/osbuilder/node-builder/azure-linux/package_install.sh
@@ -46,12 +46,6 @@ if [ "${CONF_PODS}" == "yes" ]; then
 		echo "Skipping installation of SNP shim debug configuration"
 	fi
 
-	if [ "${SHIM_USE_DEBUG_CONFIG}" == "yes" ]; then
-		# We simply override the release config with the debug config,
-		# which is probably fine when debugging.
-		ln -sf src/runtime/config/"${SHIM_DBG_CONFIG_FILE_NAME}" src/runtime/config/"${SHIM_CONFIG_FILE_NAME}" 
-	fi
-
 	echo "Enabling and starting snapshotter service"
 	if [ "${START_SERVICES}" == "yes" ]; then
 		systemctl enable tardev-snapshotter && systemctl daemon-reload && systemctl restart tardev-snapshotter
@@ -70,6 +64,14 @@ cp -a --backup=numbered src/runtime/containerd-shim-kata-v2 "${PREFIX}/${SHIM_BI
 if [ "${SHIM_REDEPLOY_CONFIG}" == "yes" ]; then
 	echo "Installing shim configuration"
 	cp -a --backup=numbered src/runtime/config/"${SHIM_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}/${SHIM_CONFIG_INST_FILE_NAME}"
+
+	if [ "${CONF_PODS}" == "yes" ] && [ "${SHIM_USE_DEBUG_CONFIG}" == "yes" ]; then
+		# We simply override the release config with the debug config,
+		# which is probably fine when debugging. Not symlinking as that
+		# would create cycles the next time this script is called.
+		echo "Overriding shim configuration with SNP debug configuration"
+		cp -a --backup=numbered src/runtime/config/"${SHIM_DBG_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}/${SHIM_CONFIG_INST_FILE_NAME}"
+	fi
 else
 	echo "Skipping installation of shim configuration"
 fi


### PR DESCRIPTION
Using a symlink would create a cycle after calling this script again when copying the final configuration at line 74 so we just use cp instead.

Also, I moved this block to the end of the file to properly override the final config file.

###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Local build
