### PR TITLE
Remove tarindex from snapshotter and solar dependencies

### DIFF
--- a/src/tardev-snapshotter/Cargo.lock
+++ b/src/tardev-snapshotter/Cargo.lock
@@ -375,18 +375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.2.16",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,17 +1287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "tar"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tardev-snapshotter"
 version = "0.1.0"
 dependencies = [
@@ -1330,29 +1307,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tarindex",
  "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",
  "uuid",
  "verity",
- "zerocopy",
-]
-
-[[package]]
-name = "tarfs-defs"
-version = "0.1.0"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
-name = "tarindex"
-version = "0.1.0"
-dependencies = [
- "tar",
- "tarfs-defs",
  "zerocopy",
 ]
 
@@ -1882,15 +1842,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.8.0",
-]
-
-[[package]]
-name = "xattr"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/src/tardev-snapshotter/Cargo.toml
+++ b/src/tardev-snapshotter/Cargo.toml
@@ -13,7 +13,6 @@ tokio = {version = "1.26", features = ["full"]}
 tokio-stream = "0.1.8"
 containerd-snapshots = "0.3.0"
 sha2 = "0.10.6"
-tarindex = { path = "./tarindex" }
 verity = { path = "./verity" }
 log = "0.4.17"
 env_logger = "0.10.0"

--- a/src/tools/sign-oci-layer-root-hashes/Cargo.lock
+++ b/src/tools/sign-oci-layer-root-hashes/Cargo.lock
@@ -444,18 +444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
-name = "filetime"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,15 +1301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,7 +1575,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "tarindex",
  "tempfile",
  "tokio",
  "tonic",
@@ -1663,33 +1641,6 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
-name = "tarfs-defs"
-version = "0.1.0"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
-name = "tarindex"
-version = "0.1.0"
-dependencies = [
- "tar",
- "tarfs-defs",
- "zerocopy",
 ]
 
 [[package]]
@@ -2306,17 +2257,6 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "xattr"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
-dependencies = [
- "libc",
- "linux-raw-sys",
- "rustix",
 ]
 
 [[package]]

--- a/src/tools/sign-oci-layer-root-hashes/Cargo.toml
+++ b/src/tools/sign-oci-layer-root-hashes/Cargo.toml
@@ -56,7 +56,6 @@ oci = { path = "../../libs/oci" }
 # dm-verity root hash support
 generic-array = "0.14.6"
 sha2 = "0.10.6"
-tarindex = { path = "../../tardev-snapshotter/tarindex" }
 tempfile = "3.5.0"
 zerocopy = "0.6.1"
 fs2 = "0.4.3"


### PR DESCRIPTION
###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
- Remove tarindex dependencies from snapshotter and solar cargo.toml files
- Update `registry_containerd.rs` to use erofs instead of tarindex

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- Tested locally by creating and starting a container using the tardev-snapshotter
