### PR TITLE
cherry-pick: gatekeeper: Add EditorConfig checker to required tests

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -96,6 +96,6 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd # v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^[\s\t]*[^:\s\t]+[\s\t]*:'
+        pattern: '^((fixup|amend)!\s)?(?!(fixup|amend)!)[^:\s\t]+[\s\t]*:'
         error: 'Failed to find subsystem in subject'
         post_error: ${{ env.error_msg }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Instead, please report them to the Microsoft Security Response Center (MSRC) at 
 
 If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 

--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -8,6 +8,7 @@ required_tests:
   - Cargo Crates Check Runner / cargo-deny-runner
   - GHA security analysis / zizmor
   - Lint GHA workflows / run-actionlint
+  - EditorConfig checker / editorconfig-checker
 
 required_regexps:
   # Always required regexps


### PR DESCRIPTION
Cherry-picking from upstream.

Cool note: I created the second commit with `git commit --fixup 4e81837` so that on the next rebase `git rebase -i --autosquash` will automatically squash the new commit into the original SECURITY.md commit:

https://blog.gitbutler.com/git-autosquash
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordcommit 