### PR TITLE
ci: replace 'main' with 'msft-preview'

### DIFF
--- a/.github/workflows/build-kubectl-image.yaml
+++ b/.github/workflows/build-kubectl-image.yaml
@@ -8,7 +8,7 @@ on:
     # Allow manual triggering
   push:
     branches:
-      - main
+      - msft-preview
     paths:
       - 'tools/packaging/kubectl/Dockerfile'
       - '.github/workflows/build-kubectl-image.yaml'

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -2,7 +2,7 @@ name: Kata Containers CI
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] See #11332.
     branches:
-      - 'main'
+      - 'msft-preview'
     types:
       # Adding 'labeled' to the list of activity types that trigger this event
       # (default: opened, synchronize, reopened) so that we can run this

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -16,7 +16,7 @@ env:
   error_msg: |+
     See the document below for help on formatting commits for the project.
 
-    https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
+    https://github.com/kata-containers/community/blob/msft-preview/CONTRIBUTING.md#patch-format
 
 jobs:
   commit-message-check:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: Documentation
 on:
   push:
     branches:
-      - main
+      - msft-preview
 permissions: {}
 jobs:
   deploy-docs:

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -9,11 +9,11 @@ name: OSV-Scanner
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "msft-preview" ]
   schedule:
     - cron: '0 1 * * 0'
   push:
-    branches: [ "main" ]
+    branches: [ "msft-preview" ]
 
 permissions: {}
 

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -2,7 +2,7 @@ name: CI | Publish Kata Containers payload
 on:
   push:
     branches:
-      - main
+      - msft-preview
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/push-oras-tarball-cache.yaml
+++ b/.github/workflows/push-oras-tarball-cache.yaml
@@ -1,11 +1,11 @@
 # Push gperf and busybox tarballs to the ORAS cache (ghcr.io) so that
 # download-with-oras-cache.sh can pull them instead of hitting upstream.
-# Runs when versions.yaml changes on main (e.g. after a PR merge) or manually.
+# Runs when versions.yaml changes on msft-preview (e.g. after a PR merge) or manually.
 name: CI | Push ORAS tarball cache
 on:
   push:
     branches:
-      - main
+      - msft-preview
     paths:
       - 'versions.yaml'
   workflow_dispatch:

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -66,7 +66,7 @@ jobs:
           # We need to do such trick here as the format of the $GITHUB_REF
           # is "refs/tags/<tag>"
           tag=$(echo "$GITHUB_REF" | cut -d/ -f3-)
-          if [ "${tag}" = "main" ]; then
+          if [ "${tag}" = "msft-preview" ]; then
               tag=$(./tools/packaging/release/release.sh release-version)
               tags=("${tag}" "latest")
           else

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -66,7 +66,7 @@ jobs:
           # We need to do such trick here as the format of the $GITHUB_REF
           # is "refs/tags/<tag>"
           tag=$(echo "$GITHUB_REF" | cut -d/ -f3-)
-          if [ "${tag}" = "main" ]; then
+          if [ "${tag}" = "msft-preview" ]; then
               tag=$(./tools/packaging/release/release.sh release-version)
               tags=("${tag}" "latest")
           else

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -63,7 +63,7 @@ jobs:
           # We need to do such trick here as the format of the $GITHUB_REF
           # is "refs/tags/<tag>"
           tag=$(echo "$GITHUB_REF" | cut -d/ -f3-)
-          if [ "${tag}" = "main" ]; then
+          if [ "${tag}" = "msft-preview" ]; then
               tag=$(./tools/packaging/release/release.sh release-version)
               tags=("${tag}" "latest")
           else

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -67,7 +67,7 @@ jobs:
           # We need to do such trick here as the format of the $GITHUB_REF
           # is "refs/tags/<tag>"
           tag=$(echo "$GITHUB_REF" | cut -d/ -f3-)
-          if [ "${tag}" = "main" ]; then
+          if [ "${tag}" = "msft-preview" ]; then
               tag=$(./tools/packaging/release/release.sh release-version)
               tags=("${tag}" "latest")
           else

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -5,10 +5,10 @@
 name: Scorecard supply-chain security
 on:
   # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  # https://github.com/ossf/scorecard/blob/msft-preview/docs/checks.md#branch-protection
   branch_protection_rule:
   push:
-    branches: [ "main" ]
+    branches: [ "msft-preview" ]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
This is a fork temporary measure to unblock CI required tests in our fork, while we find a way to remove the 'main' hard codes from upstream.