### PR TITLE
docs: node-builder: Remove references to moby-containerd-cc

### DIFF
--- a/tools/osbuilder/node-builder/azure-linux/README.md
+++ b/tools/osbuilder/node-builder/azure-linux/README.md
@@ -54,9 +54,6 @@ EOF
 sudo reboot
 ```
 
-Note: We currently use a [forked version](https://github.com/microsoft/confidential-containers-containerd/tree/tardev-v1.7.7) of `containerd` called `containerd-cc` which is installed as part of the `kata-packages-host` package. This containerd version is based on stock containerd with patches to support the Kata-CC use case and conflicts with the `containerd` package.
-As part of the build steps below, we provide instructions on how to build `containerd-cc` from source and to replace the component on the environment.
-
 ## Variant I: Utilize released components to assemble the UVM
 
 While the priorly installed `kata-packages-host` package delivers all host-side components, the tools required to assemble the UVM components are delivered through the `kata-packages-uvm-build` package.
@@ -216,21 +213,6 @@ command:
 
 ```shell
 sudo make BUILD_TYPE=debug SHIM_REDEPLOY_CONFIG=no all-confpods deploy-confpods
-```
-
-## Optional build step: Build and deploy the containerd fork from scratch
-
-```
-git clone --depth 1 --branch tardev-v1.7.7 https://github.com/microsoft/confidential-containers-containerd.git
-pushd confidential-containers-containerd/
-GODEBUG=1 make
-popd
-```
-
-Overwrite existing containerd binary, restart service:
-```
-sudo cp -a --backup=numbered confidential-containers-containerd/bin/containerd /usr/bin/containerd
-sudo systemctl restart containerd
 ```
 
 # Run Kata (Confidential) Containers


### PR DESCRIPTION

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
As we adopted containerd2, we remove references to our prior forked containerd version.

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->
N/A
###### Links to CVEs  <!-- optional -->
<!-- https://nvd.nist.gov/vuln/detail/CVE-YYYY-XXXX -->
N/A
###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
N/A