### PR TITLE
cherry-pick: ci: static-checks: Don't hardcode default repo branch

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -28,7 +28,7 @@ KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
 
-export branch="${target_branch:-main}"
+export branch="${target_branch:-"$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"}"
 
 function die() {
 	local msg="$*"


### PR DESCRIPTION
This makes the following check green:

```
[Static checks / static-checks (make static-checks)
```

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable
