### PR TITLE
runtime-rs/openvmm: add raw OCI VFIO cold-plug + correctness fixes

### DIFF
--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -45,7 +45,7 @@ protocols = { workspace = true, features = ["async"] }
 persist = { workspace = true }
 ch-config = { workspace = true, optional = true }
 tests_utils = { workspace = true }
-tracing-subscriber = { version = "0.3", optional = true }
+tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter"] }
 
 # Dependencies that only exist to support hypervisors which upstream only
 # build on x86_64 and aarch64 (dragonball, firecracker). Keeping them in a

--- a/src/runtime-rs/crates/hypervisor/src/openvmm/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/inner_hypervisor.rs
@@ -397,12 +397,28 @@ impl OpenVmmInner {
                             );
                             continue;
                         }
+                        if hostdev.domain.is_empty() {
+                            warn!(
+                                sl!(),
+                                "openvmm: skipping VFIO device with empty PCI domain (BDF {}) in group {}",
+                                hostdev.bus_slot_func,
+                                host_path
+                            );
+                            continue;
+                        }
+                        // OpenVMM expects the full PCI BDF including the segment/
+                        // domain (e.g. "0001:00:00.0") to resolve
+                        // /sys/bus/pci/devices/<full_bdf>. HostDevice splits
+                        // these into `domain` ("0001") and `bus_slot_func`
+                        // ("00:00.0"); recombine them here.
+                        let full_bdf =
+                            format!("{}:{}", hostdev.domain, hostdev.bus_slot_func);
 
                         if next_vfio_port >= OPENVMM_VFIO_COLDPLUG_PORT_COUNT {
                             return Err(anyhow!(
                                 "openvmm: too many VFIO devices (limit {}), cannot cold-plug BDF {}",
                                 OPENVMM_VFIO_COLDPLUG_PORT_COUNT,
-                                hostdev.bus_slot_func
+                                full_bdf
                             ));
                         }
 
@@ -413,7 +429,7 @@ impl OpenVmmInner {
                             .with_context(|| {
                                 format!(
                                     "openvmm: failed to open VFIO group {} for BDF {}",
-                                    host_path, hostdev.bus_slot_func
+                                    host_path, full_bdf
                                 )
                             })?;
 
@@ -425,15 +441,13 @@ impl OpenVmmInner {
 
                         info!(
                             sl!(),
-                            "openvmm: assigning VFIO BDF {} to port {}",
-                            hostdev.bus_slot_func,
-                            port_name
+                            "openvmm: assigning VFIO BDF {} to port {}", full_bdf, port_name
                         );
 
                         pcie_devices.push(PcieDeviceConfig {
                             port_name,
                             resource: vfio_assigned_device_resources::VfioDeviceHandle {
-                                pci_id: hostdev.bus_slot_func.clone(),
+                                pci_id: full_bdf,
                                 group: group_fd,
                             }
                             .into_resource(),

--- a/src/runtime-rs/crates/hypervisor/src/openvmm/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/openvmm/vmm_instance.rs
@@ -87,15 +87,30 @@ impl VmmInstance {
             .spawn(move || {
                 // Set up tracing for the VmWorker thread.
                 // Write openvmm tracing output to a log file for debugging.
+                //
+                // We install the subscriber globally (rather than thread-local
+                // via `set_default`) because `DefaultPool::run_with` may
+                // execute spawned tasks on its own internal threads where a
+                // thread-local subscriber would not be visible.
+                //
+                // `try_init()` is a no-op if a global subscriber is already
+                // installed (e.g. by an earlier sandbox in the same shim
+                // process). Kata normally creates a fresh shim per sandbox,
+                // so the first launch wins and configures verbosity.
+                //
+                // Verbosity is controlled by the `RUST_LOG` environment
+                // variable; default is `info`. For VM-launch debugging use
+                // e.g. `RUST_LOG=info,openvmm=debug,virt_mshv=debug`.
                 if let Some(ref dir) = log_dir {
                     let log_file_path = format!("{}/openvmm-worker.log", dir);
                     if let Ok(file) = std::fs::File::create(&log_file_path) {
-                        let subscriber = tracing_subscriber::fmt()
+                        let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+                            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+                        let _ = tracing_subscriber::fmt()
                             .with_writer(std::sync::Mutex::new(file))
                             .with_ansi(false)
-                            .finish();
-                        // Use set_default (thread-local) not set_global_default
-                        let _guard = tracing::subscriber::set_default(subscriber);
+                            .with_env_filter(filter)
+                            .try_init();
                     }
                 }
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -30,6 +30,7 @@ use containerd_shim_protos::events::task::{TaskExit, TaskOOM};
 ))]
 use hypervisor::ch::CloudHypervisor;
 use hypervisor::device::topology::PCIePort;
+use hypervisor::device::util::{get_host_path, DEVICE_TYPE_CHAR};
 use hypervisor::remote::Remote;
 use hypervisor::VfioDeviceBase;
 use hypervisor::VsockConfig;
@@ -227,7 +228,29 @@ impl VirtSandbox {
             None
         };
 
-        let vfio_devices = self.prepare_coldplug_cdi_devices(sandbox_config).await?;
+        // Cold-plug VFIO devices for hypervisors that build the PCIe
+        // topology at VM-creation time (notably openvmm). Two sources
+        // are unioned, in declaration order:
+        //
+        //   1. CDI via the kubelet Pod Resources API
+        //      (`prepare_coldplug_cdi_devices`). Upstream pattern; used
+        //      when the device-plugin registers with the Pod Resources
+        //      socket and emits CDI device nodes. This is the K8s path.
+        //   2. Raw OCI `linux.devices`
+        //      (`prepare_coldplug_raw_vfio_devices`). Standalone-container
+        //      path (`ctr --device /dev/vfio/0`). Aligned with the
+        //      upstream PR that adds raw VFIO cold-plug support to
+        //      runtime-rs.
+        //
+        // Each source independently gates on the `cold_plug_vfio`
+        // hypervisor config. Hot-plug back-ends (qemu, dragonball, ...)
+        // still pick devices up via the regular `handler_devices`
+        // post-start path.
+        let mut vfio_devices = self.prepare_coldplug_cdi_devices(sandbox_config).await?;
+        vfio_devices.extend(
+            self.prepare_coldplug_raw_vfio_devices(sandbox_config)
+                .await?,
+        );
         if !vfio_devices.is_empty() {
             info!(
                 sl!(),
@@ -345,6 +368,100 @@ impl VirtSandbox {
             };
             vfio_configs.push(dev_info);
         }
+
+        Ok(vfio_configs
+            .into_iter()
+            .map(ResourceConfig::VfioDeviceModern)
+            .collect())
+    }
+
+    // Raw VFIO cold-plug fallback for standalone containers
+    // (e.g. `ctr --device /dev/vfio/0`). Reads the OCI spec from the
+    // bundle and cold-plugs any VFIO char devices found in
+    // `linux.devices` before VM boot, mirroring the Go runtime's
+    // `coldOrHotPlugVFIO()`. Returns empty when `cold_plug_vfio` is not
+    // configured, when the bundle path is unavailable, or when the OCI
+    // spec is missing/has no eligible devices.
+    async fn prepare_coldplug_raw_vfio_devices(
+        &self,
+        sandbox_config: &SandboxConfig,
+    ) -> Result<Vec<ResourceConfig>> {
+        let hypervisor_config = self.hypervisor.hypervisor_config().await;
+        let cold_plug_vfio = &hypervisor_config.device_info.cold_plug_vfio;
+        if cold_plug_vfio.is_empty() || cold_plug_vfio == "no-port" {
+            return Ok(Vec::new());
+        }
+
+        let port = match cold_plug_vfio.as_str() {
+            "root-port" => PCIePort::RootPort,
+            other => {
+                return Err(anyhow!(
+                    "unsupported cold_plug_vfio value {:?}; only \"root-port\" is supported",
+                    other
+                ))
+            }
+        };
+
+        let bundle = &sandbox_config.state.bundle;
+        if bundle.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let spec_path = format!("{}/{}", bundle, spec::OCI_SPEC_CONFIG_FILE_NAME);
+        let oci_spec = match oci::Spec::load(&spec_path) {
+            Ok(s) => s,
+            Err(e) => {
+                info!(
+                    sl!(),
+                    "no OCI spec at {:?}: {:?}, skipping raw VFIO cold-plug", spec_path, e
+                );
+                return Ok(Vec::new());
+            }
+        };
+
+        let linux_devices = oci_spec
+            .linux()
+            .as_ref()
+            .and_then(|l| l.devices().as_ref())
+            .cloned()
+            .unwrap_or_default();
+
+        let mut vfio_configs = Vec::new();
+        for d in linux_devices.iter() {
+            if d.typ() != oci::LinuxDeviceType::C {
+                continue;
+            }
+            let host_path = match get_host_path(DEVICE_TYPE_CHAR, d.major(), d.minor()) {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(
+                        sl!(),
+                        "failed to resolve host path for {:?}: {:?}",
+                        d.path(),
+                        e
+                    );
+                    continue;
+                }
+            };
+            // Only process VFIO passthrough devices under /dev/vfio/*.
+            // Skip non-VFIO devices and the legacy VFIO control node
+            // (/dev/vfio/vfio).
+            if !host_path.starts_with("/dev/vfio/") || host_path == "/dev/vfio/vfio" {
+                continue;
+            }
+            vfio_configs.push(VfioDeviceBase {
+                host_path: host_path.clone(),
+                iommu_group_devnode: PathBuf::from(&host_path),
+                dev_type: "c".to_string(),
+                port,
+                hostdev_prefix: "vfio_device".to_owned(),
+                ..Default::default()
+            });
+        }
+        info!(
+            sl!(),
+            "raw VFIO cold-plug candidates: {:?}", vfio_configs
+        );
 
         Ok(vfio_configs
             .into_iter()

--- a/tests/hypervisor_helpers.sh
+++ b/tests/hypervisor_helpers.sh
@@ -17,6 +17,7 @@ ALL_HYPERVISORS=(
 	"clh"
 	"clh-runtime-rs"
 	"dragonball"
+	"openvmm"
 	"qemu"
 	"qemu-runtime-rs"
 	"qemu-nvidia-gpu"


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
Feel free to delete sections of the template which do not apply to your PR, or add additional details
-->

###### Merge Checklist  <!-- REQUIRED -->
<!-- You can set them now ([x]) or set them later using the Github UI -->
<!-- **All** boxes should be checked before merging the PR *(just tick any boxes which don't apply to this PR)* -->
- [X] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [X] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [X] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [ ] genPolicy only: Builds on Windows
- [ ] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Enables VFIO PCI cold-plug for the OpenVMM runtime-rs back-end so GPUs (and other VFIO devices) can be attached to a Kata pod under the [openvmm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) shim. OpenVMM builds its PCIe topology at VM-creation time and cannot accept VFIO devices via the post-[start_vm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) add_device path that hot-plug back-ends rely on, so the device set must be known before [start_vm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) runs.

This PR layers two changes on top of [microsoft/sprt/openvmm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html)'s existing [prepare_coldplug_cdi_devices](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (the upstream Pod Resources API / CDI path added by Alex Lyn in 4f618d09d5 "runtime-rs: Add Pod Resources CDI discovery in sandbox"):

runtime-rs/openvmm: add raw OCI VFIO cold-plug + correctness fixes (1 commit, 4 files)

Two cold-plug sources are now unioned in VirtSandbox::start:

prepare_coldplug_cdi_devices — already upstream; K8s via the kubelet Pod Resources API.
prepare_coldplug_raw_vfio_devices (NEW) — standalone-container path (ctr --device /dev/vfio/<group>). Reads the OCI spec from the sandbox bundle and cold-plugs any [/dev/vfio/<group>](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) char device declared in [linux.devices](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Mirrors the Go runtime's coldOrHotPlugVFIO() and is intentionally shaped to match the in-flight PR from @BbolroC (commit b66713d9d5 "runtime-rs: add raw VFIO device cold-plug support"), so a future merge between the two is mechanical rather than architectural.
Both helpers return [Vec<ResourceConfig::VfioDeviceModern>](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html)ResourceConfig::VfioDeviceModern and flow through the same [resource_configs.extend(...)](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) path the upstream CDI helper already uses — no [do_handle_device](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) direct calls, no new [Sandbox](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) trait method, no fight with pending_devices.clear() in [OpenVmmInner::prepare_vm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Each helper gates on the [cold_plug_vfio](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) hypervisor config and only accepts the documented [root-port](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) mode.

Hot-plug back-ends (qemu, dragonball, …) are unchanged and continue to attach VFIO devices through the regular [handler_devices](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) post-start path.

Also folds in two correctness fixes that are independent of the architectural change above and are still required against [sprt/openvmm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html):

[inner_hypervisor.rs](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html): when cold-plugging a VFIO device, OpenVMM needs the full PCI BDF including the segment/domain (e.g. 0001:00:00.0) to resolve [/sys/bus/pci/devices/<full_bdf>](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html). HostDevice splits this into [domain](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) ("0001") and [bus_slot_func](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) ("00:00.0"); recombine them and reject entries with an empty domain instead of silently producing a bad path.
[vmm_instance.rs](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html): switch the OpenVMM VmWorker tracing subscriber from thread-local (set_default) to global (try_init) and wire RUST_LOG through EnvFilter. The thread-local subscriber was invisible from tasks spawned onto DefaultPool::run_with's internal threads, so OpenVMM-side traces never reached [openvmm-worker.log](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Enables the [env-filter](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) feature on [tracing-subscriber](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for the hypervisor crate.
[tests: add openvmm to ALL_HYPERVISORS list](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (1 commit, 1 file)

[tests/hypervisor_helpers.sh::ALL_HYPERVISORS](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) lists every hypervisor that the kata test harness accepts via KATA_HYPERVISOR=…. It was introduced in 2f3fec9727 ("tests: Add new hypervisor helper script") and made authoritative by ddc36060d2 ("gha: k8s: reject unsupported KATA_HYPERVISOR values"), which causes [gha-run.sh](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to die on any value not in the list.

The earlier kata-deploy work that registered openvmm as a first-class shim (8258d0bb70 "kata-deploy: add 'openvmm' as a first-class shim") missed this file, so KATA_HYPERVISOR=openvmm gha-run.sh run-tests dies with [Unsupported KATA_HYPERVISOR=openvmm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Adding [openvmm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to ALL_HYPERVISORS lets it pass the is_supported_hypervisor gate; no new helper category is needed since openvmm is neither TEE, GPU-TEE, SE, CCA, nor firecracker.
###### Associated issues  <!-- optional -->
<!-- Link to Github issues if possible. -->

###### Links to CVEs  <!-- optional -->

###### Test Methodology
<!-- How was this test validated? i.e. local build, pipeline build etc. -->
End-to-end validated on a Standard_ND96amsr_A100_v4 bench (azlkatal1000002, AzureLinux 3, MSHV L0 → AzureLinux L1 → OpenVMM L2):

End-to-end validated on a Standard_ND96amsr_A100_v4 bench (azlkatal1000002, AzureLinux 3, MSHV L0 → AzureLinux L1 → OpenVMM L2):

Built kata-deploy via [06-prepare-and-deploy-kata.sh](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from the [KataForGPUs scripts repo](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which clones this branch, builds the NVIDIA-flavored kernel + rootfs + agent + runtime-rs shim, packages the [kata-deploy](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) tarball, and deploys it to a single-node k3s cluster with the [kata-vfio-pci-device-plugin](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) daemonset.
Launched a single-GPU Kata pod via [09-create-a-GPU-enabled-Kata-POD.sh](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which now produces a vanilla manifest (per-class vfio.io/{gpu,nvswitch,ib} resource requests only — no pod annotation). The runtime-rs shim discovers the allocated devices via [prepare_coldplug_cdi_devices](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) against the kubelet Pod Resources socket and cold-plugs them before [start_vm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Verified:
[journalctl -t kata](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html): see [openvmm: PCIe root ports: 5 static + 16 block-hotplug + 1 VFIO cold-plug = 22](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html), the CDI discovery log line, and [openvmm: assigning VFIO BDF 0001:00:00.0 to port vfio0](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
In-guest: lspci | grep NVIDIA shows the GPU, modprobe nvidia succeeds, nvidia-smi reports the device.
Standalone-container path validated with a ctr --device /dev/vfio/<group> ... run against the same runtime; the new [prepare_coldplug_raw_vfio_devices](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) picks up the [linux.devices](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) entry from the OCI bundle and cold-plugs it the same way.
KATA_HYPERVISOR=openvmm gha-run.sh deploy-kata no longer dies on the is_supported_hypervisor gate (this PR's second commit).
Existing [qemu](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / clh / clh-runtime-rs paths are unchanged — only [openvmm](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) takes the new code paths, and within openvmm the new helper no-ops unless [cold_plug_vfio = "root-port"](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is configured and the OCI bundle declares a VFIO [linux.devices](vscode-file://vscode-app/c:/Users/jocelynb/AppData/Local/Programs/Microsoft%20VS%20Code/6a44c352bd/resources/app/out/vs/code/electron-browser/workbench/workbench.html) entry.