### PR TITLE
Revert "runtime: fix error when using the debug console"

### DIFF
--- a/src/runtime/pkg/resourcecontrol/cgroups.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups.go
@@ -61,7 +61,6 @@ func sandboxDevices() []specs.LinuxDeviceCgroup {
 		"/dev/zero",
 		"/dev/urandom",
 		"/dev/console",
-		"/dev/ptmx",
 	}
 
 	// Processes running in a device-cgroup are constrained, they have acccess


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This reverts commit 3cfdd53a88ee4f9704c957895b633601c4ac4475. Based on automated and manual testing, this commit is no longer required.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
N/A

###### Links to CVEs  <!-- optional -->
<!-- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX -->
N/A

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- manual testing
- internal automation (880636, 880974)