### PR TITLE
image: revert don't insert the DAX header (#56)"

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -633,15 +633,8 @@ main() {
 		create_rootfs_image "${rootfs}" "${image}" "${rootfs_img_size}" \
 						"${fs_type}" "${block_size}" "${agent_bin}"
 	fi
-
-	# Skip the insertion of the DAX header due to
-	# https://github.com/kata-containers/kata-containers/issues/7993
-
-	#info "Partition information before set_dax_header:"
-	#fdisk -lu "${image}"
-
 	# insert at the beginning of the image the MBR + DAX header
-	# set_dax_header "${image}" "${img_size}" "${fs_type}" "${nsdax_bin}"
+	set_dax_header "${image}" "${img_size}" "${fs_type}" "${nsdax_bin}"
 
 	chown "${USER}:${GROUP}" "${image}"
 }


### PR DESCRIPTION
This reverts commit a1025659577e9d0e1259032f06bc4eae4afe672b.

That was a workaround for https://github.com/kata-containers/kata-containers/issues/7993, that has been fixed upstream.
