### PR TITLE
Extend solar to attach signatures to image manifest

### DIFF
--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "common"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -1,0 +1,31 @@
+// Common constants for use by both tardev-snapshotter and sign-oci-layer-root-hashes modules.
+
+/// OCI label for dm-verity root hash.
+pub const ROOT_HASH_LABEL: &str = "io.katacontainers.dm-verity.root-hash";
+
+/// OCI label for dm-verity root hash signature.
+pub const ROOT_HASH_SIG_LABEL: &str = "io.katacontainers.dm-verity.root-hash-sig";
+
+/// OCI label for image reference name.
+pub const IMAGE_NAME_LABEL: &str = "image.ref.name";
+
+/// OCI label for image layer digest.
+pub const IMAGE_LAYER_DIGEST_LABEL: &str = "image.layer.digest";
+
+/// OCI label for image layer root hash.
+pub const IMAGE_LAYER_ROOT_HASH_LABEL: &str = "image.layer.root_hash";
+
+/// OCI label for image layer signature.
+pub const IMAGE_LAYER_SIGNATURE_LABEL: &str = "image.layer.signature";
+
+/// Artifact type for signature manifests.
+pub const SIGNATURE_ARTIFACT_TYPE: &str = "application/vnd.oci.mt.pkcs7";
+
+/// Media type for signature blobs.
+pub const SIGNATURE_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.erofs.sig";
+
+/// Default file name for signature blobs.
+pub const SIGNATURE_FILE_NAME: &str = "signature.blob.name";
+
+/// Digest for the canonical empty config blob ({}).
+pub const EMPTY_CONFIG_DIGEST: &str = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a";

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -1,0 +1,2 @@
+// Export constants module
+pub mod constants;

--- a/src/tools/sign-oci-layer-root-hashes/Cargo.lock
+++ b/src/tools/sign-oci-layer-root-hashes/Cargo.lock
@@ -103,7 +103,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -123,9 +123,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -134,7 +134,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -149,8 +149,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -183,6 +183,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -219,9 +225,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -237,9 +243,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -247,7 +253,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -269,7 +275,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -278,10 +284,10 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -304,6 +310,26 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "containerd-client"
@@ -364,6 +390,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,15 +482,6 @@ name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "env_logger"
@@ -556,7 +639,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -611,6 +694,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,7 +722,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.2.3",
  "slab",
  "tokio",
@@ -652,6 +747,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -695,6 +796,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-auth"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,7 +822,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -743,8 +878,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -757,12 +892,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -770,15 +924,37 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.5.2",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -803,6 +979,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1043,18 +1225,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "oci-distribution"
-version = "0.10.0"
+name = "oci-client"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a635cabf7a6eb4e5f13e9e82bd9503b7c2461bf277132e38638a935ebd684b4"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
 dependencies = [
  "bytes",
  "chrono",
  "futures-util",
- "http",
+ "http 1.3.1",
  "http-auth",
  "jwt",
  "lazy_static",
+ "oci-spec",
  "olpc-cjson",
  "regex",
  "reqwest",
@@ -1065,6 +1248,23 @@ dependencies = [
  "tokio",
  "tracing",
  "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e9beda9d92fac7bf4904c34c83340ef1024159faee67179a04e0277523da33"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror",
 ]
 
 [[package]]
@@ -1107,7 +1307,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1161,7 +1361,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1199,10 +1399,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.78"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1224,7 +1446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "lazy_static",
  "log",
@@ -1331,20 +1553,20 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -1357,8 +1579,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -1392,11 +1613,20 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.21.7",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -1469,7 +1699,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1537,6 +1767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
 name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1789,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.7",
+ "chrono",
  "clap",
  "containerd-client",
  "docker_credential",
@@ -1566,7 +1803,7 @@ dependencies = [
  "k8s-cri",
  "log",
  "oci",
- "oci-distribution",
+ "oci-client",
  "openssl",
  "rand",
  "serde",
@@ -1589,6 +1826,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1623,25 +1885,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
+name = "sync_wrapper"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -1666,22 +1913,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1734,7 +1981,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1785,9 +2032,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -1878,7 +2125,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1931,6 +2178,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -1997,7 +2250,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -2031,7 +2284,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2116,6 +2369,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-sys"
@@ -2251,9 +2510,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -2286,5 +2545,11 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.101",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/src/tools/sign-oci-layer-root-hashes/Cargo.lock
+++ b/src/tools/sign-oci-layer-root-hashes/Cargo.lock
@@ -312,6 +312,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "common"
+version = "0.1.0"
+
+[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1795,7 @@ dependencies = [
  "base64 0.21.7",
  "chrono",
  "clap",
+ "common",
  "containerd-client",
  "docker_credential",
  "env_logger",

--- a/src/tools/sign-oci-layer-root-hashes/Cargo.toml
+++ b/src/tools/sign-oci-layer-root-hashes/Cargo.toml
@@ -53,6 +53,9 @@ erofs-common = { path = "../../tardev-snapshotter/erofs-common" }
 # OCI container specs.
 oci = { path = "../../libs/oci" }
 
+# Common constants
+common = { path = "../../common" }
+
 # dm-verity root hash support
 generic-array = "0.14.6"
 sha2 = "0.10.6"

--- a/src/tools/sign-oci-layer-root-hashes/Cargo.toml
+++ b/src/tools/sign-oci-layer-root-hashes/Cargo.toml
@@ -40,7 +40,7 @@ anyhow = "1.0.32"
 async-trait = "0.1.68"
 docker_credential = "1.3.1"
 flate2 = { version = "1.0.26", features = ["zlib-ng"], default-features = false }
-oci-distribution = { version = "0.10.0" }
+oci-client = "0.15.0"
 openssl = { version = "0.10.54" }
 serde_ignored = "0.1.7"
 serde_json = "1.0.39"
@@ -62,6 +62,7 @@ fs2 = "0.4.3"
 k8s-cri = "0.7.0"
 tonic = "0.9.2"
 tower = "0.4.13"
+chrono = "0.4.41"
 [target.'cfg(target_os = "linux")'.dependencies]
 containerd-client = "0.4.0"
 rand = "0.8.5"

--- a/src/tools/sign-oci-layer-root-hashes/src/main.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/main.rs
@@ -89,7 +89,6 @@ async fn main() -> Result<(), Error> {
         utils::Commands::AttachSignaturesToImageManifest {
             ref output_image_group
         } => {
-            println!("image_tags: {}", image_tags.join("\n"));
             let output_image_tags = match output_image_group {
                 Some(ref output_image_group) => {
                     utils::get_image_tags(&output_image_group.images, &output_image_group.image)
@@ -97,10 +96,10 @@ async fn main() -> Result<(), Error> {
                 }
                 None => image_tags.clone(),
             };
-            println!("output_image_tags: {}", output_image_tags.join("\n"));
             let images = sign::get_root_hash_signatures(&config, &output_image_tags)
                 .await
                 .context("Failed to get root hashes")?;
+
             attach_signatures_to_image_manifests(images)
                 .await
                 .context("Failed to attach signatures to image manifests")?;
@@ -158,8 +157,6 @@ fn output_signature_manifest(
 async fn attach_signatures_to_image_manifests(
     images: Vec<ImageInfo>,
 ) -> Result<(), Error> {
-    use futures::future;
-
     future::try_join_all(
         images
             .iter()

--- a/src/tools/sign-oci-layer-root-hashes/src/main.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Error> {
             };
             sign::attach_root_hash_signatures(&config, &output_image_tags)
                 .await
-                .context("Failed to attach root hashe sigantures")?;
+                .context("Failed to attach root hash sigantures")?;
         }
 
     }

--- a/src/tools/sign-oci-layer-root-hashes/src/main.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/main.rs
@@ -96,13 +96,9 @@ async fn main() -> Result<(), Error> {
                 }
                 None => image_tags.clone(),
             };
-            let images = sign::get_root_hash_signatures(&config, &output_image_tags)
+            sign::attach_root_hash_signatures(&config, &output_image_tags)
                 .await
-                .context("Failed to get root hashes")?;
-
-            attach_signatures_to_image_manifests(images)
-                .await
-                .context("Failed to attach signatures to image manifests")?;
+                .context("Failed to attach root hashe sigantures")?;
         }
 
     }
@@ -150,19 +146,5 @@ fn output_signature_manifest(
         }
     }
 
-    Ok(())
-}
-
-/// Attach signatures to the image manifest as referrers without repushing the manifest
-async fn attach_signatures_to_image_manifests(
-    images: Vec<ImageInfo>,
-) -> Result<(), Error> {
-    future::try_join_all(
-        images
-            .iter()
-            .map(|image| sign::attach_signatures(image))
-    )
-    .await
-    .context("Failed to attach signatures to image manifests")?;
     Ok(())
 }

--- a/src/tools/sign-oci-layer-root-hashes/src/main.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Error> {
             };
             sign::attach_root_hash_signatures(&config, &output_image_tags)
                 .await
-                .context("Failed to attach root hash sigantures")?;
+                .context("Failed to attach root hash signatures")?;
         }
 
     }

--- a/src/tools/sign-oci-layer-root-hashes/src/registry.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/registry.rs
@@ -14,10 +14,10 @@ use docker_credential::{CredentialRetrievalError, DockerCredential};
 use fs2::FileExt;
 use log::warn;
 use log::{debug, info, LevelFilter};
-use oci_distribution::client::{linux_amd64_resolver, ClientConfig};
-use oci_distribution::manifest::{OciImageManifest, OciManifest};
-use oci_distribution::RegistryOperation;
-use oci_distribution::{manifest, secrets::RegistryAuth, Client, Reference};
+use oci_client::client::{linux_amd64_resolver, ClientConfig};
+use oci_client::manifest::{OciImageManifest, OciManifest};
+use oci_client::RegistryOperation;
+use oci_client::{manifest, secrets::RegistryAuth, Client, Reference};
 use serde::{Deserialize, Serialize};
 use sha2::{digest::typenum::Unsigned, digest::OutputSizeUser, Sha256};
 use std::fs::OpenOptions;
@@ -73,7 +73,7 @@ impl Container {
         let reference: Reference = image.parse()?;
         let auth = build_auth(&reference);
 
-        let mut client = Client::new(ClientConfig {
+        let client = Client::new(ClientConfig {
             platform_resolver: Some(Box::new(linux_amd64_resolver)),
             ..Default::default()
         });
@@ -130,7 +130,7 @@ impl Container {
                     image_layers,
                 })
             }
-            Err(oci_distribution::errors::OciDistributionError::AuthenticationFailure(message)) => {
+            Err(oci_client::errors::OciDistributionError::AuthenticationFailure(message)) => {
                 panic!("Container image registry authentication failure ({}). Are docker credentials set-up for current user?", &message);
             }
             Err(e) => {
@@ -452,7 +452,7 @@ pub async fn get_container(config: &Config, image: &str) -> Result<Container> {
     Container::new(config.use_cache, image).await
 }
 
-fn build_auth(reference: &Reference) -> RegistryAuth {
+pub fn build_auth(reference: &Reference) -> RegistryAuth {
     debug!("build_auth: {:?}", reference);
 
     let server = reference

--- a/src/tools/sign-oci-layer-root-hashes/src/registry_containerd.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/registry_containerd.rs
@@ -12,7 +12,7 @@ use containerd_client::{services::v1::GetImageRequest, with_namespace};
 use docker_credential::{CredentialRetrievalError, DockerCredential};
 use k8s_cri::v1::{image_service_client::ImageServiceClient, AuthConfig};
 use log::{debug, info, warn};
-use oci_distribution::{manifest, Reference};
+use oci_client::{manifest, Reference};
 use std::{collections::HashMap, convert::TryFrom, io::Write, path::Path};
 use tokio::{
     io,

--- a/src/tools/sign-oci-layer-root-hashes/src/sign.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/sign.rs
@@ -1,19 +1,33 @@
 use std::{
+    fs,
     io::Write,
     path::PathBuf,
     process::{Command, Stdio},
+    collections::BTreeMap,
 };
 
 use anyhow::{Context, Error};
 use base64::{engine::general_purpose, Engine};
 use futures::future;
-use oci_distribution::manifest::OciImageManifest;
+use oci_client::manifest::{OciDescriptor, OciManifest, OciImageManifest};
+use oci_client::client::{Client, linux_amd64_resolver, ClientConfig};
+use oci_client::secrets::RegistryAuth;
+use oci_client::{RegistryOperation, Reference};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::{registry, utils};
 
 const ROOT_HASH_LABEL: &str = "io.katacontainers.dm-verity.root-hash";
 const ROOT_HASH_SIG_LABEL: &str = "io.katacontainers.dm-verity.root-hash-sig";
+
+const IMAGE_NAME_LABEL: &str = "image.ref.name";
+const IMAGE_LAYER_DIGEST_LABEL: &str = "image.layer.digest";
+const IMAGE_LAYER_ROOT_HASH_LABEL: &str = "image.layer.root_hash";
+const IMAGE_LAYER_SIGNATURE_LABEL: &str = "image.layer.signature";
+const SIGNATURE_ARTIFACT_TYPE: &str = "application/vnd.oci.mt.pkcs7";
+const SIGNATURE_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.erofs.sig";
+const SIGNATURE_FILE_NAME: &str = "signature.blob.name";
 
 /// Aggregates per-image layer information. While the image name is not strictly
 /// necessary, it is convenient for human inspection of the manifest.
@@ -34,6 +48,127 @@ struct LayerInfo {
     digest: String,
     root_hash: String,
     signature: String,
+}
+
+pub(super) async fn attach_signatures(
+    image: &ImageInfo
+) -> Result<(), Error> {
+    let image_ref: Reference = image.name.to_string().parse().unwrap();
+    let client = Client::new(ClientConfig {
+            platform_resolver: Some(Box::new(linux_amd64_resolver)),
+            ..Default::default()
+        });
+    // Authenticate with the registry (if needed)
+    let auth: RegistryAuth = registry::build_auth(&image_ref);
+    let op = RegistryOperation::Push;
+    client.auth(&image_ref, &auth, op).await?;
+
+    let accepted_media_types = &[
+        oci_client::manifest::OCI_IMAGE_INDEX_MEDIA_TYPE,
+        oci_client::manifest::OCI_IMAGE_MEDIA_TYPE,
+        oci_client::manifest::IMAGE_MANIFEST_LIST_MEDIA_TYPE,
+        oci_client::manifest::IMAGE_MANIFEST_MEDIA_TYPE,
+    ];
+    // 1. Resolve the subject descriptor
+    let (raw_bytes, subject_digest) = client
+        .pull_manifest_raw(&image_ref, &auth, accepted_media_types)
+        .await?;
+    // Parse the raw_bytes into an OCI manifest
+    let image_manifest: OciManifest = serde_json::from_slice(&raw_bytes)
+        .context("Failed to parse raw bytes into OCI manifest")?;
+    // Print the digest, raw bytes length, the manifest media type
+    println!("Subject Digest: {}", subject_digest);
+    println!("Raw bytes length: {}", raw_bytes.len());
+
+    let subject_descriptor = OciDescriptor {
+        digest: subject_digest, // Digest of the manifest to attach
+        size: raw_bytes.len() as i64, // Size in bytes
+        media_type: image_manifest.content_type().to_string(),
+        ..Default::default()
+    };
+
+    // 2. Prepare the signature blobs to be attached
+    let mut sig_descriptors: Vec<OciDescriptor> = Vec::new();
+    for layer in &image.layers {
+        let json_obj = serde_json::json!({
+            "layer_digest": layer.digest,
+            "root_hash": layer.root_hash,
+            "signature": layer.signature,
+        });
+        let file_name = format!("signature_for_layer_{}.json", layer.digest.trim_start_matches("sha256:"));
+        // let file_path = Path::new("/workspace/sig_verify").join(&file_name);
+        fs::write(&file_name, serde_json::to_string_pretty(&json_obj)?)?;
+        println!("Wrote signature info for layer {} to {}", layer.digest, file_name);
+        let blob_bytes = fs::read(file_name.clone())?;
+        let blob_digest = format!("sha256:{:x}", Sha256::digest(blob_bytes.clone()));
+        println!("Blob size and Digest: {}, {}", blob_bytes.len(), blob_digest);
+
+        let mut annotations = BTreeMap::new();
+        annotations.insert(IMAGE_LAYER_DIGEST_LABEL.to_string(), layer.digest.clone());
+        annotations.insert(IMAGE_LAYER_ROOT_HASH_LABEL.to_string(), layer.root_hash.clone());
+        annotations.insert(IMAGE_LAYER_SIGNATURE_LABEL.to_string(), layer.signature.clone());
+        annotations.insert(SIGNATURE_FILE_NAME.to_string(), file_name.clone());
+
+        // Push each signature blob to the repository
+        client.push_blob(
+            &image_ref,
+            &blob_bytes,
+            &blob_digest.clone(),
+        ).await
+        .context("Blob pushed failed")?;
+
+        // Create the signature descriptor
+        let sig_descriptor = OciDescriptor {
+            media_type: SIGNATURE_MEDIA_TYPE.to_string(),
+            digest: blob_digest.clone(),
+            size: blob_bytes.len() as i64,
+            annotations: Some(annotations),
+            urls: None,
+            ..Default::default()
+        };
+
+        // Add the signature descriptor to the signature list
+        sig_descriptors.push(sig_descriptor);
+    }
+    // 3. Create the signature manifest with the subject descriptor, artifact type, and annotations
+    let mut annotations = BTreeMap::new();
+    annotations.insert(IMAGE_NAME_LABEL.to_string(), image.name.clone());
+    annotations.insert(
+        "org.opencontainers.image.created".to_string(),
+        chrono::Utc::now().to_rfc3339(),
+    );
+    // Empty Descriptor for config, as per OCI spec, this is required for the manifest, refer to https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidance-for-an-empty-descriptor
+    let config_descriptor = OciDescriptor {
+        media_type: "application/vnd.oci.empty.v1+json".to_string(),
+            digest:"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a".to_string(),
+            size: 2,
+            annotations: None,
+            urls: None,
+    };
+    let sig_manifest = oci_client::manifest::OciImageManifest {
+        schema_version: 2,
+        media_type: Some(oci_client::manifest::OCI_IMAGE_MEDIA_TYPE.to_string()),
+        artifact_type: Some(SIGNATURE_ARTIFACT_TYPE.to_string()),
+        config: config_descriptor,
+        layers: sig_descriptors.clone(),
+        subject: Some(subject_descriptor.clone()),
+        annotations: Some(annotations.clone()),
+    };
+
+    // 4. Push the signature manifest to a new reference (e.g., with a ".erofs.sig" suffix)
+    let sig_ref: Reference = Reference::with_tag(
+            image_ref.registry().to_string(),
+            image_ref.repository().to_string(),
+            format!("{}.erofs.sig", image_ref.tag().unwrap()),
+        );
+    if let Err(e) = client.push_manifest(&sig_ref, &OciManifest::Image(sig_manifest)).await {
+        eprintln!(
+            "Failed to push signature manifest to {}: {}",
+            sig_ref, e
+        );
+    }
+    println!("Signature manifest pushed successfully to: {}", sig_ref);
+    Ok(())
 }
 
 async fn get_image_root_hashes(image: &str, config: &utils::Config) -> Result<ImageInfo, Error> {

--- a/src/tools/sign-oci-layer-root-hashes/src/sign.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/sign.rs
@@ -12,18 +12,18 @@ use sha2::{Digest, Sha256};
 
 use crate::{registry, utils};
 
-const ROOT_HASH_LABEL: &str = "io.katacontainers.dm-verity.root-hash";
-const ROOT_HASH_SIG_LABEL: &str = "io.katacontainers.dm-verity.root-hash-sig";
-
-const IMAGE_NAME_LABEL: &str = "image.ref.name";
-const IMAGE_LAYER_DIGEST_LABEL: &str = "image.layer.digest";
-const IMAGE_LAYER_ROOT_HASH_LABEL: &str = "image.layer.root_hash";
-const IMAGE_LAYER_SIGNATURE_LABEL: &str = "image.layer.signature";
-const SIGNATURE_ARTIFACT_TYPE: &str = "application/vnd.oci.mt.pkcs7";
-const SIGNATURE_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.erofs.sig";
-const SIGNATURE_FILE_NAME: &str = "signature.blob.name";
-
-const EMPTY_CONFIG_DIGEST: &str = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a";
+use common::constants::{
+    IMAGE_NAME_LABEL,
+    IMAGE_LAYER_DIGEST_LABEL,
+    IMAGE_LAYER_ROOT_HASH_LABEL,
+    IMAGE_LAYER_SIGNATURE_LABEL,
+    SIGNATURE_MEDIA_TYPE,
+    SIGNATURE_FILE_NAME,
+    EMPTY_CONFIG_DIGEST,
+    SIGNATURE_ARTIFACT_TYPE,
+    ROOT_HASH_LABEL,
+    ROOT_HASH_SIG_LABEL,
+};
 
 /// Aggregates per-image layer information. While the image name is not strictly
 /// necessary, it is convenient for human inspection of the manifest.

--- a/src/tools/sign-oci-layer-root-hashes/src/utils.rs
+++ b/src/tools/sign-oci-layer-root-hashes/src/utils.rs
@@ -92,6 +92,9 @@ impl Commands {
             Commands::InjectSignaturesToImageManifest { .. } => {
                 "inject-signatures-to-image-manifest"
             }
+            Commands::AttachSignaturesToImageManifest { .. } => {
+                "attach-signatures-to-image-manifest"
+            }
         }
     }
 }
@@ -112,6 +115,12 @@ pub enum Commands {
 
     /// Embed signatures into the image manifest and repush updated manifest
     InjectSignaturesToImageManifest {
+        #[clap(flatten)]
+        output_image_group: Option<OutputImageGroup>,
+    },
+
+    /// Attach signatures to the image manifest as referrers without repushing the manifest
+    AttachSignaturesToImageManifest {
         #[clap(flatten)]
         output_image_group: Option<OutputImageGroup>,
     },


### PR DESCRIPTION

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of WHAT changed and WHY. -->
This PR updates oci-distribution (renamed to oci-client, ref: https://crates.io/crates/oci-client) to the latest version, and extends Solar to attach signatures to image manifest with a new command. 
The usage of the attach command:
```
solar \
--image $TEST_IMAGE \  OR --images <approved-container-images>
--use-cached-files \
--signer $CERT \
--key $KEY \
--passphrase pass: \
attach-signatures-to-image-manifest
```


###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
