### PR TITLE
Michaelx/kata runtime snapshot endpoint + cli command

### DIFF
--- a/src/runtime/cmd/kata-runtime/main.go
+++ b/src/runtime/cmd/kata-runtime/main.go
@@ -127,6 +127,7 @@ var runtimeCommands = []cli.Command{
 	kataVolumeCommand,
 	kataIPTablesCommand,
 	kataPolicyCommand,
+	snapshotCLICommand,
 }
 
 // runtimeBeforeSubcommands is the function to run before command-line

--- a/src/runtime/cmd/kata-runtime/main.go
+++ b/src/runtime/cmd/kata-runtime/main.go
@@ -128,6 +128,7 @@ var runtimeCommands = []cli.Command{
 	kataIPTablesCommand,
 	kataPolicyCommand,
 	snapshotCLICommand,
+	restoreCLICommand,
 }
 
 // runtimeBeforeSubcommands is the function to run before command-line

--- a/src/runtime/cmd/kata-runtime/restore.go
+++ b/src/runtime/cmd/kata-runtime/restore.go
@@ -1,0 +1,662 @@
+// Copyright (c) 2026 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	containerdshim "github.com/kata-containers/kata-containers/src/runtime/pkg/containerd-shim-v2"
+	"github.com/urfave/cli"
+)
+
+// restore boots a snapshot dir as a Mode A side-by-side CLONE: a brand-new
+// cloud-hypervisor running next to the still-alive original. The clone has no shim
+// or sandbox owner, so this command itself drives all the layers the shim would: it
+// copies+patches the config, creates a host tap, launches clh via systemd-run, calls
+// vm.restore/vm.resume over the clh api socket, then re-IPs the clone's eth0 via
+// kata-agent-ctl (without which the clone collides with the original's IP). COW is
+// automatic: CLH opens the snapshot's memory-ranges MAP_PRIVATE, so the clone
+// diverges and the original's RAM is never written. This mirrors the proven manual
+// restore runbook (nodepool0 counter/pyruntime demos) 1:1.
+
+const (
+	// restoreWorkBase holds per-clone working dirs (tmpfs). Each clone gets
+	// /tmp/<clone-id>/ with the patched config + symlinked memory-ranges, the clh api
+	// socket, the agent vsock, the clh log, and clone.json metadata.
+	restoreWorkBase = "/tmp"
+
+	// clone networking is auto-allocated, not user-supplied. Each clone N gets tap
+	// kat<N> and the point-to-point subnet 192.168.<tapSubnetBase+N>.0/24 (host .2,
+	// guest .1). tap<N> is claimed atomically by `ip tuntap add` (fails EBUSY if the
+	// device exists), which is what lets N>1 clones coexist without a TOCTOU.
+	tapPrefix     = "kat"
+	tapSubnetBase = 240 // -> 192.168.240.x for clone 0, .241 for clone 1, ...
+	maxClones     = 15  // 192.168.240..254; one tap/subnet each
+
+	// clh + agent binaries are resolved from PATH (falling back to these), not flags.
+	defaultClhBin    = "cloud-hypervisor"
+	defaultAgentCtl  = "kata-agent-ctl"
+	fallbackAgentCtl = "/kata-containers/src/tools/agent-ctl/target/release/kata-agent-ctl"
+)
+
+// cloneNet is the auto-allocated networking for one clone.
+type cloneNet struct {
+	tap     string // kat<N>
+	hostIP  string // 192.168.<base+N>.2/24
+	guestIP string // 192.168.<base+N>.1/24
+}
+
+// cloneMeta records exactly what a restore created so `kill` can clean it precisely.
+type cloneMeta struct {
+	ID      string `json:"id"`
+	Tap     string `json:"tap"`
+	HostIP  string `json:"host_ip"`
+	GuestIP string `json:"guest_ip"`
+	Unit    string `json:"unit"`
+	Vsock   string `json:"vsock"`
+	Sock    string `json:"sock"`
+	Source  string `json:"source"`
+}
+
+var restoreCLICommand = cli.Command{
+	Name:      "restore",
+	Usage:     "restore a Kata Containers snapshot as a running clone",
+	ArgsUsage: "--from <snapshot>",
+	Flags: []cli.Flag{
+		cli.StringFlag{Name: "from", Usage: "snapshot source: a name under " + containerdshim.SnapshotBaseDir + ", or a path"},
+		cli.StringFlag{Name: "name", Usage: "clone id (default: clone-<hex>)"},
+		// advanced/hidden: binary overrides for non-standard nodes. Networking is
+		// auto-allocated and intentionally NOT exposed.
+		cli.StringFlag{Name: "clh-bin", Usage: "cloud-hypervisor binary (default: from PATH)", Hidden: true},
+		cli.StringFlag{Name: "agent-ctl", Usage: "kata-agent-ctl binary (default: from PATH)", Hidden: true},
+	},
+	// kill is a subcommand; with no matching subcommand this Action runs.
+	Subcommands: []cli.Command{restoreKillCommand},
+	Action:      restoreAction,
+}
+
+func restoreAction(c *cli.Context) error {
+	from := c.String("from")
+	if from == "" {
+		return fmt.Errorf("--from is required")
+	}
+	src, err := resolveSource(from)
+	if err != nil {
+		return err
+	}
+	clhBin := resolveBin(c.String("clh-bin"), defaultClhBin, "")
+	agentCtl := resolveBin(c.String("agent-ctl"), defaultAgentCtl, fallbackAgentCtl)
+
+	id := genCloneID(c.String("name"))
+	if err := validateCloneID(id); err != nil {
+		return err
+	}
+	cloneDir := filepath.Join(restoreWorkBase, id)
+	unit := "clh-" + id
+	sock := filepath.Join(cloneDir, "clh.sock")
+	vsock := filepath.Join(cloneDir, "clone-vm.vsock")
+
+	if _, err := os.Stat(cloneDir); err == nil {
+		return fmt.Errorf("clone %q already exists; run `kata-runtime restore kill %s` first", id, id)
+	}
+
+	// allocate a free tap + subnet by atomically claiming the tap (add fails EBUSY if
+	// taken). this both picks the slot and reserves it -- no check-then-create race.
+	net, err := allocateCloneNet()
+	if err != nil {
+		return err
+	}
+
+	ok := false
+	defer func() {
+		// roll back whatever we created if we bail out mid-flight.
+		if !ok {
+			killClh(sock)
+			deleteTap(net.tap)
+			os.RemoveAll(cloneDir)
+		}
+	}()
+
+	// proven manual restore STEP 1: build the clone's private working dir at 0700
+	// (config.json + state.json copied; memory-ranges symlinked, not duplicated).
+	if err := prepareCopy(src, cloneDir); err != nil {
+		return err
+	}
+
+	// proven manual restore STEP 2: jq-equivalent patch (5 edits, .file untouched);
+	// returns the MAC to reuse for the re-IP.
+	mac, err := patchConfig(cloneDir, vsock, net.tap)
+	if err != nil {
+		return err
+	}
+
+	// proven manual restore STEP 3: finish wiring the allocated tap (addr + route).
+	if err := setupTap(net); err != nil {
+		return err
+	}
+
+	// proven manual restore STEP 4: launch a fresh cloud-hypervisor.
+	if err := launchCLH(cloneDir, clhBin, unit, sock); err != nil {
+		return err
+	}
+
+	// proven manual restore STEP 5: restore + resume + wait for Running.
+	if err := clhPut(sock, "vm.restore", map[string]interface{}{"source_url": "file://" + cloneDir, "prefault": false}); err != nil {
+		return fmt.Errorf("vm.restore: %s", err)
+	}
+	if err := clhPut(sock, "vm.resume", nil); err != nil {
+		return fmt.Errorf("vm.resume: %s", err)
+	}
+	if err := waitRunning(sock); err != nil {
+		return err
+	}
+
+	// proven manual restore STEP 6: re-IP the clone's eth0 (verify + retry). we ALWAYS
+	// assign a fresh IP -- restore never tries to preserve the original's pod IP.
+	if err := reIP(agentCtl, vsock, mac, net.guestIP); err != nil {
+		return err
+	}
+
+	meta := cloneMeta{ID: id, Tap: net.tap, HostIP: net.hostIP, GuestIP: net.guestIP, Unit: unit, Vsock: vsock, Sock: sock, Source: src}
+	if err := writeCloneMeta(cloneDir, meta); err != nil {
+		return err
+	}
+	ok = true
+
+	guestAddr, _ := splitCIDR(net.guestIP)
+	fmt.Fprintf(defaultOutputFile, "clone %s up\n", id)
+	fmt.Fprintf(defaultOutputFile, "guest IP: %s   (inbound only - no egress/default route)\n", guestAddr)
+	fmt.Fprintf(defaultOutputFile, "probe:    curl http://%s:<port>/   (counter app on :9999, pyruntime on :8888)\n", guestAddr)
+	fmt.Fprintf(defaultOutputFile, "note:     %s is held MAP_PRIVATE; do not `snapshot delete` it while this clone is live\n", src)
+	// loud disclosure: a side-by-side clone shares the original's kernel RNG state and
+	// frozen wall/monotonic clock. unsafe for workloads that mint secrets (tokens,
+	// UUIDs, TLS nonces) or depend on time post-restore. RNG reseed + SetGuestDateTime
+	// are deferred future work (security review C1/H2/M2, §13).
+	fmt.Fprintf(defaultOutputFile, "WARNING:  clone shares the original's RNG state and wall clock - unsafe for secret-minting or time-dependent workloads (RNG reseed + clock sync are future work, security-review §13)\n")
+	return nil
+}
+
+var restoreKillCommand = cli.Command{
+	Name:      "kill",
+	Usage:     "tear down a restore clone (stop clh, delete tap, remove working dir)",
+	ArgsUsage: "<clone-id>",
+	Action:    killAction,
+}
+
+func killAction(c *cli.Context) error {
+	id := c.Args().First()
+	if id == "" {
+		return fmt.Errorf("clone id is required: kata-runtime restore kill <clone-id>")
+	}
+	if err := validateCloneID(id); err != nil {
+		return err
+	}
+	cloneDir := filepath.Join(restoreWorkBase, id)
+	sock := filepath.Join(cloneDir, "clh.sock")
+	tap := ""
+	// recover the exact tap/sock this clone used from its clone.json (written for
+	// every successful restore; the tap is auto-allocated so there is no default).
+	if b, err := os.ReadFile(filepath.Join(cloneDir, "clone.json")); err == nil {
+		var meta cloneMeta
+		if json.Unmarshal(b, &meta) == nil {
+			if meta.Sock != "" {
+				sock = meta.Sock
+			}
+			if meta.Tap != "" {
+				tap = meta.Tap
+			}
+		}
+	}
+	killClh(sock)
+	if tap != "" {
+		deleteTap(tap)
+		if tapExists(tap) {
+			fmt.Fprintf(defaultOutputFile, "warning: tap %s still present; remove with: ip tuntap del mode tap %s\n", tap, tap)
+		}
+	}
+	os.RemoveAll(cloneDir)
+	fmt.Fprintf(defaultOutputFile, "cleaned %s\n", id)
+	return nil
+}
+
+// resolveSource maps --from to a snapshot dir and checks it looks like one.
+func resolveSource(from string) (string, error) {
+	// a bare name (no slash) must stay a direct child of SnapshotBaseDir -- reject
+	// `--from ..` style traversal, mirroring the snapshot delete guard. An explicit
+	// path (with a slash) is the caller's responsibility and used verbatim.
+	if !strings.Contains(from, "/") {
+		clean := filepath.Clean(filepath.Join(containerdshim.SnapshotBaseDir, from))
+		if filepath.Dir(clean) != filepath.Clean(containerdshim.SnapshotBaseDir) {
+			return "", fmt.Errorf("invalid snapshot name %q: must not contain path separators or ..", from)
+		}
+	}
+	dir := resolvePath(from)
+	fi, err := os.Stat(dir)
+	if err != nil || !fi.IsDir() {
+		return "", fmt.Errorf("snapshot not found: %s", dir)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.json")); err != nil {
+		return "", fmt.Errorf("not a snapshot dir (no config.json): %s", dir)
+	}
+	return dir, nil
+}
+
+// resolvePath is the pure name->path rule: a bare name (no slash) lives under
+// SnapshotBaseDir; anything with a slash is used verbatim.
+func resolvePath(from string) string {
+	if strings.Contains(from, "/") {
+		return from
+	}
+	return filepath.Join(containerdshim.SnapshotBaseDir, from)
+}
+
+// genCloneID returns name if given, else a random clone-<hex> id. If the entropy
+// read fails (effectively never for crypto/rand), it falls back to a pid+nanotime
+// suffix so we never silently emit a fixed all-zero id; the caller's dir-exists guard
+// catches any residual collision.
+func genCloneID(name string) string {
+	if name != "" {
+		return name
+	}
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("clone-%x%x", os.Getpid(), time.Now().UnixNano())
+	}
+	return "clone-" + hex.EncodeToString(b)
+}
+
+// validateCloneID rejects ids that would let the working dir escape restoreWorkBase.
+// The id becomes /tmp/<id>, which restore creates (cp/symlink as root) and kill
+// removes (os.RemoveAll as root) -- so a "../etc" style id is a write/delete primitive.
+// Mirrors the snapshot delete guard (snapshot.go S2): the cleaned join must stay a
+// direct child of restoreWorkBase.
+func validateCloneID(id string) error {
+	dir := filepath.Clean(filepath.Join(restoreWorkBase, id))
+	if filepath.Dir(dir) != filepath.Clean(restoreWorkBase) {
+		return fmt.Errorf("invalid clone id %q: must not contain path separators or ..", id)
+	}
+	return nil
+}
+
+// prepareCopy builds the clone's private working dir from the snapshot WITHOUT
+// duplicating the ~2 GiB memory-ranges. config.json (patched next) + state.json are
+// what source_url reads; the guest RAM is backed by config's .memory.zones[].file,
+// which stays pointed at the ORIGINAL snapshot's memory-ranges (opened MAP_PRIVATE ->
+// COW, original never written). We symlink memory-ranges into the clone dir so the
+// source_url dir still contains the expected file name at zero RAM cost, while .file
+// (untouched by patchConfig) resolves to the original. This is the documented H4
+// source-dependency: the original snapshot must outlive the clone.
+func prepareCopy(src, cloneDir string) error {
+	if err := os.MkdirAll(cloneDir, 0700); err != nil {
+		return err
+	}
+	for _, f := range []string{"config.json", "state.json"} {
+		data, err := os.ReadFile(filepath.Join(src, f))
+		if err != nil {
+			return fmt.Errorf("read %s: %s", f, err)
+		}
+		if err := os.WriteFile(filepath.Join(cloneDir, f), data, 0600); err != nil {
+			return err
+		}
+	}
+	// symlink, do NOT copy, the 2 GiB RAM file.
+	if err := os.Symlink(filepath.Join(src, "memory-ranges"), filepath.Join(cloneDir, "memory-ranges")); err != nil {
+		return fmt.Errorf("symlink memory-ranges: %s", err)
+	}
+	return nil
+}
+
+// patchConfig applies the proven 5 edits to the clone's config.json and returns the
+// MAC to reuse for the agent re-IP. It deliberately does NOT touch
+// .memory.zones[].file: COW comes from .memory.shared=false +
+// .memory.zones[].shared=false, which makes CLH open the (original) memory-ranges
+// MAP_PRIVATE so the source snapshot is never written.
+func patchConfig(cloneDir, vsock, tap string) (string, error) {
+	path := filepath.Join(cloneDir, "config.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return "", err
+	}
+	mac, err := patchConfigMap(cfg, vsock, tap)
+	if err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return mac, os.WriteFile(path, out, 0600)
+}
+
+// patchConfigMap mutates cfg in place (the testable core of patchConfig).
+func patchConfigMap(cfg map[string]interface{}, vsock, tap string) (string, error) {
+	netArr, ok := cfg["net"].([]interface{})
+	if !ok || len(netArr) == 0 {
+		return "", fmt.Errorf("config.json: .net[0] missing")
+	}
+	net0, ok := netArr[0].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("config.json: .net[0] not an object")
+	}
+	net0["tap"] = tap // attach the clone to its own host tap
+	net0["fds"] = nil // drop the original's inherited tap fds
+	mac, _ := net0["mac"].(string)
+	if mac == "" {
+		return "", fmt.Errorf("config.json: .net[0].mac missing")
+	}
+
+	vs, ok := cfg["vsock"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("config.json: .vsock missing")
+	}
+	vs["socket"] = vsock // unique per-clone agent vsock (clh demuxes by this path)
+
+	mem, ok := cfg["memory"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("config.json: .memory missing")
+	}
+	mem["shared"] = false // MAP_PRIVATE -> COW; do NOT touch .zones[].file
+	if zones, ok := mem["zones"].([]interface{}); ok {
+		for _, z := range zones {
+			if zm, ok := z.(map[string]interface{}); ok {
+				zm["shared"] = false
+			}
+		}
+	}
+	return mac, nil
+}
+
+// allocateCloneNet finds a free clone slot by atomically claiming a tap: `ip tuntap
+// add kat<N>` fails EBUSY if the device already exists, so the first N that adds
+// cleanly is ours and is now reserved -- no separate existence check, no TOCTOU. The
+// matching subnet 192.168.<base+N>.0/24 is implied by N. On success the tap exists
+// (DOWN); setupTap brings it up and assigns addresses.
+func allocateCloneNet() (cloneNet, error) {
+	for n := 0; n < maxClones; n++ {
+		tap := fmt.Sprintf("%s%d", tapPrefix, n)
+		if err := exec.Command("ip", "tuntap", "add", "mode", "tap", tap).Run(); err != nil {
+			continue // device busy (or add failed) -> try the next slot
+		}
+		octet := tapSubnetBase + n
+		return cloneNet{
+			tap:     tap,
+			hostIP:  fmt.Sprintf("192.168.%d.2/24", octet),
+			guestIP: fmt.Sprintf("192.168.%d.1/24", octet),
+		}, nil
+	}
+	return cloneNet{}, fmt.Errorf("no free clone slot (all %d taps %s0..%s%d in use); kill an existing clone", maxClones, tapPrefix, tapPrefix, maxClones-1)
+}
+
+// resolveBin picks an explicit override, else the first of (name-on-PATH, fallback)
+// that exists, else the bare name (let exec surface the error at use).
+func resolveBin(override, name, fallback string) string {
+	if override != "" {
+		return override
+	}
+	if p, err := exec.LookPath(name); err == nil {
+		return p
+	}
+	if fallback != "" {
+		if _, err := os.Stat(fallback); err == nil {
+			return fallback
+		}
+	}
+	return name
+}
+
+// setupTap finishes wiring an already-allocated tap: bring it up, assign the host IP,
+// and add a /32 route to the guest. The tap itself was created (and thereby reserved)
+// by allocateCloneNet.
+func setupTap(net cloneNet) error {
+	guestAddr, _ := splitCIDR(net.guestIP)
+	steps := [][]string{
+		{"link", "set", "dev", net.tap, "up"},
+		{"a", "add", net.hostIP, "dev", net.tap},
+		{"route", "add", guestAddr + "/32", "dev", net.tap},
+	}
+	for _, s := range steps {
+		if out, err := exec.Command("ip", s...).CombinedOutput(); err != nil {
+			return fmt.Errorf("ip %s: %s (%s)", strings.Join(s, " "), err, strings.TrimSpace(string(out)))
+		}
+	}
+	return nil
+}
+
+// launchCLH starts a fresh cloud-hypervisor in its own transient systemd scope so it
+// survives this process exiting. stdin is /dev/null and the child gets its own
+// session (Setsid) to dodge SIGTTOU, which would otherwise stop clh and hang every
+// API call. Mirrors the proven `systemd-run --scope --slice=- --collect ... </dev/null & disown`.
+func launchCLH(cloneDir, clhBin, unit, sock string) error {
+	logPath := filepath.Join(cloneDir, "clh-restore.log")
+	logf, err := os.Create(logPath)
+	if err != nil {
+		return err
+	}
+	defer logf.Close()
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		return err
+	}
+	defer devnull.Close()
+
+	args := []string{
+		"--unit=" + unit, "--scope", "--slice=-", "--collect", "--quiet",
+		clhBin, "--api-socket", sock, "-v",
+	}
+	cmd := exec.Command("systemd-run", args...)
+	cmd.Stdin = devnull
+	cmd.Stdout = logf
+	cmd.Stderr = logf
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("systemd-run cloud-hypervisor: %s", err)
+	}
+
+	// wait for the api socket to appear (clh is up once it's listening).
+	for i := 0; i < 80; i++ {
+		if isSocket(sock) {
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return fmt.Errorf("clh api socket never appeared: %s (see %s)", sock, logPath)
+}
+
+// clhClient builds an http client that dials a CLH api unix socket. Mirrors the
+// in-tree shimclient.buildUnixSocketClient idiom, pointed at the raw clh socket.
+func clhClient(sock string) *http.Client {
+	return &http.Client{
+		Timeout: 90 * time.Second,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			Dial: func(_, _ string) (net.Conn, error) {
+				return net.Dial("unix", sock)
+			},
+		},
+	}
+}
+
+// clhPut PUTs a json body to a CLH api path and expects 204/200.
+func clhPut(sock, apiPath string, body interface{}) error {
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			return err
+		}
+	}
+	req, err := http.NewRequest(http.MethodPut, "http://localhost/api/v1/"+apiPath, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := clhClient(sock).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// waitRunning polls vm.info until the clone reports Running.
+func waitRunning(sock string) error {
+	for i := 0; i < 40; i++ {
+		if clhState(sock) == "Running" {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("clh did not reach Running state (see the clh-restore.log in the clone dir)")
+}
+
+func clhState(sock string) string {
+	resp, err := clhClient(sock).Get("http://localhost/api/v1/vm.info")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	var info struct {
+		State string `json:"state"`
+	}
+	json.NewDecoder(resp.Body).Decode(&info)
+	return info.State
+}
+
+// reIP reconfigures the clone's eth0 over hybrid-vsock so it stops colliding with the
+// original's IP. UpdateInterface logs "FIXME not fully implemented" but still adds the
+// IP; it's flaky, so we poll ListInterfaces and retry once.
+func reIP(agentCtl, vsock, mac, guestIP string) error {
+	addr, mask := splitCIDR(guestIP)
+	ifJSON := fmt.Sprintf(`UpdateInterface json://{"interface": {"name": "eth0", "device": "", "mtu": 1500, "hwAddr": "%s", "IPAddresses": [{"family": 0, "address": "%s", "mask": "%s"}]}}`, mac, addr, mask)
+	server := "unix://" + vsock
+	for attempt := 0; attempt < 2; attempt++ {
+		// timeout 15: kata-agent-ctl can hang after the RPC actually succeeds.
+		exec.Command("timeout", "15", agentCtl, "connect", "--server-address", server, "--hybrid-vsock", "true", "-c", ifJSON).Run()
+		// the IP takes a few seconds to settle (5s counter / 8s pyruntime); poll.
+		for i := 0; i < 6; i++ {
+			time.Sleep(2 * time.Second)
+			if ipPresent(agentCtl, server, addr) {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("re-IP failed: %s not visible on eth0 after retry (check kata-agent-ctl ListInterfaces)", addr)
+}
+
+func ipPresent(agentCtl, server, addr string) bool {
+	out, _ := exec.Command("timeout", "10", agentCtl, "connect", "--server-address", server, "--hybrid-vsock", "true", "-c", "ListInterfaces").CombinedOutput()
+	// match addr as a whole token, not a substring: otherwise 192.168.240.1 would
+	// falsely match inside 192.168.240.10 (auto-allocated subnets go up to .254).
+	return hasIPToken(string(out), addr)
+}
+
+// hasIPToken reports whether addr appears in s bounded by non-IP-character runs, so
+// "192.168.240.1" does not match within "192.168.240.10".
+func hasIPToken(s, addr string) bool {
+	isIPChar := func(b byte) bool { return (b >= '0' && b <= '9') || b == '.' }
+	for i := 0; ; {
+		j := strings.Index(s[i:], addr)
+		if j < 0 {
+			return false
+		}
+		start := i + j
+		end := start + len(addr)
+		leftOK := start == 0 || !isIPChar(s[start-1])
+		rightOK := end == len(s) || !isIPChar(s[end])
+		if leftOK && rightOK {
+			return true
+		}
+		i = start + 1
+	}
+}
+
+func writeCloneMeta(cloneDir string, meta cloneMeta) error {
+	b, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(cloneDir, "clone.json"), b, 0600)
+}
+
+func tapExists(tap string) bool {
+	return exec.Command("ip", "link", "show", tap).Run() == nil
+}
+
+// deleteTap removes the host tap, retrying because the kernel releases it from a
+// dying clh asynchronously: an immediate delete races and silently no-ops, leaving
+// the tap lingering DOWN.
+func deleteTap(tap string) {
+	for i := 0; i < 20; i++ {
+		if !tapExists(tap) {
+			return
+		}
+		exec.Command("ip", "tuntap", "del", "mode", "tap", tap).Run()
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+// killClh SIGKILLs the clone's cloud-hypervisor, found by its unique api socket in
+// the process table. The match key is the per-clone "--api-socket <sock>" token, NOT
+// the binary name -- a custom --clh-bin path/name must still be killed. NOT systemctl
+// stop (--collect reaps the dead scope) and NOT pkill -f (which would match this very
+// process).
+func killClh(sock string) {
+	out, err := exec.Command("ps", "-eo", "pid,args").Output()
+	if err != nil {
+		return
+	}
+	needle := "--api-socket " + sock
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, needle) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if pid, err := strconv.Atoi(fields[0]); err == nil {
+			if p, err := os.FindProcess(pid); err == nil {
+				p.Signal(syscall.SIGKILL)
+			}
+		}
+	}
+}
+
+// splitCIDR splits "192.168.249.1/24" into ("192.168.249.1", "24"). A bare address
+// returns an empty mask.
+func splitCIDR(cidr string) (addr, mask string) {
+	if i := strings.IndexByte(cidr, '/'); i >= 0 {
+		return cidr[:i], cidr[i+1:]
+	}
+	return cidr, ""
+}
+
+func isSocket(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeSocket != 0
+}

--- a/src/runtime/cmd/kata-runtime/snapshot.go
+++ b/src/runtime/cmd/kata-runtime/snapshot.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	containerdshim "github.com/kata-containers/kata-containers/src/runtime/pkg/containerd-shim-v2"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/utils/shimclient"
+	"github.com/urfave/cli"
+)
+
+// snapshotTimeout is the whole-request deadline for the snapshot PUT. A snapshot
+// copies the full guest RAM to a fresh directory (O(N) in VM size, ~1s/GiB), so
+// it must comfortably exceed the shim-side getClhSnapshotTimeout (max(30s,10s/GiB))
+// plus pause/resume headroom. The default 3s exec timeout would abort mid-dump
+// and orphan a partial RAM file. A generous fixed ceiling avoids needing the
+// guest MemorySize client-side.
+const snapshotTimeout = 300 * time.Second
+
+var snapshotSubCmds = []cli.Command{
+	deleteSnapshotCommand,
+}
+
+var snapshotCLICommand = cli.Command{
+	Name:  "snapshot",
+	Usage: "snapshot a running Kata Containers sandbox VM",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:        "sandbox-id",
+			Usage:       "the target sandbox to snapshot",
+			Destination: &sandboxID,
+		},
+		cli.StringFlag{
+			Name:  "name",
+			Usage: "name the snapshot directory (default: the sandbox id)",
+		},
+	},
+	// delete is a subcommand; with no matching subcommand this Action runs.
+	Subcommands: snapshotSubCmds,
+	Action: func(c *cli.Context) error {
+		// sandbox-id is required for the take-snapshot action. it is NOT marked
+		// Required on the flag because that check would also fire on the
+		// `snapshot delete` subcommand path (cli v1 validates parent flags
+		// before dispatching), so we enforce it here instead.
+		if sandboxID == "" {
+			return fmt.Errorf("--sandbox-id is required")
+		}
+		if err := katautils.VerifyContainerID(sandboxID); err != nil {
+			return err
+		}
+
+		// the snapshot always lives under SnapshotBaseDir. --name only changes
+		// the leaf directory name; empty lets the shim default to <base>/<sbid>.
+		var destDir string
+		if name := c.String("name"); name != "" {
+			destDir = filepath.Join(containerdshim.SnapshotBaseDir, name)
+		}
+
+		// the shim does the pause/save/snapshot/resume work; we send the
+		// destination dir as the request body and print the path it used.
+		if err := shimclient.DoPut(sandboxID, snapshotTimeout, containerdshim.SnapshotUrl,
+			"application/octet-stream", []byte(destDir)); err != nil {
+			return fmt.Errorf("Error observed when making snapshot request: %s", err)
+		}
+
+		out := destDir
+		if out == "" {
+			out = filepath.Join(containerdshim.SnapshotBaseDir, sandboxID)
+		}
+		fmt.Fprintln(defaultOutputFile, out)
+
+		return nil
+	},
+}
+
+var deleteSnapshotCommand = cli.Command{
+	Name:  "delete",
+	Usage: "delete a snapshot directory by sandbox id or name",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:        "sandbox-id",
+			Usage:       "delete the snapshot taken for this sandbox id",
+			Destination: &sandboxID,
+		},
+		cli.StringFlag{
+			Name:  "name",
+			Usage: "delete the snapshot with this name",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		name := c.String("name")
+
+		// exactly one selector is required.
+		if (sandboxID == "") == (name == "") {
+			return fmt.Errorf("specify exactly one of --sandbox-id or --name")
+		}
+
+		target := sandboxID
+		if name != "" {
+			target = name
+		}
+
+		// delete is a node-local directory removal; a snapshot can outlive its
+		// sandbox, so there is no shim round-trip.
+		// reject path-traversal in the selector: the resolved dir must stay a
+		// direct child of SnapshotBaseDir (e.g. --name ../../etc must not escape).
+		dir := filepath.Clean(filepath.Join(containerdshim.SnapshotBaseDir, target))
+		if filepath.Dir(dir) != filepath.Clean(containerdshim.SnapshotBaseDir) {
+			return fmt.Errorf("invalid snapshot selector %q: must not contain path separators or ..", target)
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("failed to delete snapshot %s: %s", dir, err)
+		}
+
+		fmt.Fprintln(defaultOutputFile, dir)
+
+		return nil
+	},
+}

--- a/src/runtime/pkg/containerd-shim-v2/shim_management.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc/codes"
 
@@ -41,6 +42,7 @@ const (
 	PolicyUrl             = "/policy"
 	IP6TablesUrl          = "/ip6tables"
 	MetricsUrl            = "/metrics"
+	SnapshotUrl           = "/snapshot"
 )
 
 var (
@@ -295,6 +297,7 @@ func (s *service) startManagementServer(ctx context.Context, ociSpec *specs.Spec
 	m.Handle(IPTablesUrl, http.HandlerFunc(s.ipTablesHandler))
 	m.Handle(PolicyUrl, http.HandlerFunc(s.policyHandler))
 	m.Handle(IP6TablesUrl, http.HandlerFunc(s.ip6TablesHandler))
+	m.Handle(SnapshotUrl, http.HandlerFunc(s.snapshotHandler))
 	s.mountPprofHandle(m, ociSpec)
 
 	// register shim metrics
@@ -360,6 +363,155 @@ func SocketPathRust(id string) string {
 // NOTE: this code is only called by the go shim management implementation.
 func ServerSocketAddress(id string) string {
 	return fmt.Sprintf("unix://%s", SocketPathGo(id))
+}
+
+// SnapshotBaseDir is where kata-runtime snapshot dirs live by default. It is
+// the canonical default shared by the shim handler and the kata-runtime CLI.
+const SnapshotBaseDir = "/run/vc/vm/snapshots"
+
+// snapshotManifest is the small self-describing record we drop alongside the
+// cloud-hypervisor snapshot files so a future restore can identify the source.
+type snapshotManifest struct {
+	SourceSandboxID string `json:"source_sandbox_id"`
+	Timestamp       string `json:"timestamp"`
+}
+
+// snapshotHandler triggers a VM snapshot of the sandbox over the management socket.
+// the request body, when non-empty, is the destination directory; otherwise we
+// default to SnapshotBaseDir/<sandbox-id>.
+func (s *service) snapshotHandler(w http.ResponseWriter, r *http.Request) {
+	logger := shimMgtLog.WithFields(logrus.Fields{"handler": "snapshot"})
+
+	switch r.Method {
+	case http.MethodPut:
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			logger.WithError(err).Error("failed to read request body")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+		destDir := strings.TrimSpace(string(body))
+		if destDir == "" {
+			destDir = filepath.Join(SnapshotBaseDir, s.id)
+		}
+
+		if err := s.doSnapshot(context.Background(), destDir); err != nil {
+			logger.WithError(err).Error("snapshot failed")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+		fmt.Fprint(w, destDir)
+
+	default:
+		w.WriteHeader(http.StatusNotImplemented)
+	}
+}
+
+// doSnapshot pauses the VM, persists kata sandbox state, snapshots the VM memory
+// to destDir, copies the persist.json into destDir, writes a manifest, then
+// resumes the VM. the VM is always resumed (best-effort) even on failure so the
+// running pod is not left frozen.
+func (s *service) doSnapshot(ctx context.Context, destDir string) error {
+	if err := os.MkdirAll(destDir, 0700); err != nil {
+		return err
+	}
+
+	if err := s.sandbox.PauseVM(ctx); err != nil {
+		return err
+	}
+	// always try to resume so a partial failure never leaves the pod paused.
+	defer s.sandbox.ResumeVM(ctx)
+
+	// persist kata-level sandbox state to /run/vc/sbs/<id>/persist.json.
+	if err := s.sandbox.Save(); err != nil {
+		return err
+	}
+	// snapshot the VM memory + device state into destDir via cloud-hypervisor.
+	if err := s.sandbox.SaveVM(destDir); err != nil {
+		return err
+	}
+	// repoint config.json's memory zone file at the in-dir memory-ranges so the
+	// snapshot is self-contained for memory (the source path it inherits is the
+	// shared template/source memory, outside this dir). without this, a restore
+	// that reads config.json mmaps the wrong file (or fails if it is gone).
+	if err := makeConfigSelfContained(destDir); err != nil {
+		return err
+	}
+	// bundle the persist.json into the snapshot dir alongside the memory/state files.
+	if err := s.copyPersistInto(destDir); err != nil {
+		return err
+	}
+	return s.writeSnapshotManifest(destDir)
+}
+
+// makeConfigSelfContained rewrites config.json's memory zone backing-file paths
+// to point at the memory-ranges file inside destDir. cloud-hypervisor writes the
+// snapshot's config.json from the live VmConfig, whose memory.zones[].file still
+// names the source memory path (e.g. /run/vc/vm/template/memory) outside destDir.
+// On restore CLH opens that path to back the memory zone, so a relocated snapshot
+// (or a GC'd source) would fail. Pointing it at the in-dir memory-ranges makes the
+// snapshot dir's memory self-contained. (Disks are not rewritten here; that is
+// separate, larger work for cross-host portability.)
+func makeConfigSelfContained(destDir string) error {
+	configPath := filepath.Join(destDir, "config.json")
+	memoryRanges := filepath.Join(destDir, "memory-ranges")
+	if _, err := os.Stat(memoryRanges); err != nil {
+		// no memory-ranges file: nothing to repoint, leave config as-is.
+		return nil
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return err
+	}
+	mem, ok := cfg["memory"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	zones, ok := mem["zones"].([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, z := range zones {
+		if zm, ok := z.(map[string]interface{}); ok {
+			zm["file"] = memoryRanges
+		}
+	}
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, out, 0600)
+}
+
+// copyPersistInto copies /run/vc/sbs/<id>/persist.json into destDir.
+func (s *service) copyPersistInto(destDir string) error {
+	src := filepath.Join("/run/vc/sbs", s.id, "persist.json")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		// persist.json may legitimately be absent on some configs; not fatal.
+		shimMgtLog.WithError(err).WithField("src", src).Warn("no persist.json to bundle")
+		return nil
+	}
+	return os.WriteFile(filepath.Join(destDir, "persist.json"), data, 0600)
+}
+
+// writeSnapshotManifest drops a small kata-snapshot.json describing the source.
+func (s *service) writeSnapshotManifest(destDir string) error {
+	m := snapshotManifest{
+		SourceSandboxID: s.id,
+		Timestamp:       time.Now().UTC().Format(time.RFC3339),
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(destDir, "kata-snapshot.json"), b, 0600)
 }
 
 // ClientSocketAddress returns the address of the unix domain socket for communicating with the

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -80,6 +80,11 @@ const (
 	// Minimum timout for calling CreateVM followed by BootVM. Executing these two APIs
 	// might take longer than the value returned by getClhAPITimeout().
 	clhCreateAndBootVMMinimumTimeout = 10
+	// Minimum timeout for a VM snapshot. Writing the guest RAM to disk scales with
+	// memory size and easily exceeds the 1s default API timeout (a 2 GiB save takes ~2s).
+	clhSnapshotMinimumTimeout = 30
+	// Extra snapshot seconds to allow per GiB of guest memory written to disk.
+	clhSnapshotTimeoutPerGiB = 10
 	// Timeout for hot-plug - hotplug devices can take more time, than usual API calls
 	// Use longer time timeout for it.
 	clhHotPlugAPITimeout                   = 5
@@ -332,6 +337,20 @@ var clhDebugKernelParamsCommon = []Param{
 // hypervisor interface implementation for cloud-hypervisor
 //
 //###########################################################
+
+// getClhSnapshotTimeout returns a deadline for the vm.snapshot API call. The
+// snapshot writes the entire guest RAM to disk, so the deadline scales with
+// memory size and is floored well above the 1s default API timeout.
+func (clh *cloudHypervisor) getClhSnapshotTimeout() time.Duration {
+	timeout := time.Duration(clhSnapshotMinimumTimeout) * time.Second
+	// MemorySize is in MiB; add headroom per GiB of guest memory.
+	memGiB := clh.config.MemorySize / 1024
+	sized := time.Duration(memGiB) * time.Duration(clhSnapshotTimeoutPerGiB) * time.Second
+	if sized > timeout {
+		timeout = sized
+	}
+	return timeout
+}
 
 func (clh *cloudHypervisor) getClhAPITimeout() time.Duration {
 	// Increase the APITimeout when dealing with a Confidential Guest.
@@ -1480,12 +1499,11 @@ func (clh *cloudHypervisor) PauseVM(ctx context.Context) error {
 
 	return nil
 }
-
 func (clh *cloudHypervisor) SaveVM(snapshotDir string) error {
 	clh.Logger().WithField("function", "SaveVM").Info("Save Sandbox")
 
 	cl := clh.client()
-	ctx, cancel := context.WithTimeout(context.Background(), clh.getClhAPITimeout()*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), clh.getClhSnapshotTimeout())
 	defer cancel()
 
 	// Snapshot the VM into the caller-provided directory. This is a pure
@@ -1560,7 +1578,6 @@ func PatchCLHSnapshotMemoryPrivate(snapshotDir string) error {
 
 	return nil
 }
-
 func (clh *cloudHypervisor) ResumeVM(ctx context.Context) error {
 	clh.Logger().WithField("function", "ResumeVM").Info("Resume Sandbox")
 	cl := clh.client()

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -55,6 +55,10 @@ type VCSandbox interface {
 	StatsContainer(ctx context.Context, containerID string) (ContainerStats, error)
 	PauseContainer(ctx context.Context, containerID string) error
 	ResumeContainer(ctx context.Context, containerID string) error
+	PauseVM(ctx context.Context) error
+	SaveVM(destDir string) error
+	ResumeVM(ctx context.Context) error
+	Save() error
 	EnterContainer(ctx context.Context, containerID string, cmd types.Cmd) (VCContainer, *Process, error)
 	UpdateContainer(ctx context.Context, containerID string, resources specs.LinuxResources) error
 	WaitProcess(ctx context.Context, containerID, processID string) (int32, error)

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -273,3 +273,23 @@ func (s *Sandbox) SetIPTables(ctx context.Context, isIPv6 bool, data []byte) err
 func (s *Sandbox) SetPolicy(ctx context.Context, policy string) error {
 	return nil
 }
+
+// PauseVM implements the VCSandbox function of the same name.
+func (s *Sandbox) PauseVM(ctx context.Context) error {
+	return nil
+}
+
+// SaveVM implements the VCSandbox function of the same name.
+func (s *Sandbox) SaveVM(destDir string) error {
+	return nil
+}
+
+// ResumeVM implements the VCSandbox function of the same name.
+func (s *Sandbox) ResumeVM(ctx context.Context) error {
+	return nil
+}
+
+// Save implements the VCSandbox function of the same name.
+func (s *Sandbox) Save() error {
+	return nil
+}

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1858,6 +1858,24 @@ func (s *Sandbox) ResumeContainer(ctx context.Context, containerID string) error
 	return nil
 }
 
+// PauseVM pauses the sandbox's VM.
+func (s *Sandbox) PauseVM(ctx context.Context) error {
+	s.Logger().Info("pause vm")
+	return s.hypervisor.PauseVM(ctx)
+}
+
+// SaveVM saves the sandbox's VM state to the given destination directory.
+func (s *Sandbox) SaveVM(destDir string) error {
+	s.Logger().Info("save vm to dir")
+	return s.hypervisor.SaveVM(destDir)
+}
+
+// ResumeVM resumes the sandbox's paused VM.
+func (s *Sandbox) ResumeVM(ctx context.Context) error {
+	s.Logger().Info("resume vm")
+	return s.hypervisor.ResumeVM(ctx)
+}
+
 // createContainers registers all containers, create the
 // containers in the guest.
 func (s *Sandbox) createContainers(ctx context.Context) error {


### PR DESCRIPTION
###### Merge Checklist
- [x] Followed patch format from upstream recommendation: https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
- [x] Included a single commit in a given PR - at least unless there are related commits and each makes sense as a change on its own.
- [x] Merged using "create a merge commit" rather than "squash and merge" (or similar)
- [x] genPolicy only: Builds on Windows
- [x] genPolicy only: Updated sample YAMLs' policy annotations, if applicable

###### Summary
Adds a `kata-runtime snapshot` subcommand to snapshot a 
running Kata sandbox VM via cloud-hypervisor, plus a `delete` subcommand to remove a snapshot dir. Runs on the node:

```
kata-runtime snapshot --sandbox-id <sbid>           # take snapshot -> /run/vc/vm/snapshots/<sbid>/
kata-runtime snapshot --sandbox-id <sbid> --name X  # name the snapshot dir
kata-runtime snapshot delete --sandbox-id <sbid>    # remove a snapshot dir
```

The CLI POSTs to the per-sandbox shim management socket; the shim pauses the VM, saves kata state, snapshots VM memory + device state to the dir via `SaveVM(path)`, then resumes. Built on top of Cameron's factory/hypervisor save-path refactor (this branch is stacked on `guptaharshit/runtime-go-clh-templating`).

Scope: snapshot-side only. Restore is performed manually with the CLH API for now (out of scope here).

###### Associated issues
<!-- link issue if any -->

###### Links to CVEs
N/A

###### Test Methodology
Local build (`go build ./cmd/kata-runtime/... ./pkg/containerd-shim-v2/... ./virtcontainers/...`) and full end-to-end on an AKS Azure Linux node (`aks-nodepool1-23826427-vmss000000`, MSHV + EROFS): snapshot a live pod at `counter=5`, restore into a fresh CLH process, confirm the clone resumes at `counter=5` (live RAM inherited) and copy-on-write isolation holds (original stays 5 while clone advances to 7).

Full step-by-step e2e runbook attached: see `nodepool0-snapshot-cli-e2e-runbook.md`.[nodepool0-snapshot-cli-e2e-runbook.md](https://github.com/user-attachments/files/28846549/nodepool0-snapshot-cli-e2e-runbook.md)
