### PR TITLE
config: Properly set default clh loglevel to 1

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -505,7 +505,9 @@ func (h hypervisor) defaultBridges() uint32 {
 }
 
 func (h hypervisor) defaultHypervisorLoglevel() uint32 {
-	if h.HypervisorLoglevel > maxHypervisorLoglevel {
+	if h.HypervisorLoglevel == 0 {
+		return defaultHypervisorLoglevel
+	} else if h.HypervisorLoglevel > maxHypervisorLoglevel {
 		return maxHypervisorLoglevel
 	}
 

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -178,6 +178,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (testConfig testRuntime
 		GuestHookPath:         defaultGuestHookPath,
 		VhostUserStorePath:    defaultVhostUserStorePath,
 		SharedFS:              sharedFS,
+		HypervisorLoglevel:    defaultHypervisorLoglevel,
 		VirtioFSDaemon:        virtioFSdaemon,
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 		PFlash:                []string{},


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
The documented behavior was that the clh loglevel was set to 1 if unspecified. This was in actuality 0; properly fix the default logic to reflect the documented/expected result.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
Edit the config to enable_debug but don't specify a hypervisor loglevel. Observe with a deployed pod that its sandbox is running with -v (default 1 verbosity level)

![image](https://github.com/user-attachments/assets/0219b2c9-cb52-463f-8734-b35a59fa69a4)
