### PR TITLE
genpolicy: add support for BUILD_TYPE=debug

### DIFF
--- a/src/tools/genpolicy/Makefile
+++ b/src/tools/genpolicy/Makefile
@@ -28,7 +28,7 @@ $(GENERATED_FILES): %: %.in
 default: build
 
 build: $(GENERATED_FILES)
-	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release)
 
 static-checks-build:
 	@echo "INFO: static-checks-build do nothing.."


### PR DESCRIPTION
Use "cargo build --release" when BUILD_TYPE was not specified, or when BUILD_TYPE=release. The default "cargo build" behavior is to build in debug mode.
