### PR TITLE
runtime: fix `make test`

### DIFF
--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -943,7 +943,7 @@ func TestHypervisorDefaults(t *testing.T) {
 	assert.Equal(h.machineType(), defaultMachineType, "default hypervisor machine type wrong")
 	assert.Equal(h.defaultVCPUs(), float32(defaultVCPUCount), "default vCPU number is wrong")
 	assert.Equal(h.defaultMaxVCPUs(), numCPUs, "default max vCPU number is wrong")
-	assert.Equal(h.defaultMemSz(), defaultMemSize, "default memory size is wrong")
+	assert.Equal(h.defaultMemSz(), uint32(0), "default memory size is wrong")
 
 	machineType := "foo"
 	h.MachineType = machineType
@@ -1526,7 +1526,7 @@ func TestCheckHypervisorConfig(t *testing.T) {
 	// function, hence no test for it here.
 
 	data := []testData{
-		{"", "", 0, true, false},
+		{"", "", 0, false, false},
 
 		{imageENOENT, "", 2, true, false},
 		{"", initrdENOENT, 2, true, false},


### PR DESCRIPTION
This addresses the following errors from `make test` to allow us to require that upstream CI:

https://github.com/microsoft/kata-containers/actions/runs/16656407213/job/47142422035?pr=392#step:13:53

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [ ] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Builds on Windows
- [ ] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->

###### Links to CVEs  <!-- optional -->
<!-- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
