### PR TITLE
policy: add tests for createContainerRequest

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "anyhow",
  "json-patch",
  "logging",
+ "protocols",
  "regorus",
  "serde",
  "serde_json",

--- a/src/agent/policy/Cargo.toml
+++ b/src/agent/policy/Cargo.toml
@@ -27,12 +27,14 @@ regorus = { version = "0.2.8", default-features = false, features = [
     "arc",
     "regex",
     "std",
+    "base64",
 ] }
 json-patch = "2.0.0"
 sha2 = { version = "0.10.6" }
 sev = { git = "https://github.com/virtee/sev", tag = "v1.2.0", default-features = false, features = [
     "snp",
 ] }
+protocols = { path = "../../libs/protocols" }
 
 # Note: this crate sets the slog 'max_*' features which allows the log level
 # to be modified at runtime.

--- a/src/agent/policy/src/policy.rs
+++ b/src/agent/policy/src/policy.rs
@@ -41,6 +41,17 @@ pub struct PolicyCopyFileRequest {
     pub symlink_src: PathBuf,
 }
 
+/// PolicyCreateContainerRequest is very similar to CreateContainerRequest from src/libs/protocols, except:
+/// - It wraps the base CreateContainerRequest.
+/// - It has an env_map field which is a map of environment variable names to expanded values.
+/// This makes it easier to validate the environment variables inside the rego rules.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct PolicyCreateContainerRequest {
+    pub base: protocols::agent::CreateContainerRequest,
+    // a map of environment variable names to value
+    pub env_map: std::collections::BTreeMap<String, String>,
+}
+
 /// Singleton policy object.
 #[derive(Debug, Default)]
 pub struct AgentPolicy {

--- a/src/agent/src/policy.rs
+++ b/src/agent/src/policy.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use crate::rpc::ttrpc_error;
 use crate::AGENT_POLICY;
-use kata_agent_policy::policy::{AgentPolicy, PolicyCopyFileRequest};
+use kata_agent_policy::policy::{AgentPolicy, PolicyCopyFileRequest, PolicyCreateContainerRequest};
 
 async fn allow_request(policy: &mut AgentPolicy, ep: &str, request: &str) -> ttrpc::Result<()> {
     match policy.allow_request(ep, request).await {
@@ -64,17 +64,6 @@ pub async fn is_allowed_copy_file(req: &protocols::agent::CopyFileRequest) -> tt
     let request = serde_json::to_string(&policy_req).unwrap();
     let mut policy = AGENT_POLICY.lock().await;
     allow_request(&mut policy, "CopyFileRequest", &request).await
-}
-
-/// PolicyCreateContainerRequest is very similar to CreateContainerRequest from src/libs/protocols, except:
-/// - It wraps the base CreateContainerRequest.
-/// - It has an env_map field which is a map of environment variable names to expanded values.
-/// This makes it easier to validate the environment variables inside the rego rules.
-#[derive(Debug, serde::Serialize)]
-struct PolicyCreateContainerRequest {
-    base: protocols::agent::CreateContainerRequest,
-    // a map of environment variable names to value
-    env_map: std::collections::BTreeMap<String, String>,
 }
 
 pub async fn is_allowed_create_container(

--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -416,6 +416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1132,7 @@ dependencies = [
  "anyhow",
  "json-patch",
  "logging",
+ "protocols",
  "regorus",
  "serde",
  "serde_json",
@@ -1879,6 +1886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843c3d97f07e3b5ac0955d53ad0af4c91fe4a4f8525843ece5bf014f27829b73"
 dependencies = [
  "anyhow",
+ "data-encoding",
  "lazy_static",
  "rand",
  "regex",

--- a/src/tools/genpolicy/tests/main.rs
+++ b/src/tools/genpolicy/tests/main.rs
@@ -11,11 +11,15 @@ mod tests {
     use std::path;
     use std::str;
 
-    use protocols::agent::{CreateSandboxRequest, UpdateInterfaceRequest, UpdateRoutesRequest};
+    use protocols::agent::{
+        CreateContainerRequest, CreateSandboxRequest, UpdateInterfaceRequest, UpdateRoutesRequest,
+    };
     use serde::de::DeserializeOwned;
     use serde::{Deserialize, Serialize};
 
-    use kata_agent_policy::policy::{AgentPolicy, PolicyCopyFileRequest};
+    use kata_agent_policy::policy::{
+        AgentPolicy, PolicyCopyFileRequest, PolicyCreateContainerRequest,
+    };
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     struct TestCase<T> {
@@ -129,6 +133,7 @@ mod tests {
     fn map_request(request: &str) -> &str {
         match request {
             "PolicyCopyFileRequest" => "CopyFileRequest",
+            "PolicyCreateContainerRequest" => "CreateContainerRequest",
             _ => request,
         }
     }
@@ -151,5 +156,14 @@ mod tests {
     #[tokio::test]
     async fn test_update_interface() {
         runtests::<UpdateInterfaceRequest>("updateinterface").await;
+    }
+    #[tokio::test]
+    async fn test_legacy_basic_create_container() {
+        runtests::<CreateContainerRequest>("createContainer/legacy").await;
+    }
+
+    #[tokio::test]
+    async fn test_basic_create_container() {
+        runtests::<PolicyCreateContainerRequest>("createContainer/basic").await;
     }
 }

--- a/src/tools/genpolicy/tests/testdata/createContainer/basic/pod.yaml
+++ b/src/tools/genpolicy/tests/testdata/createContainer/basic/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+spec:
+  runtimeClassName: kata-cc
+  containers:
+    - name: first-test-container
+      image: "quay.io/prometheus/busybox:latest"
+      env:
+        - name: CONTAINER_NAME
+          value: first-test-container
+      command:
+        - sleep
+        - "3600"

--- a/src/tools/genpolicy/tests/testdata/createContainer/basic/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/createContainer/basic/testcases.json
@@ -1,0 +1,289 @@
+[
+  {
+    "description": "basic request for pause container",
+    "allowed": true,
+    "request": {
+      "base": {
+        "OCI": {
+          "Annotations": {
+            "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/4878266238663ca723dc5ecbd8b2d06a56c2d5e562eeb77b492046a267c50951",
+            "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+            "io.kubernetes.cri.container-type": "sandbox",
+            "io.kubernetes.cri.sandbox-cpu-period": "100000",
+            "io.kubernetes.cri.sandbox-cpu-quota": "0",
+            "io.kubernetes.cri.sandbox-cpu-shares": "2",
+            "io.kubernetes.cri.sandbox-id": "4878266238663ca723dc5ecbd8b2d06a56c2d5e562eeb77b492046a267c50951",
+            "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_busybox_eb1495ed-331a-44ff-ad6d-fce1a69280cd",
+            "io.kubernetes.cri.sandbox-memory": "0",
+            "io.kubernetes.cri.sandbox-name": "busybox",
+            "io.kubernetes.cri.sandbox-namespace": "default",
+            "io.kubernetes.cri.sandbox-uid": "eb1495ed-331a-44ff-ad6d-fce1a69280cd",
+            "nerdctl/network-namespace": "/var/run/netns/cni-27ff7b1c-fc08-da24-6925-706999f65227"
+          },
+          "Hooks": null,
+          "Hostname": "busybox",
+          "Linux": {
+            "CgroupsPath": "/kubepods/besteffort/podeb1495ed-331a-44ff-ad6d-fce1a69280cd/4878266238663ca723dc5ecbd8b2d06a56c2d5e562eeb77b492046a267c50951",
+            "Devices": [],
+            "GIDMappings": [],
+            "IntelRdt": null,
+            "MaskedPaths": [
+              "/proc/acpi",
+              "/proc/asound",
+              "/proc/kcore",
+              "/proc/keys",
+              "/proc/latency_stats",
+              "/proc/timer_list",
+              "/proc/timer_stats",
+              "/proc/sched_debug",
+              "/sys/firmware",
+              "/proc/scsi"
+            ],
+            "MountLabel": "",
+            "Namespaces": [
+              {
+                "Path": "",
+                "Type": "ipc"
+              },
+              {
+                "Path": "",
+                "Type": "uts"
+              },
+              {
+                "Path": "",
+                "Type": "mount"
+              }
+            ],
+            "ReadonlyPaths": [
+              "/proc/bus",
+              "/proc/fs",
+              "/proc/irq",
+              "/proc/sys",
+              "/proc/sysrq-trigger"
+            ],
+            "Resources": {
+              "BlockIO": null,
+              "CPU": {
+                "Cpus": "",
+                "Mems": "",
+                "Period": 0,
+                "Quota": 0,
+                "RealtimePeriod": 0,
+                "RealtimeRuntime": 0,
+                "Shares": 2
+              },
+              "Devices": [],
+              "HugepageLimits": [],
+              "Memory": null,
+              "Network": null,
+              "Pids": null
+            },
+            "RootfsPropagation": "",
+            "Seccomp": null,
+            "Sysctl": {},
+            "UIDMappings": []
+          },
+          "Mounts": [
+            {
+              "destination": "/proc",
+              "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+              ],
+              "source": "proc",
+              "type_": "proc"
+            },
+            {
+              "destination": "/dev",
+              "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+              ],
+              "source": "tmpfs",
+              "type_": "tmpfs"
+            },
+            {
+              "destination": "/dev/pts",
+              "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
+              ],
+              "source": "devpts",
+              "type_": "devpts"
+            },
+            {
+              "destination": "/dev/mqueue",
+              "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+              ],
+              "source": "mqueue",
+              "type_": "mqueue"
+            },
+            {
+              "destination": "/sys",
+              "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "ro"
+              ],
+              "source": "sysfs",
+              "type_": "sysfs"
+            },
+            {
+              "destination": "/dev/shm",
+              "options": [
+                "rbind"
+              ],
+              "source": "/run/kata-containers/sandbox/shm",
+              "type_": "bind"
+            },
+            {
+              "destination": "/etc/resolv.conf",
+              "options": [
+                "rbind",
+                "ro",
+                "nosuid",
+                "nodev",
+                "noexec"
+              ],
+              "source": "/run/kata-containers/shared/containers/4878266238663ca723dc5ecbd8b2d06a56c2d5e562eeb77b492046a267c50951-a03e767168d4d11d-resolv.conf",
+              "type_": "bind"
+            }
+          ],
+          "Process": {
+            "ApparmorProfile": "",
+            "Args": [
+              "/pause"
+            ],
+            "Capabilities": {
+              "Ambient": [],
+              "Bounding": [
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_FSETID",
+                "CAP_FOWNER",
+                "CAP_MKNOD",
+                "CAP_NET_RAW",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETFCAP",
+                "CAP_SETPCAP",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_SYS_CHROOT",
+                "CAP_KILL",
+                "CAP_AUDIT_WRITE"
+              ],
+              "Effective": [
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_FSETID",
+                "CAP_FOWNER",
+                "CAP_MKNOD",
+                "CAP_NET_RAW",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETFCAP",
+                "CAP_SETPCAP",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_SYS_CHROOT",
+                "CAP_KILL",
+                "CAP_AUDIT_WRITE"
+              ],
+              "Inheritable": [],
+              "Permitted": [
+                "CAP_CHOWN",
+                "CAP_DAC_OVERRIDE",
+                "CAP_FSETID",
+                "CAP_FOWNER",
+                "CAP_MKNOD",
+                "CAP_NET_RAW",
+                "CAP_SETGID",
+                "CAP_SETUID",
+                "CAP_SETFCAP",
+                "CAP_SETPCAP",
+                "CAP_NET_BIND_SERVICE",
+                "CAP_SYS_CHROOT",
+                "CAP_KILL",
+                "CAP_AUDIT_WRITE"
+              ]
+            },
+            "ConsoleSize": null,
+            "Cwd": "/",
+            "Env": [
+              "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ],
+            "NoNewPrivileges": true,
+            "OOMScoreAdj": -998,
+            "Rlimits": [],
+            "SelinuxLabel": "",
+            "Terminal": false,
+            "User": {
+              "AdditionalGids": [
+                65535
+              ],
+              "GID": 65535,
+              "UID": 65535,
+              "Username": ""
+            }
+          },
+          "Root": {
+            "Path": "/run/kata-containers/shared/containers/4878266238663ca723dc5ecbd8b2d06a56c2d5e562eeb77b492046a267c50951",
+            "Readonly": true
+          },
+          "Solaris": null,
+          "Version": "1.1.0-rc.1",
+          "Windows": null
+        },
+        "container_id": "4878266238663ca723dc5ecbd8b2d06a56c2d5e562eeb77b492046a267c50951",
+        "devices": [],
+        "exec_id": "4878266238663ca723dc5ecbd8b2d06a56c2d5e562eeb77b492046a267c50951",
+        "sandbox_pidns": false,
+        "shared_mounts": [],
+        "storages": [
+          {
+            "driver": "blk",
+            "driver_options": [],
+            "fs_group": null,
+            "fstype": "tar",
+            "mount_point": "/run/kata-containers/sandbox/layers/5a5aad80055ff20012a50dc25f8df7a29924474324d65f7d5306ee8ee27ff71d",
+            "options": [
+              "ro",
+              "io.katacontainers.fs-opt.block_device=file",
+              "io.katacontainers.fs-opt.is-layer",
+              "io.katacontainers.fs-opt.root-hash=817250f1a3e336da76f5bd3fa784e1b26d959b9c131876815ba2604048b70c18"
+            ],
+            "source": "0001:00:01.0"
+          },
+          {
+            "driver": "overlayfs",
+            "driver_options": [],
+            "fs_group": null,
+            "fstype": "fuse3.kata-overlay",
+            "mount_point": "/run/kata-containers/shared/containers/4878266238663ca723dc5ecbd8b2d06a56c2d5e562eeb77b492046a267c50951",
+            "options": [
+              "io.katacontainers.fs-opt.layer-src-prefix=/var/lib/containerd/io.containerd.snapshotter.v1.tardev/layers",
+              "io.katacontainers.fs-opt.layer=NWE1YWFkODAwNTVmZjIwMDEyYTUwZGMyNWY4ZGY3YTI5OTI0NDc0MzI0ZDY1ZjdkNTMwNmVlOGVlMjdmZjcxZCx0YXIscm8saW8ua2F0YWNvbnRhaW5lcnMuZnMtb3B0LmJsb2NrX2RldmljZT1maWxlLGlvLmthdGFjb250YWluZXJzLmZzLW9wdC5pcy1sYXllcixpby5rYXRhY29udGFpbmVycy5mcy1vcHQucm9vdC1oYXNoPTgxNzI1MGYxYTNlMzM2ZGE3NmY1YmQzZmE3ODRlMWIyNmQ5NTliOWMxMzE4NzY4MTViYTI2MDQwNDhiNzBjMTg=",
+              "io.katacontainers.fs-opt.overlay-rw",
+              "lowerdir=5a5aad80055ff20012a50dc25f8df7a29924474324d65f7d5306ee8ee27ff71d"
+            ],
+            "source": "none"
+          }
+        ],
+        "string_user": null
+      },
+      "env_map": {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      }
+    }
+  }
+]

--- a/src/tools/genpolicy/tests/testdata/createContainer/legacy/pod.yaml
+++ b/src/tools/genpolicy/tests/testdata/createContainer/legacy/pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+spec:
+  runtimeClassName: kata-cc
+  containers:
+    - name: first-test-container
+      image: "quay.io/prometheus/busybox:latest"
+      env:
+        - name: CONTAINER_NAME
+          value: first-test-container
+      command:
+        - sleep
+        - "3600"

--- a/src/tools/genpolicy/tests/testdata/createContainer/legacy/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/createContainer/legacy/testcases.json
@@ -1,0 +1,284 @@
+[
+  {
+    "description": "legacy request for pause container",
+    "allowed": true,
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/4bbf2a6b6b510a279cd17b2bfc8b64d39c11ebb55f855ba78a0034c4fe394246",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.kubernetes.cri.sandbox-cpu-period": "100000",
+          "io.kubernetes.cri.sandbox-cpu-quota": "0",
+          "io.kubernetes.cri.sandbox-cpu-shares": "2",
+          "io.kubernetes.cri.sandbox-id": "4bbf2a6b6b510a279cd17b2bfc8b64d39c11ebb55f855ba78a0034c4fe394246",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_busybox_3a371de8-72b3-4bf8-9b5d-9dbb91e59fe3",
+          "io.kubernetes.cri.sandbox-memory": "0",
+          "io.kubernetes.cri.sandbox-name": "busybox",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "3a371de8-72b3-4bf8-9b5d-9dbb91e59fe3",
+          "nerdctl/network-namespace": "/var/run/netns/cni-04edf9ab-d968-fa0f-1c47-2707af676350"
+        },
+        "Hooks": null,
+        "Hostname": "busybox",
+        "Linux": {
+          "CgroupsPath": "/kubepods/besteffort/pod3a371de8-72b3-4bf8-9b5d-9dbb91e59fe3/4bbf2a6b6b510a279cd17b2bfc8b64d39c11ebb55f855ba78a0034c4fe394246",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 0,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": null,
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "ro",
+              "nosuid",
+              "nodev",
+              "noexec"
+            ],
+            "source": "/run/kata-containers/shared/containers/4bbf2a6b6b510a279cd17b2bfc8b64d39c11ebb55f855ba78a0034c4fe394246-7523f46cbb9b887f-resolv.conf",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "",
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          ],
+          "NoNewPrivileges": true,
+          "OOMScoreAdj": -998,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              65535
+            ],
+            "GID": 65535,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/shared/containers/4bbf2a6b6b510a279cd17b2bfc8b64d39c11ebb55f855ba78a0034c4fe394246",
+          "Readonly": true
+        },
+        "Solaris": null,
+        "Version": "1.1.0-rc.1",
+        "Windows": null
+      },
+      "container_id": "4bbf2a6b6b510a279cd17b2bfc8b64d39c11ebb55f855ba78a0034c4fe394246",
+      "devices": [],
+      "exec_id": "4bbf2a6b6b510a279cd17b2bfc8b64d39c11ebb55f855ba78a0034c4fe394246",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "storages": [
+        {
+          "driver": "blk",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "tar",
+          "mount_point": "/run/kata-containers/sandbox/layers/5a5aad80055ff20012a50dc25f8df7a29924474324d65f7d5306ee8ee27ff71d",
+          "options": [
+            "ro",
+            "io.katacontainers.fs-opt.block_device=file",
+            "io.katacontainers.fs-opt.is-layer",
+            "io.katacontainers.fs-opt.root-hash=817250f1a3e336da76f5bd3fa784e1b26d959b9c131876815ba2604048b70c18"
+          ],
+          "source": "0001:00:01.0"
+        },
+        {
+          "driver": "overlayfs",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "fuse3.kata-overlay",
+          "mount_point": "/run/kata-containers/shared/containers/4bbf2a6b6b510a279cd17b2bfc8b64d39c11ebb55f855ba78a0034c4fe394246",
+          "options": [
+            "io.katacontainers.fs-opt.layer-src-prefix=/var/lib/containerd/io.containerd.snapshotter.v1.tardev/layers",
+            "io.katacontainers.fs-opt.layer=NWE1YWFkODAwNTVmZjIwMDEyYTUwZGMyNWY4ZGY3YTI5OTI0NDc0MzI0ZDY1ZjdkNTMwNmVlOGVlMjdmZjcxZCx0YXIscm8saW8ua2F0YWNvbnRhaW5lcnMuZnMtb3B0LmJsb2NrX2RldmljZT1maWxlLGlvLmthdGFjb250YWluZXJzLmZzLW9wdC5pcy1sYXllcixpby5rYXRhY29udGFpbmVycy5mcy1vcHQucm9vdC1oYXNoPTgxNzI1MGYxYTNlMzM2ZGE3NmY1YmQzZmE3ODRlMWIyNmQ5NTliOWMxMzE4NzY4MTViYTI2MDQwNDhiNzBjMTg=",
+            "io.katacontainers.fs-opt.overlay-rw",
+            "lowerdir=5a5aad80055ff20012a50dc25f8df7a29924474324d65f7d5306ee8ee27ff71d"
+          ],
+          "source": "none"
+        }
+      ],
+      "string_user": null
+    }
+  }
+]


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
Add test cases for basic and legacy requests to create pause container. These 2 tests provide a reasonable amount of coverage for CreateContainerRequest validation

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
