### PR TITLE
virtcontainers: Add automatic crashdump collection for Cloud  Hypervisor

### DIFF
--- a/docs/crashdump.md
+++ b/docs/crashdump.md
@@ -1,0 +1,32 @@
+# Cloud Hypervisor automatic crashdump collection
+
+## High level summary
+
+This change adds automatic guest crashdump collection for Cloud Hypervisor in Kata Containers, matching the existing QEMU crashdump capability.
+
+When a guest panic event is detected, the runtime collects a guest memory dump and related metadata so post-mortem analysis can be done without manual intervention.
+
+## Major changes
+
+- Added Cloud Hypervisor panic-event monitoring in `virtcontainers` to detect guest kernel panics.
+- Enabled Cloud Hypervisor `pvpanic` and event monitor integration when crashdump collection is configured.
+- Added Cloud Hypervisor guest memory dump collection flow (ELF `vmcore` plus metadata).
+- Added `guest_memory_dump_path` to `configuration-clh.toml.in` so operators can configure where crashdumps are stored on the host.
+- Set guest kernel panic behavior to avoid immediate reboot during dump collection (to allow dump capture to complete).
+
+Crashdump artifacts are stored under:
+
+`<guest_memory_dump_path>/<sandbox-id>/`
+
+## Breaking changes
+
+No API or config breaking changes were introduced.
+
+Behavioral note:
+
+- With crashdump collection enabled, VM teardown may wait briefly while dump capture completes (bounded by timeout safeguards in runtime logic).
+
+## Azure-specific notes
+
+- No Azure-only code path was introduced in this change.
+- The feature is runtime/Cloud Hypervisor based and applies the same way on Azure-hosted Kata deployments as on other environments.

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -247,6 +247,16 @@ disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM@
 # but it will not abort container execution.
 #guest_hook_path = "/usr/share/oci/hooks"
 #
+# Set where to save the guest memory dump file.
+# If set, when a panic event is received from the guest via the event monitor,
+# guest memory will be dumped to host filesystem under guest_memory_dump_path.
+# This directory will be created automatically if it does not exist.
+# The dumped file (also called vmcore) can be processed with crash or gdb.
+# WARNING:
+#   Dump guest's memory can take very long depending on the amount of guest memory
+#   and use much disk space.
+#guest_memory_dump_path="/var/crash/kata"
+#
 # These options are related to network rate limiter at the VMM level, and are
 # based on the Cloud Hypervisor I/O throttling.  Those are disabled by default
 # and we strongly advise users to refer the Cloud Hypervisor official

--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/containerd/console v1.0.4
 	github.com/containerd/containerd v1.7.27
 	github.com/containerd/containerd/api v1.8.0
+	github.com/containerd/continuity v0.4.4
 	github.com/containerd/cri-containerd v1.19.0
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/ttrpc v1.2.7
@@ -74,7 +75,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cilium/ebpf v0.16.0 // indirect
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect
-	github.com/containerd/continuity v0.4.4 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/go-runc v1.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1110,6 +1110,7 @@ func newClhHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		EnableAnnotations:              h.EnableAnnotations,
 		DisableSeccomp:                 h.DisableSeccomp,
 		ConfidentialGuest:              h.ConfidentialGuest,
+		GuestMemoryDumpPath:            h.GuestMemoryDumpPath,
 		Rootless:                       h.Rootless,
 		DisableSeLinux:                 h.DisableSeLinux,
 		DisableGuestSeLinux:            h.DisableGuestSeLinux,

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -119,6 +119,11 @@ func (c *clhClientMock) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice ch
 	return nil, nil
 }
 
+//nolint:golint
+func (c *clhClientMock) VmCoredumpPut(ctx context.Context, coredumpData chclient.VmCoredumpData) (*http.Response, error) {
+	return nil, nil
+}
+
 func TestCloudHypervisorAddVSock(t *testing.T) {
 	assert := assert.New(t)
 	clh := cloudHypervisor{}


### PR DESCRIPTION
###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [ ] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Builds on Windows
- [ ] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Implement automatic guest memory dump collection when a guest VM panics in Cloud Hypervisor, achieving feature parity with QEMU hypervisor.

Implementation:
- Monitor CLH event file for panic events with non-blocking I/O
- Enable pvpanic device and configure event-monitor when crashdump enabled
- Set `panic=0` kernel cmdline param to prevent reboot during memory dump
- Dump guest memory to ELF format with hypervisor metadata
- Add `guest_memory_dump_path` option to configuration-clh.toml.in

Memory dumps saved to <guest_memory_dump_path>/<sandbox-id>/ including vmcore ELF file, hypervisor config/version, and sandbox state.

Requires CLH built with `guest_debug` feature.

This enables automated crash analysis workflows for Kata Containers with Cloud Hypervisor, similar to existing QEMU functionality.
###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
