### PR TITLE
node-builder: Build and install debug configuration for pod sandboxing

### DIFF
--- a/tools/osbuilder/node-builder/azure-linux/clean.sh
+++ b/tools/osbuilder/node-builder/azure-linux/clean.sh
@@ -18,6 +18,11 @@ source "${common_file}"
 
 pushd "${repo_dir}"
 
+echo "Clean debug shim config"
+pushd src/runtime/config/
+rm -f "${SHIM_DBG_CONFIG_FILE_NAME}"
+popd
+
 echo "Clean runtime build"
 pushd src/runtime/
 make clean SKIP_GO_VERSION_CHECK=1
@@ -39,11 +44,6 @@ echo "Clean IGVM tool installation"
 
 
 if [ "${CONF_PODS}" == "yes" ]; then
-
-	echo "Clean SNP debug shim config"
-	pushd src/runtime/config/
-	rm -f "${SHIM_DBG_CONFIG_FILE_NAME}"
-	popd
 
 	echo "Clean tardev-snapshotter tarfs driver build"
 	pushd src/tarfs

--- a/tools/osbuilder/node-builder/azure-linux/common.sh
+++ b/tools/osbuilder/node-builder/azure-linux/common.sh
@@ -39,6 +39,8 @@ else
 	SHIM_CONFIG_PATH="${INSTALL_PATH_PREFIX}/share/defaults/kata-containers"
 	SHIM_CONFIG_FILE_NAME="configuration-clh.toml"
 	SHIM_CONFIG_INST_FILE_NAME="configuration.toml"
+	SHIM_DBG_CONFIG_FILE_NAME="configuration-clh-debug.toml"
+	SHIM_DBG_CONFIG_INST_FILE_NAME="${SHIM_DBG_CONFIG_FILE_NAME}"
 	DEBUGGING_BINARIES_PATH="${INSTALL_PATH_PREFIX}/local/bin"
 	SHIM_BINARIES_PATH="${INSTALL_PATH_PREFIX}/local/bin"
 	SHIM_BINARY_NAME="containerd-shim-kata-v2"

--- a/tools/osbuilder/node-builder/azure-linux/package_build.sh
+++ b/tools/osbuilder/node-builder/azure-linux/package_build.sh
@@ -77,13 +77,14 @@ fi
 popd
 
 pushd src/runtime/config/
-if [ "${CONF_PODS}" == "yes" ]; then
+echo "Creating shim debug configuration"
+cp "${SHIM_CONFIG_FILE_NAME}" "${SHIM_DBG_CONFIG_FILE_NAME}"
+sed -i '/^#enable_debug =/s|^#||g' "${SHIM_DBG_CONFIG_FILE_NAME}"
+sed -i '/^#debug_console_enabled =/s|^#||g' "${SHIM_DBG_CONFIG_FILE_NAME}"
 
-	echo "Creating SNP shim debug configuration"
-	cp "${SHIM_CONFIG_FILE_NAME}" "${SHIM_DBG_CONFIG_FILE_NAME}"
+if [ "${CONF_PODS}" == "yes" ]; then
+	echo "Adding debug igvm to SNP shim debug configuration"
 	sed -i "s|${IGVM_FILE_NAME}|${IGVM_DBG_FILE_NAME}|g" "${SHIM_DBG_CONFIG_FILE_NAME}"
-	sed -i '/^#enable_debug =/s|^#||g' "${SHIM_DBG_CONFIG_FILE_NAME}"
-	sed -i '/^#debug_console_enabled =/s|^#||g' "${SHIM_DBG_CONFIG_FILE_NAME}"
 fi
 popd
 

--- a/tools/osbuilder/node-builder/azure-linux/package_install.sh
+++ b/tools/osbuilder/node-builder/azure-linux/package_install.sh
@@ -39,13 +39,6 @@ if [ "${CONF_PODS}" == "yes" ]; then
 	mkdir -p ${PREFIX}/usr/lib/systemd/system/
 	cp -a --backup=numbered src/tardev-snapshotter/tardev-snapshotter.service ${PREFIX}/usr/lib/systemd/system/
 
-	if [ "${SHIM_REDEPLOY_CONFIG}" == "yes" ]; then
-		echo "Installing SNP shim debug configuration"
-		cp -a --backup=numbered src/runtime/config/"${SHIM_DBG_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}"/"${SHIM_DBG_CONFIG_INST_FILE_NAME}"
-	else
-		echo "Skipping installation of SNP shim debug configuration"
-	fi
-
 	echo "Enabling and starting snapshotter service"
 	if [ "${START_SERVICES}" == "yes" ]; then
 		systemctl enable tardev-snapshotter && systemctl daemon-reload && systemctl restart tardev-snapshotter
@@ -64,12 +57,13 @@ cp -a --backup=numbered src/runtime/containerd-shim-kata-v2 "${PREFIX}/${SHIM_BI
 if [ "${SHIM_REDEPLOY_CONFIG}" == "yes" ]; then
 	echo "Installing shim configuration"
 	cp -a --backup=numbered src/runtime/config/"${SHIM_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}/${SHIM_CONFIG_INST_FILE_NAME}"
+	cp -a --backup=numbered src/runtime/config/"${SHIM_DBG_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}/${SHIM_DBG_CONFIG_INST_FILE_NAME}"
 
-	if [ "${CONF_PODS}" == "yes" ] && [ "${SHIM_USE_DEBUG_CONFIG}" == "yes" ]; then
+	if "${SHIM_USE_DEBUG_CONFIG}" == "yes"; then
 		# We simply override the release config with the debug config,
 		# which is probably fine when debugging. Not symlinking as that
 		# would create cycles the next time this script is called.
-		echo "Overriding shim configuration with SNP debug configuration"
+		echo "Overriding shim configuration with debug configuration"
 		cp -a --backup=numbered src/runtime/config/"${SHIM_DBG_CONFIG_FILE_NAME}" "${PREFIX}/${SHIM_CONFIG_PATH}/${SHIM_CONFIG_INST_FILE_NAME}"
 	fi
 else


### PR DESCRIPTION
For ease of debugging, install a configuration-clh-debug.toml for pod sandboxing as we do in Conf pods.

###### Merge Checklist  <!-- REQUIRED -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
  - [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [ ] Aware about the PR to be merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] The `upstream/missing` label (or `upstream/not-needed`) has been set on the PR. 

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
