### PR TITLE
kata-deploy: add 'openvmm' as a first-class shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ virtio_resources = { git = "https://github.com/microsoft/openvmm", rev = "14ad21
 vm_resource = { git = "https://github.com/microsoft/openvmm", rev = "14ad213b739a2ca7976f00ea090b475ceddd4592" }
 disk_backend_resources = { git = "https://github.com/microsoft/openvmm", rev = "14ad213b739a2ca7976f00ea090b475ceddd4592" }
 disk_blockdevice = { git = "https://github.com/microsoft/openvmm", rev = "14ad213b739a2ca7976f00ea090b475ceddd4592" }
+vfio_assigned_device_resources = { git = "https://github.com/microsoft/openvmm", rev = "14ad213b739a2ca7976f00ea090b475ceddd4592" }
 ovmm_vmm_core_defs = { git = "https://github.com/microsoft/openvmm", rev = "14ad213b739a2ca7976f00ea090b475ceddd4592", package = "vmm_core_defs" }
 ovmm_guid = { git = "https://github.com/microsoft/openvmm", rev = "14ad213b739a2ca7976f00ea090b475ceddd4592", package = "guid" }
 ovmm_memory_range = { git = "https://github.com/microsoft/openvmm", rev = "14ad213b739a2ca7976f00ea090b475ceddd4592", package = "memory_range" }

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -88,6 +88,7 @@ virtio_resources = { workspace = true, optional = true }
 vm_resource = { workspace = true, optional = true }
 disk_backend_resources = { workspace = true, optional = true }
 disk_blockdevice = { workspace = true, optional = true }
+vfio_assigned_device_resources = { workspace = true, optional = true }
 ovmm_vmm_core_defs = { workspace = true, optional = true }
 ovmm_guid = { workspace = true, optional = true }
 ovmm_memory_range = { workspace = true, optional = true }
@@ -123,6 +124,7 @@ openvmm = [
     "dep:vm_resource",
     "dep:disk_backend_resources",
     "dep:disk_blockdevice",
+    "dep:vfio_assigned_device_resources",
     "dep:ovmm_vmm_core_defs",
     "dep:ovmm_guid",
     "dep:ovmm_memory_range",

--- a/src/runtime-rs/crates/hypervisor/src/openvmm/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/inner_device.rs
@@ -117,6 +117,13 @@ impl OpenVmmInner {
                 Ok(DeviceType::Block(block))
             }
             other => {
+                if matches!(other, DeviceType::Vfio(_)) {
+                    return Err(anyhow!(
+                        "openvmm: VFIO devices are cold-plug only and must be \
+                         added before start_vm; got {} after VMM start",
+                        other
+                    ));
+                }
                 warn!(sl!(), "openvmm: add_device stub for {}", other);
                 Ok(other)
             }

--- a/src/runtime-rs/crates/hypervisor/src/openvmm/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/inner_hypervisor.rs
@@ -16,6 +16,7 @@ use super::vmm_instance::DeferredNetworkDevice;
 use super::{
     OPENVMM_BLOCK_HOTPLUG_PORT_COUNT, OPENVMM_BLOCK_HOTPLUG_PORT_PREFIX, OPENVMM_CONSOLE_PCI_PORT,
     OPENVMM_NET_PCI_PORT, OPENVMM_ROOTFS_PCI_PORT, OPENVMM_SHAREFS_PCI_PORT,
+    OPENVMM_VFIO_COLDPLUG_PORT_COUNT, OPENVMM_VFIO_COLDPLUG_PORT_PREFIX,
 };
 use crate::kernel_param::KernelParams;
 use crate::utils::{get_jailer_root, get_sandbox_path};
@@ -194,6 +195,17 @@ impl OpenVmmInner {
                     });
                 }
 
+                // Cold-plug ports for VFIO PCI pass-through (GPUs, NVSwitches,
+                // InfiniBand VFs). These are always created so the OpenVMM
+                // root-complex layout is stable; unused ones simply appear
+                // empty in the guest.
+                for index in 0..OPENVMM_VFIO_COLDPLUG_PORT_COUNT {
+                    ports.push(PcieRootPortConfig {
+                        name: format!("{}{}", OPENVMM_VFIO_COLDPLUG_PORT_PREFIX, index),
+                        hotplug: false,
+                    });
+                }
+
                 ports
             },
         }];
@@ -221,6 +233,7 @@ impl OpenVmmInner {
             Vec::new();
         let mut deferred_block_devices = Vec::new();
         let mut deferred_network_devices = Vec::new();
+        let mut next_vfio_port: u8 = 0;
 
         for dev in &pending {
             match dev {
@@ -336,6 +349,72 @@ impl OpenVmmInner {
                             blk_dev.config.path_on_host);
                     } else {
                         deferred_block_devices.push(dev.clone());
+                    }
+                }
+                crate::DeviceType::Vfio(vfio_dev) => {
+                    // Cold-plug VFIO PCI pass-through. Each HostDevice in the
+                    // IOMMU group becomes its own PcieDeviceConfig on a
+                    // pre-reserved root port. The /dev/vfio/<group> fd is
+                    // opened here (one open per device, which the kernel
+                    // allows for the same group).
+                    let host_path = &vfio_dev.config.host_path;
+                    info!(
+                        sl!(),
+                        "openvmm: cold-plug VFIO group {} ({} device(s))",
+                        host_path,
+                        vfio_dev.devices.len()
+                    );
+
+                    for hostdev in &vfio_dev.devices {
+                        if hostdev.bus_slot_func.is_empty() {
+                            warn!(
+                                sl!(),
+                                "openvmm: skipping VFIO device with empty BDF in group {}",
+                                host_path
+                            );
+                            continue;
+                        }
+
+                        if next_vfio_port >= OPENVMM_VFIO_COLDPLUG_PORT_COUNT {
+                            return Err(anyhow!(
+                                "openvmm: too many VFIO devices (limit {}), cannot cold-plug BDF {}",
+                                OPENVMM_VFIO_COLDPLUG_PORT_COUNT,
+                                hostdev.bus_slot_func
+                            ));
+                        }
+
+                        let group_fd = std::fs::OpenOptions::new()
+                            .read(true)
+                            .write(true)
+                            .open(host_path)
+                            .with_context(|| {
+                                format!(
+                                    "openvmm: failed to open VFIO group {} for BDF {}",
+                                    host_path, hostdev.bus_slot_func
+                                )
+                            })?;
+
+                        let port_name = format!(
+                            "{}{}",
+                            OPENVMM_VFIO_COLDPLUG_PORT_PREFIX, next_vfio_port
+                        );
+                        next_vfio_port += 1;
+
+                        info!(
+                            sl!(),
+                            "openvmm: assigning VFIO BDF {} to port {}",
+                            hostdev.bus_slot_func,
+                            port_name
+                        );
+
+                        pcie_devices.push(PcieDeviceConfig {
+                            port_name,
+                            resource: vfio_assigned_device_resources::VfioDeviceHandle {
+                                pci_id: hostdev.bus_slot_func.clone(),
+                                group: group_fd,
+                            }
+                            .into_resource(),
+                        });
                     }
                 }
                 other => {

--- a/src/runtime-rs/crates/hypervisor/src/openvmm/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/mod.rs
@@ -38,6 +38,11 @@ pub(crate) const OPENVMM_CONSOLE_PCI_PORT: &str = "rp4";
 pub(crate) const OPENVMM_STATIC_PCI_PORT_COUNT: u8 = 5;
 pub(crate) const OPENVMM_BLOCK_HOTPLUG_PORT_PREFIX: &str = "hp";
 pub(crate) const OPENVMM_BLOCK_HOTPLUG_PORT_COUNT: u8 = 24;
+/// Number of pre-reserved PCIe root ports for cold-plug VFIO pass-through
+/// devices (e.g., GPUs, NVSwitches). These ports are created with
+/// `hotplug: false` so the guest sees the assigned devices at boot.
+pub(crate) const OPENVMM_VFIO_COLDPLUG_PORT_PREFIX: &str = "vfio";
+pub(crate) const OPENVMM_VFIO_COLDPLUG_PORT_COUNT: u8 = 16;
 
 /// The OpenVMM hypervisor struct, wrapping inner state behind a lock.
 pub struct OpenVmm {

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -23,6 +23,7 @@ const ALL_SHIMS: &[&str] = &[
     "dragonball",
     "fc",
     "firecracker",
+    "openvmm",
     "remote",
     // QEMU shims
     "qemu",
@@ -62,6 +63,7 @@ fn get_hypervisor_name(shim: &str) -> Result<&str> {
         "cloud-hypervisor" => Ok("cloud-hypervisor"),
         "dragonball" => Ok("dragonball"),
         "fc" | "firecracker" => Ok("firecracker"),
+        "openvmm" => Ok("openvmm"),
         "remote" => Ok("remote"),
         _ => anyhow::bail!(
             "Unknown shim '{}'. Valid shims are: {}",
@@ -865,6 +867,16 @@ async fn configure_experimental_force_guest_pull(config_file: &Path) -> Result<(
 }
 
 async fn configure_mariner(config: &Config) -> Result<()> {
+    // configure_mariner mutates configuration-clh.toml in place to point it
+    // at the cbl-mariner-shipped cloud-hypervisor binary (and to flip a
+    // couple of related knobs). It is a no-op for hosts that do not have
+    // the clh shim enabled — for example, an openvmm-only deployment must
+    // not have its `hypervisor_name = "openvmm"` rewritten to `clh`. Gate
+    // on the active shim list to keep this function clh-specific.
+    if !config.shims_for_arch.iter().any(|s| s == "clh") {
+        return Ok(());
+    }
+
     let config_path = format!(
         "{}/share/defaults/kata-containers/configuration-clh.toml",
         config.host_install_dir
@@ -945,6 +957,7 @@ mod tests {
     #[case("dragonball", "dragonball")]
     #[case("fc", "firecracker")]
     #[case("firecracker", "firecracker")]
+    #[case("openvmm", "openvmm")]
     #[case("remote", "remote")]
     fn test_get_hypervisor_name_other_hypervisors(#[case] shim: &str, #[case] expected: &str) {
         assert_eq!(get_hypervisor_name(shim).unwrap(), expected);

--- a/tools/packaging/kata-deploy/binary/src/utils/system.rs
+++ b/tools/packaging/kata-deploy/binary/src/utils/system.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 pub const RUST_SHIMS: &[&str] = &[
     "cloud-hypervisor",
     "dragonball",
+    "openvmm",
     "qemu-runtime-rs",
     "qemu-coco-dev-runtime-rs",
     "qemu-se-runtime-rs",

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -86,6 +86,7 @@ scheduling:
   "cloud-hypervisor" (dict "memory" "130Mi" "cpu" "250m")
   "dragonball" (dict "memory" "130Mi" "cpu" "250m")
   "fc" (dict "memory" "130Mi" "cpu" "250m")
+  "openvmm" (dict "memory" "130Mi" "cpu" "250m")
   "qemu" (dict "memory" "160Mi" "cpu" "250m")
   "qemu-coco-dev" (dict "memory" "160Mi" "cpu" "250m")
   "qemu-coco-dev-runtime-rs" (dict "memory" "160Mi" "cpu" "250m")

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -310,6 +310,15 @@ shims:
       httpsProxy: ""
       noProxy: ""
 
+  openvmm:
+    enabled: ~
+    supportedArches:
+      - amd64
+      - arm64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: ""
+
 # Default shim per architecture
 defaultShim:
   amd64: qemu


### PR DESCRIPTION
The runtime-rs shim can be built with the openvmm feature to link the OpenVMM Rust hypervisor in-process. To deploy this shim end-to-end (as a RuntimeClass named kata-openvmm with its own configuration-openvmm.toml and per-arch enablement in the helm chart), kata-deploy needs to recognize 'openvmm' as a valid shim name.

Three places need the addition:

  1. tools/packaging/kata-deploy/binary/src/utils/system.rs

     Add 'openvmm' to RUST_SHIMS so kata-deploy resolves the shim binary under /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 (where the runtime-rs build drops it) and the per-shim config under /opt/kata/share/defaults/kata-containers/runtime-rs/.

  2. tools/packaging/kata-deploy/binary/src/artifacts/install.rs

     - Add 'openvmm' to ALL_SHIMS so install.rs accepts it on the SHIMS_<ARCH> / DEFAULT_SHIM_<ARCH> environment variables and on the helm 'shims.openvmm' selector.
     - Add 'openvmm => openvmm' to get_hypervisor_name so the per-shim containerd config is rendered against the [hypervisor.openvmm] section of configuration-openvmm.toml. - Gate configure_mariner on the shims_for_arch list containing 'clh'. configure_mariner unconditionally opens configuration-clh.toml and rewrites runtime.hypervisor_name = 'clh' plus hypervisor.clh.{path,valid_hypervisor_paths,...}. That is the right thing to do when clh is the active shim, but on an openvmm-only deployment it would clobber runtime.hypervisor_name = 'openvmm' set by the configuration-openvmm.toml template. The mariner-specific path mutations are still applied whenever clh is in the shim list.

  3. tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml

     Add an 'openvmm:' block under shims: so the helm chart can render the SHIMS_<ARCH> env var and the kata-openvmm RuntimeClass when the user opts in with --set shims.openvmm.enabled=true.

The configuration-openvmm.toml.in template under src/runtime-rs/config/ already exists and is rendered by the runtime-rs Makefile when USE_OPENVMM=true. With these three changes, 'openvmm' becomes a fully-supported shim and no downstream consumer (helm install, kata-deploy install, nerdctl, kubectl with runtimeClassName=kata-openvmm) needs to do any post-deploy TOML fixups.

<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [ ] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [ ] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [ ] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Builds on Windows
- [ ] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
