### PR TITLE
network: preseed default-gateway neighbor

### DIFF
--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -315,12 +315,15 @@ func generateVCNetworkStructures(ctx context.Context, endpoints []Endpoint) ([]*
 			routes = append(routes, &r)
 		}
 
-		for _, neigh := range endpoint.Properties().Neighbors {
-			var n pbTypes.ARPNeighbor
+		gatewaySet := gatewaySetFromRoutes(endpoint.Properties().Routes)
 
-			if !validGuestNeighbor(neigh) {
+		for _, neigh := range endpoint.Properties().Neighbors {
+
+			if !validGuestNeighbor(neigh, gatewaySet) {
 				continue
 			}
+
+			var n pbTypes.ARPNeighbor
 
 			n.Device = endpoint.Name()
 			n.State = int32(neigh.State)


### PR DESCRIPTION


<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Cherry pick from https://github.com/kata-containers/kata-containers/pull/11704 (not including policy changes since we don't need those for vanilla kata)

This change mirrors host networking into the guest as before, but now also includes the default gateway neighbor entry for each interface.

Pods using overlay/synthetic gateways (e.g., 169.254.1.1) can hit a first-connect race while the guest performs the initial ARP. Preseeding the gateway neighbor removes that latency and makes early connections (e.g., to the API Service) deterministic.

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
- CI: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=907588&view=results
  - Buddy Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=907601&view=results
  - Image Build: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=907608&view=results
  - Conformance: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=907687&view=results
  - Performance: https://dev.azure.com/mariner-org/mariner/_build/results?buildId=907688&view=results