### PR TITLE
runtime: Implement MVP support for block-based emptyDir

### DIFF
--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -291,6 +291,8 @@ fn mount_storage(logger: &Logger, storage: &Storage) -> Result<()> {
             .arg("^has_journal")
             .arg("-E")
             .arg("assume_storage_prezeroed=1")
+            .arg("-m")
+            .arg("0")
             .arg("/dev/vdb")
             .output()
             .context("Failed to execute mkfs.ext4")?;

--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -272,7 +272,7 @@ fn mount_storage(logger: &Logger, storage: &Storage) -> Result<()> {
         return Ok(());
     }
 
-    let (flags, options) = parse_mount_options(&storage.options)?;
+    let (flags, mut options) = parse_mount_options(&storage.options)?;
     let mount_path = Path::new(&storage.mount_point);
     let src_path = Path::new(&storage.source);
     create_mount_destination(src_path, mount_path, "", &storage.fstype)
@@ -302,6 +302,11 @@ fn mount_storage(logger: &Logger, storage: &Storage) -> Result<()> {
             );
             return Err(anyhow!("mkfs.ext4 failed: {}", stderr));
         }
+
+        if !options.is_empty() {
+            options.push(',');
+        }
+        options.push_str("discard");
     }
 
     info!(logger, "mounting storage";

--- a/src/runtime/pkg/direct-volume/utils.go
+++ b/src/runtime/pkg/direct-volume/utils.go
@@ -77,6 +77,14 @@ func Add(volumePath string, mountInfo string) error {
 	return os.WriteFile(filepath.Join(volumeDir, mountInfoFileName), []byte(mountInfo), 0600)
 }
 
+func AddMountInfo(volumePath string, mountInfo MountInfo) error {
+	s, err := json.Marshal(&mountInfo)
+	if err != nil {
+		return err
+	}
+	return Add(volumePath, string(s))
+}
+
 // Remove deletes the direct volume path including all the files inside it.
 func Remove(volumePath string) error {
 	return os.RemoveAll(filepath.Join(kataDirectVolumeRootPath, b64.URLEncoding.EncodeToString([]byte(volumePath))))
@@ -97,6 +105,17 @@ func VolumeMountInfo(volumePath string) (*MountInfo, error) {
 		return nil, err
 	}
 	return &mountInfo, nil
+}
+
+// IsVolumeMounted returns whether the direct volume mount is present.
+func IsVolumeMounted(volumePath string) (bool, error) {
+	if _, err := VolumeMountInfo(volumePath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // RecordSandboxId associates a sandbox id with a direct volume.

--- a/src/runtime/pkg/resourcecontrol/utils.go
+++ b/src/runtime/pkg/resourcecontrol/utils.go
@@ -17,6 +17,8 @@ import (
 
 var (
 	ErrCgroupMode = errors.New("cgroup controller type error")
+	VirtualDeviceMajor = 254
+	VirtualDeviceMinor = 254
 )
 
 func DeviceToCgroupDeviceRule(device string) (*devices.Rule, error) {
@@ -35,16 +37,19 @@ func DeviceToCgroupDeviceRule(device string) (*devices.Rule, error) {
 	switch devType {
 	case unix.S_IFCHR:
 		deviceRule.Type = 'c'
+		deviceRule.Major = int64(unix.Major(uint64(st.Rdev)))
+		deviceRule.Minor = int64(unix.Minor(uint64(st.Rdev)))
 	case unix.S_IFBLK:
 		deviceRule.Type = 'b'
+		deviceRule.Major = int64(unix.Major(uint64(st.Rdev)))
+		deviceRule.Minor = int64(unix.Minor(uint64(st.Rdev)))
+	case unix.S_IFREG:
+		deviceRule.Type = 'b'
+		deviceRule.Major = int64(VirtualDeviceMajor)
+		deviceRule.Minor = int64(VirtualDeviceMinor)
 	default:
-		return nil, fmt.Errorf("unsupported device type: %v", devType)
+		return nil, fmt.Errorf("unsupported type %v for device: %v", devType, device)
 	}
-
-	major := int64(unix.Major(uint64(st.Rdev)))
-	minor := int64(unix.Minor(uint64(st.Rdev)))
-	deviceRule.Major = major
-	deviceRule.Minor = minor
 
 	return &deviceRule, nil
 }

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -873,8 +873,9 @@ func (c *Container) createEphemeralDisks(_ context.Context) error {
 
 		// Create the disk file in the same folder as the original
 		// emptyDir mount so that we use the same backing storage.
-		emptyDirFolder := filepath.Dir(c.mounts[i].Source)
-		diskPath := filepath.Join(emptyDirFolder, fmt.Sprintf("%s-disk.img", emptyDirName))
+		// emptyDirFolder := filepath.Dir(c.mounts[i].Source)
+		// diskPath := filepath.Join(emptyDirFolder, fmt.Sprintf("%s-disk.img", emptyDirName))
+		diskPath := "/foo.img"
 		f, err := os.Create(diskPath)
 		if err != nil {
 			c.Logger().WithError(err).Errorf("failed to create disk file at %s", diskPath)

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -893,15 +893,6 @@ func (c *Container) createEphemeralDisks(_ context.Context) error {
 			return err
 		}
 
-		mkfs := exec.Command("mkfs.ext4", "-F", diskPath)
-		if output, err := mkfs.CombinedOutput(); err != nil {
-			c.Logger().WithError(err).WithFields(logrus.Fields{
-				"output":   string(output),
-				"exitCode": mkfs.ProcessState.ExitCode(),
-			}).Error("failed to create filesystem on disk")
-			return err
-		}
-
 		if err := volume.AddMountInfo(c.mounts[i].Source, volume.MountInfo{
 			VolumeType: "blk",
 			Device:     diskPath,

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"sort"

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -288,13 +288,6 @@ const (
 	ForceGuestPull = kataAnnotRuntimePrefix + "experimental_force_guest_pull"
 )
 
-// Volume related annotations
-const (
-	kataVolumesAnnotPrefix = kataAnnotationsPrefix + "volumes."
-
-	EmptyDirSizeLimitPrefix = kataVolumesAnnotPrefix + "emptydir_sizelimit."
-)
-
 // Agent related annotations
 const (
 	kataAnnotAgentPrefix = kataConfAnnotationsPrefix + "agent."

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -288,6 +288,13 @@ const (
 	ForceGuestPull = kataAnnotRuntimePrefix + "experimental_force_guest_pull"
 )
 
+// Volume related annotations
+const (
+	kataVolumesAnnotPrefix = kataAnnotationsPrefix + "volumes."
+
+	EmptyDirSizeLimitPrefix = kataVolumesAnnotPrefix + "emptydir_sizelimit."
+)
+
 // Agent related annotations
 const (
 	kataAnnotAgentPrefix = kataConfAnnotationsPrefix + "agent."

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
@@ -7,6 +7,6 @@
 OS_NAME=cbl-mariner
 OS_VERSION=${OS_VERSION:-3.0}
 LIBC="gnu"
-PACKAGES="kata-packages-uvm"
+PACKAGES="kata-packages-uvm e2fsprogs"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" systemd"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp"


### PR DESCRIPTION
## User-facing changes

* Users need to specify the disk sizeLimit via an annotation because K8s doesn't pass the its sizeLimit parameter over CRI, e.g.:

```yaml
  annotations:
    io.katacontainers.volumes.emptydir_sizelimit.scratch: 1G
```

## Servicing changes

- Add the below flag to containerd config so that containerd forwards the sizeLimit annotation to Kata:

```diff
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
   runtime_type = "io.containerd.kata.v2"
   privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.volumes.emptydir_sizelimit.*"]
```

## Current gaps with final implementation

- Format fs in the guest instead of host
- Kata config flag to enable block-based emptyDir
- Policy support

### Bugs

```
root@busybox:/scratch# dd if=/dev/zero of=output.bin bs=1M count=80 oflag=direct
command terminated with exit code 255

then df -hT shows virtiofs
```

## Demo

```yaml
# busy.yaml
apiVersion: v1
kind: Pod
metadata:
  name: busybox
  annotations:
    io.katacontainers.volumes.emptydir_sizelimit.scratch: 1G
spec:
  runtimeClassName: kata
  containers:
  - image: docker.io/library/busybox:latest
    name: container
    command: ["sleep", "inf"]
    volumeMounts:
    - name: scratch
      mountPath: /scratch
  volumes:
  - name: scratch
    emptyDir:
      sizeLimit: 1G # No effect with block-based
```

Below you notice that the mount source is `ext4` (instead of `virtiofs` today) and the fs type is `ext4` (instead of `overlay` today):

```shell
$ kubectl apply -f busy.yaml
pod/busybox created
$ kubectl exec -it busybox -c container -- df -hT | grep scratch
/dev/vdb             ext4          920.3M    260.0K    856.4M   0% /scratch
```