### PR TITLE
runtime: Conform to static_resource_mgmt behavior for templating and allow one-time resize at restore time. 

### DIFF
--- a/src/runtime/cmd/kata-runtime/factory.go
+++ b/src/runtime/cmd/kata-runtime/factory.go
@@ -167,7 +167,7 @@ var initFactoryCommand = cli.Command{
 			VMCache:      runtimeConfig.FactoryConfig.VMCacheNumber > 0,
 			VMConfig: vc.VMConfig{
 				HypervisorType:   runtimeConfig.HypervisorType,
-				HypervisorConfig: runtimeConfig.HypervisorConfig,
+				HypervisorConfig: oci.StaticHypervisorConfig(runtimeConfig),
 				AgentConfig:      runtimeConfig.AgentConfig,
 			},
 		}

--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -67,6 +67,7 @@ func HandleFactory(ctx context.Context, vci vc.VC, runtimeConfig *oci.RuntimeCon
 	if !runtimeConfig.FactoryConfig.Template && runtimeConfig.FactoryConfig.VMCacheNumber == 0 {
 		return
 	}
+
 	factoryConfig := vf.Config{
 		Template:        runtimeConfig.FactoryConfig.Template,
 		TemplatePath:    runtimeConfig.FactoryConfig.TemplatePath,
@@ -74,7 +75,7 @@ func HandleFactory(ctx context.Context, vci vc.VC, runtimeConfig *oci.RuntimeCon
 		VMCacheEndpoint: runtimeConfig.FactoryConfig.VMCacheEndpoint,
 		VMConfig: vc.VMConfig{
 			HypervisorType:   runtimeConfig.HypervisorType,
-			HypervisorConfig: runtimeConfig.HypervisorConfig,
+			HypervisorConfig: oci.StaticHypervisorConfig(*runtimeConfig),
 			AgentConfig:      runtimeConfig.AgentConfig,
 		},
 	}

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -1265,6 +1265,34 @@ func addAgentConfigOverrides(ocispec specs.Spec, config *vc.SandboxConfig) error
 	return nil
 }
 
+// applyStaticSizingDefaults substitutes the static workload default vCPU/memory
+// values for any size that is left at 0 when static_sandbox_resource_mgmt is
+// enabled. This is the single definition of a sandbox's "base" size: the size a
+// VM (or a VM template) boots at before any per-pod workload resizing. With the
+// fork's default_vcpus=0 / default_memory=0, this resolves to the static
+// workload defaults (e.g. 512 MiB / 1 vCPU), i.e. the BestEffort baseline.
+func applyStaticSizingDefaults(hc *vc.HypervisorConfig, runtime RuntimeConfig) {
+	if !runtime.StaticSandboxResourceMgmt {
+		return
+	}
+	if hc.MemorySize == 0 && runtime.StaticSandboxWorkloadDefaultMem > 0 {
+		hc.MemorySize = runtime.StaticSandboxWorkloadDefaultMem
+	}
+	if hc.NumVCPUsF == 0 && runtime.StaticSandboxWorkloadDefaultVcpus > 0 {
+		hc.NumVCPUsF = runtime.StaticSandboxWorkloadDefaultVcpus
+	}
+}
+
+// StaticHypervisorConfig returns a copy of the runtime's HypervisorConfig sized
+// to the static "base" size (see applyStaticSizingDefaults). It is used to build
+// VM templates so the template boots at the same base size that a per-pod
+// sandbox starts from, ensuring the factory's config match succeeds.
+func StaticHypervisorConfig(runtime RuntimeConfig) vc.HypervisorConfig {
+	hc := runtime.HypervisorConfig
+	applyStaticSizingDefaults(&hc, runtime)
+	return hc
+}
+
 // SandboxConfig converts an OCI compatible runtime configuration file
 // to a virtcontainers sandbox configuration structure.
 func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid string, detach, systemdCgroup bool) (vc.SandboxConfig, error) {
@@ -1358,10 +1386,10 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
 		sandboxConfig.SandboxResources.BaseCPUs = sandboxConfig.HypervisorConfig.NumVCPUsF
 		sandboxConfig.SandboxResources.BaseMemMB = sandboxConfig.HypervisorConfig.MemorySize
 
+		// Always size the VM to the full static size (base + workload) up front so
+		// that the normal/direct boot path is born at the correct size before boot.
 		sandboxConfig.HypervisorConfig.NumVCPUsF += sandboxConfig.SandboxResources.WorkloadCPUs
 		sandboxConfig.HypervisorConfig.MemorySize += sandboxConfig.SandboxResources.WorkloadMemMB
-
-		sandboxConfig.HypervisorConfig.DefaultMaxVCPUs = sandboxConfig.HypervisorConfig.NumVCPUs()
 
 		ociLog.WithFields(logrus.Fields{
 			"workload cpu":       sandboxConfig.SandboxResources.WorkloadCPUs,

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -89,6 +89,10 @@ const (
 	clhAPISocket                           = "clh-api.sock"
 	virtioFsSocket                         = "virtiofsd.sock"
 	defaultClhPath                         = "/usr/local/bin/cloud-hypervisor"
+	// virtio-mem requires its hotplug region size to be a multiple of the
+	// virtio-mem block size (128 MiB). cloud-hypervisor rejects unaligned sizes
+	// with "Virtio-mem size is not aligned".
+	virtioMemBlockSizeMiB = 128
 )
 
 // Interface that hides the implementation of openAPI client
@@ -109,6 +113,8 @@ type clhClient interface {
 	BootVM(ctx context.Context) (*http.Response, error)
 	// Add/remove CPUs to/from the VM
 	VmResizePut(ctx context.Context, vmResize chclient.VmResize) (*http.Response, error)
+	// Resize a memory zone of the VM
+	VmResizeZonePut(ctx context.Context, vmResizeZone chclient.VmResizeZone) (*http.Response, error)
 	// Add VFIO PCI device to the VM
 	VmAddDevicePut(ctx context.Context, deviceConfig chclient.DeviceConfig) (chclient.PciDeviceInfo, *http.Response, error)
 	// Add a new disk device to the VM
@@ -152,6 +158,10 @@ func (c *clhClientApi) BootVM(ctx context.Context) (*http.Response, error) {
 
 func (c *clhClientApi) VmResizePut(ctx context.Context, vmResize chclient.VmResize) (*http.Response, error) {
 	return c.ApiInternal.VmResizePut(ctx).VmResize(vmResize).Execute()
+}
+
+func (c *clhClientApi) VmResizeZonePut(ctx context.Context, vmResizeZone chclient.VmResizeZone) (*http.Response, error) {
+	return c.ApiInternal.VmResizeZonePut(ctx).VmResizeZone(vmResizeZone).Execute()
 }
 
 func (c *clhClientApi) VmAddDevicePut(ctx context.Context, deviceConfig chclient.DeviceConfig) (chclient.PciDeviceInfo, *http.Response, error) {
@@ -609,25 +619,41 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 			// So we need to set shared to true in this case.
 			memoryZoneConfig.SetShared(true)
 			clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(true)
-
-			if !clh.config.ConfidentialGuest {
-				// TODO: Remove this warning once memory hotplugging is supported
-				// for template VMs.
-				//
-				// Memory hotplug is intentionally not configured for template VMs.
-				// Resizing a memory zone requires the virtio-mem hotplug method
-				// (cloud-hypervisor rejects the default ACPI hotplug on a zone that
-				// carries a hotplug_size), which is not currently supported in the
-				// templating path. As a result, VMs restored from this template
-				// cannot grow their memory beyond the template's boot size.
-				clh.Logger().Warn("memory hotplugging is currently unsupported for template VMs")
-			}
 		} else {
 			// When BootFromTemplate is true, set shared=false to ensure Copy-On-Write is used for the memory file.
 			// So that the VM can have its own private memory.
 			memoryZoneConfig.SetShared(false)
 			clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(false)
 		}
+
+		// Enable memory hotplug for template VMs so that a VM restored from the
+		// template can grow its memory to match the incoming pod's resource limits.
+		// A file-backed memory zone can only be resized via the virtio-mem hotplug
+		// method - cloud-hypervisor rejects the default ACPI hotplug on a zone that
+		// carries a hotplug_size. Configuring this at template-creation time
+		// (BootToBeTemplate) captures the hotplug_method/hotplug_size in the snapshot
+		// so every VM restored from the template inherits a resizable memory zone.
+		// This is intentionally not enabled for confidential guests.
+		if !clh.config.ConfidentialGuest {
+			// The hotplug region is the headroom between the boot memory size and
+			// the configured maximum memory. Note that DefaultMaxMemorySize resolves
+			// to the total host memory when default_maxmemory is set to 0, which is
+			// usually not 128 MiB-aligned, so the region must be aligned down to the
+			// virtio-mem block size or cloud-hypervisor rejects it at boot.
+			var hotplugSizeMiB uint64
+			if clh.config.DefaultMaxMemorySize > uint64(clh.config.MemorySize) {
+				hotplugSizeMiB = clh.config.DefaultMaxMemorySize - uint64(clh.config.MemorySize)
+			}
+			hotplugSizeMiB = (hotplugSizeMiB / virtioMemBlockSizeMiB) * virtioMemBlockSizeMiB
+
+			if hotplugSizeMiB > 0 {
+				clh.vmconfig.Memory.SetHotplugMethod("VirtioMem")
+				memoryZoneConfig.SetHotplugSize(int64((utils.MemUnit(hotplugSizeMiB) * utils.MiB).ToBytes()))
+			} else {
+				clh.Logger().Warn("memory hotplug region too small to align to the virtio-mem block size; restored template VMs will not be able to grow their memory")
+			}
+		}
+
 		memoryZoneConfig.SetFile(clh.config.MemoryPath)
 		clh.vmconfig.Memory.Zones = &[]chclient.MemoryZoneConfig{
 			*memoryZoneConfig,
@@ -1372,6 +1398,14 @@ func (clh *cloudHypervisor) ResizeMemory(ctx context.Context, reqMemMB uint32, m
 		return 0, MemoryDevice{}, err
 	}
 
+	// VMs booted with a file-backed memory zone (the template/restore path) expose
+	// their hotpluggable memory on the zone rather than on the top-level memory
+	// config, and must be resized per-zone via the virtio-mem hotplug method. The
+	// global vm.resize API does not resize zone-backed memory.
+	if info.Config.Memory.Zones != nil && len(*info.Config.Memory.Zones) > 0 {
+		return clh.resizeMemoryZone(ctx, (*info.Config.Memory.Zones)[0], reqMemMB, memoryBlockSizeMB)
+	}
+
 	// HotplugSize can be nil in cases where Hotplug is not supported, as Cloud Hypervisor API
 	// does *not* allow us to set 0 as the HotplugSize.
 	maxHotplugSize := 0 * utils.Byte
@@ -1428,6 +1462,73 @@ func (clh *cloudHypervisor) ResizeMemory(ctx context.Context, reqMemMB uint32, m
 	if _, err = cl.VmResizePut(ctx, resize); err != nil {
 		clh.Logger().WithError(err).WithFields(log.Fields{"current-memory": currentMem, "new-memory": newMem}).Warnf("failed to update memory %s", openAPIClientError(err))
 		err = fmt.Errorf("Failed to resize memory from %d to %d: %s", currentMem, newMem, openAPIClientError(err))
+		return uint32(currentMem.ToMiB()), MemoryDevice{}, openAPIClientError(err)
+	}
+
+	return uint32(newMem.ToMiB()), MemoryDevice{SizeMB: int(hotplugSize.ToMiB())}, nil
+}
+
+// resizeMemoryZone grows a file-backed memory zone (used by template/restore VMs)
+// to reqMemMB using cloud-hypervisor's per-zone virtio-mem hotplug API. The zone's
+// boot size plus its hotplug_size define the maximum total size it can reach.
+func (clh *cloudHypervisor) resizeMemoryZone(ctx context.Context, zone chclient.MemoryZoneConfig, reqMemMB uint32, memoryBlockSizeMB uint32) (uint32, MemoryDevice, error) {
+	zoneSize := utils.MemUnit(zone.Size) * utils.Byte
+
+	// hotplug_size is the additional memory that can be hotplugged on top of the
+	// zone's boot size. If it is unset the zone cannot grow.
+	maxHotplugSize := 0 * utils.Byte
+	if zone.HotplugSize != nil {
+		maxHotplugSize = utils.MemUnit(*zone.HotplugSize) * utils.Byte
+	}
+	maxMem := zoneSize + maxHotplugSize
+
+	// Current zone size is the boot size plus whatever has already been hotplugged.
+	currentMem := zoneSize
+	if zone.HotpluggedSize != nil {
+		currentMem += utils.MemUnit(*zone.HotpluggedSize) * utils.Byte
+	}
+
+	newMem := utils.MemUnit(reqMemMB) * utils.MiB
+	if newMem > maxMem {
+		clh.Logger().WithFields(log.Fields{"request": newMem, "max": maxMem}).Debug("capping memory zone request to max size")
+		newMem = maxMem
+	}
+
+	if currentMem == newMem {
+		clh.Logger().WithField("memory", reqMemMB).Debug("memory zone already has requested memory")
+		return uint32(currentMem.ToMiB()), MemoryDevice{}, nil
+	}
+
+	if currentMem > newMem {
+		clh.Logger().Warn("Remove memory is not supported, nothing to do")
+		return uint32(currentMem.ToMiB()), MemoryDevice{}, nil
+	}
+
+	// Align the amount of memory being added to the guest's memory block size.
+	blockSize := utils.MemUnit(memoryBlockSizeMB) * utils.MiB
+	hotplugSize := (newMem - currentMem).AlignMem(blockSize)
+	newMem = currentMem + hotplugSize
+	if newMem > maxMem {
+		newMem = maxMem
+		hotplugSize = newMem - currentMem
+	}
+
+	if hotplugSize == 0*utils.Byte {
+		clh.Logger().Debug("memory zone already has requested memory (after alignment)")
+		return uint32(currentMem.ToMiB()), MemoryDevice{}, nil
+	}
+
+	cl := clh.client()
+	ctx, cancelResize := context.WithTimeout(ctx, clh.getClhAPITimeout()*time.Second)
+	defer cancelResize()
+
+	resize := *chclient.NewVmResizeZone()
+	resize.SetId(zone.Id)
+	// OpenApi does not support uint64, convert to int64
+	resize.SetDesiredRam(int64(newMem.ToBytes()))
+	clh.Logger().WithFields(log.Fields{"zone": zone.Id, "current-memory": currentMem, "new-memory": newMem}).Debug("updating VM memory zone")
+	if _, err := cl.VmResizeZonePut(ctx, resize); err != nil {
+		clh.Logger().WithError(err).WithFields(log.Fields{"current-memory": currentMem, "new-memory": newMem}).Warnf("failed to resize memory zone %s", openAPIClientError(err))
 		return uint32(currentMem.ToMiB()), MemoryDevice{}, openAPIClientError(err)
 	}
 
@@ -1521,6 +1622,27 @@ func (clh *cloudHypervisor) SaveVM() error {
 	cl := clh.client()
 	ctx, cancel := context.WithTimeout(context.Background(), clh.getClhAPITimeout()*time.Second)
 	defer cancel()
+
+	// Warn (but do not block) when snapshotting a VM whose file-backed virtio-mem
+	// zone has memory hotplugged on top of it. cloud-hypervisor restores such a zone
+	// by re-mapping the hotplug region over the zone's backing file at offset 0, which
+	// can map past the file's EOF (failing the restore / SIGBUS) and punch holes in a
+	// shared template file. Templating is unaffected because the template is
+	// snapshotted at boot, before any hotplug (hotplugged_size == 0). This is left as
+	// a warning for now so the failure mode can be observed in practice.
+	if info, err := clh.vmInfo(); err != nil {
+		return err
+	} else if info.Config.Memory != nil && info.Config.Memory.Zones != nil {
+		for _, zone := range *info.Config.Memory.Zones {
+			if zone.File != nil && *zone.File != "" && zone.HotpluggedSize != nil && *zone.HotpluggedSize > 0 {
+				clh.Logger().WithFields(log.Fields{
+					"zone":            zone.Id,
+					"file":            *zone.File,
+					"hotplugged-size": *zone.HotpluggedSize,
+				}).Warn("snapshotting a file-backed virtio-mem zone with hotplugged memory; restore of a grown file-backed virtio-mem zone is not known to be safe (possible past-EOF map / template hole-punch)")
+			}
+		}
+	}
 
 	snapshotDir := filepath.Dir(clh.config.MemoryPath)
 	// Create snapshot config with file URL to template path

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -108,6 +108,11 @@ func (c *clhClientMock) VmResizePut(ctx context.Context, vmResize chclient.VmRes
 }
 
 //nolint:golint
+func (c *clhClientMock) VmResizeZonePut(ctx context.Context, vmResizeZone chclient.VmResizeZone) (*http.Response, error) {
+	return nil, nil
+}
+
+//nolint:golint
 func (c *clhClientMock) VmAddDevicePut(ctx context.Context, deviceConfig chclient.DeviceConfig) (chclient.PciDeviceInfo, *http.Response, error) {
 	return chclient.PciDeviceInfo{}, nil, nil
 }
@@ -616,6 +621,39 @@ func TestClhSaveVM(t *testing.T) {
 		expectedDestinationURL := "file://" + filepath.Dir(clhConfig.MemoryPath)
 		assert.Equal(expectedDestinationURL, mockClient.snapshotRequest.GetDestinationUrl())
 	}
+}
+
+func TestClhSaveVMWarnsHotpluggedFileBackedZone(t *testing.T) {
+	assert := assert.New(t)
+
+	store, err := persist.GetDriver()
+	assert.NoError(err)
+
+	clhConfig, err := newClhConfig()
+	assert.NoError(err)
+	clhConfig.MemoryPath = filepath.Join(store.RunVMStoragePath(), "memory")
+	clhConfig.VMStorePath = store.RunVMStoragePath()
+	clhConfig.RunStorePath = store.RunStoragePath()
+
+	mockClient := &clhClientMock{}
+	// Simulate a restored template VM that has grown its file-backed virtio-mem
+	// zone (hotplugged_size > 0). SaveVM should warn but still proceed.
+	zone := chclient.NewMemoryZoneConfig("mem0", int64(512*utils.MiB.ToBytes()))
+	zone.SetFile(clhConfig.MemoryPath)
+	zone.HotpluggedSize = func(i int64) *int64 { return &i }(int64(1024 * utils.MiB.ToBytes()))
+	mockClient.vmInfo.Config = *chclient.NewVmConfig(*chclient.NewPayloadConfig())
+	mockClient.vmInfo.Config.Memory = chclient.NewMemoryConfig(0)
+	mockClient.vmInfo.Config.Memory.Zones = &[]chclient.MemoryZoneConfig{*zone}
+
+	clh := &cloudHypervisor{
+		config:    clhConfig,
+		APIClient: mockClient,
+	}
+
+	err = clh.SaveVM()
+	assert.NoError(err)
+	// The snapshot must still have been attempted despite the warning.
+	assert.NotNil(mockClient.snapshotRequest)
 }
 
 func TestCloudHypervisorStartSandbox(t *testing.T) {

--- a/src/runtime/virtcontainers/factory/factory_linux.go
+++ b/src/runtime/virtcontainers/factory/factory_linux.go
@@ -112,7 +112,6 @@ func (f *factory) GetVM(ctx context.Context, config vc.VMConfig) (*vc.VM, error)
 	span, ctx := katatrace.Trace(ctx, f.log(), "GetVM", factoryTracingTags)
 	defer span.End()
 
-	hypervisorConfig := config.HypervisorConfig
 	if err := config.Valid(); err != nil {
 		f.log().WithError(err).Error("invalid hypervisor config")
 		return nil, err
@@ -120,8 +119,8 @@ func (f *factory) GetVM(ctx context.Context, config vc.VMConfig) (*vc.VM, error)
 
 	err := f.checkConfig(config)
 	if err != nil {
-		f.log().WithError(err).Info("fallback to direct factory vm")
-		return direct.New(ctx, config).GetBaseVM(ctx, config)
+		f.log().WithError(err).Warn("factory config mismatch, caller should fall back to direct boot")
+		return nil, err
 	}
 
 	f.log().Info("get base VM")
@@ -156,31 +155,9 @@ func (f *factory) GetVM(ctx context.Context, config vc.VMConfig) (*vc.VM, error)
 		return nil, err
 	}
 
-	online := false
-	baseConfig := f.base.Config().HypervisorConfig
-	if baseConfig.NumVCPUsF < hypervisorConfig.NumVCPUsF {
-		err = vm.AddCPUs(ctx, hypervisorConfig.NumVCPUs()-baseConfig.NumVCPUs())
-		if err != nil {
-			return nil, err
-		}
-		online = true
-	}
-
-	if baseConfig.MemorySize < hypervisorConfig.MemorySize {
-		err = vm.AddMemory(ctx, hypervisorConfig.MemorySize-baseConfig.MemorySize)
-		if err != nil {
-			return nil, err
-		}
-		online = true
-	}
-
-	if online {
-		err = vm.OnlineCPUMemory(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+	// NOTE: The factory intentionally does NOT resize the restored VM here.
+	// Sizing the VM up to the pod's workload is owned solely by the sandbox's
+	// updateResources()
 	return vm, nil
 }
 

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1591,10 +1591,10 @@ func (s *Sandbox) startVM(ctx context.Context, prestartHookFunc func(context.Con
 				AgentConfig:      s.config.AgentConfig,
 			})
 			if err != nil {
-				return err
+				s.Logger().WithError(err).Warn("factory GetVM failed, falling back to direct boot")
+			} else {
+				return vm.assignSandbox(s)
 			}
-
-			return vm.assignSandbox(s)
 		}
 
 		return s.hypervisor.StartVM(ctx, VmStartTimeout)
@@ -2400,26 +2400,48 @@ func (s *Sandbox) updateResources(ctx context.Context) error {
 		return fmt.Errorf("sandbox config is nil")
 	}
 
-	if s.config.StaticResourceMgmt {
-		s.Logger().Debug("no resources updated: static resource management is set")
+	// Static resource management without a VM template: the VM was already booted
+	// directly at its full, correct size (default + workload), so there is nothing
+	// to resize here.
+	if s.config.StaticResourceMgmt && s.factory == nil {
+		s.Logger().Debug("no resources updated: static resource management is set and no factory in use")
 		return nil
 	}
 
-	sandboxVCPUs, err := s.calculateSandboxCPUs()
-	if err != nil {
-		return err
-	}
-	// Add default vcpus for sandbox
-	sandboxVCPUs += s.hypervisor.HypervisorConfig().NumVCPUsF
+	var (
+		sandboxVCPUs       float32
+		sandboxMemoryByte  uint64
+		sandboxneedPodSwap bool
+		sandboxSwapByte    int64
+		err                error
+	)
 
-	sandboxMemoryByte, sandboxneedPodSwap, sandboxSwapByte := s.calculateSandboxMemory()
+	if s.config.StaticResourceMgmt {
+		// Static resource management with a VM template: the template was booted at
+		// the small static *default* size (it is shared, so it can't be pre-sized
+		// per pod). Grow it up to the full size in s.config.HypervisorConfig, which
+		// already includes the workload - so use it directly.
+		sandboxVCPUs = s.config.HypervisorConfig.NumVCPUsF
+		sandboxMemoryByte = uint64(s.config.HypervisorConfig.MemorySize) << utils.MibToBytesShift
+	} else {
+		// Dynamic resource management: nothing is sized up front. The VM was booted
+		// at the configured base/overhead size and grows on demand. The target is
+		// *additive* - the sum of the live container requests plus the base
+		// overhead - and is recomputed every time a container is added or started.
+		sandboxVCPUs, err = s.calculateSandboxCPUs()
+		if err != nil {
+			return err
+		}
+		// Add default vcpus for sandbox
+		sandboxVCPUs += s.hypervisor.HypervisorConfig().NumVCPUsF
 
-	// Add default / rsvd memory for sandbox.
-	hypervisorMemoryByteI64 := int64(s.hypervisor.HypervisorConfig().MemorySize) << utils.MibToBytesShift
-	hypervisorMemoryByte := uint64(hypervisorMemoryByteI64)
-	sandboxMemoryByte += hypervisorMemoryByte
-	if sandboxneedPodSwap {
-		sandboxSwapByte += hypervisorMemoryByteI64
+		sandboxMemoryByte, sandboxneedPodSwap, sandboxSwapByte = s.calculateSandboxMemory()
+		// Add default / rsvd memory for sandbox.
+		hypervisorMemoryByteI64 := int64(s.hypervisor.HypervisorConfig().MemorySize) << utils.MibToBytesShift
+		sandboxMemoryByte += uint64(hypervisorMemoryByteI64)
+		if sandboxneedPodSwap {
+			sandboxSwapByte += hypervisorMemoryByteI64
+		}
 	}
 	s.Logger().WithField("sandboxMemoryByte", sandboxMemoryByte).WithField("sandboxneedPodSwap", sandboxneedPodSwap).WithField("sandboxSwapByte", sandboxSwapByte).Debugf("updateResources: after calculateSandboxMemory")
 
@@ -2432,21 +2454,29 @@ func (s *Sandbox) updateResources(ctx context.Context) error {
 	}
 
 	// Update VCPUs
-	s.Logger().WithField("cpus-sandbox", sandboxVCPUs).Debugf("Request to hypervisor to update vCPUs")
-	oldCPUs, newCPUs, err := s.hypervisor.ResizeVCPUs(ctx, RoundUpNumVCPUs(sandboxVCPUs))
-	if err != nil {
-		return err
-	}
-
-	s.Logger().Debugf("Request to hypervisor to update oldCPUs/newCPUs: %d/%d", oldCPUs, newCPUs)
-	// If the CPUs were increased, ask agent to online them
-	if oldCPUs < newCPUs {
-		s.Logger().Debugf("Request to onlineCPUMem with %d CPUs", newCPUs)
-		if err := s.agent.onlineCPUMem(ctx, newCPUs, true); err != nil {
+	reqVCPUs := RoundUpNumVCPUs(sandboxVCPUs)
+	if reqVCPUs == 0 {
+		// No workload vCPU request (e.g. a BestEffort pod restored from a
+		// template). Leave the VM at its current/boot vCPU count - resizing to 0
+		// is invalid and the template already provides the baseline vCPUs.
+		s.Logger().Debug("no vCPU request; skipping vCPU update")
+	} else {
+		s.Logger().WithField("cpus-sandbox", sandboxVCPUs).Debugf("Request to hypervisor to update vCPUs")
+		oldCPUs, newCPUs, err := s.hypervisor.ResizeVCPUs(ctx, reqVCPUs)
+		if err != nil {
 			return err
 		}
+
+		s.Logger().Debugf("Request to hypervisor to update oldCPUs/newCPUs: %d/%d", oldCPUs, newCPUs)
+		// If the CPUs were increased, ask agent to online them
+		if oldCPUs < newCPUs {
+			s.Logger().Debugf("Request to onlineCPUMem with %d CPUs", newCPUs)
+			if err := s.agent.onlineCPUMem(ctx, newCPUs, true); err != nil {
+				return err
+			}
+		}
+		s.Logger().Debugf("Sandbox CPUs: %d", newCPUs)
 	}
-	s.Logger().Debugf("Sandbox CPUs: %d", newCPUs)
 
 	// Update Memory --
 	// If we're using ACPI hotplug for memory, there's a limitation on the amount of memory which can be hotplugged at a single time.
@@ -2463,34 +2493,45 @@ func (s *Sandbox) updateResources(ctx context.Context) error {
 
 	hconfig := s.hypervisor.HypervisorConfig()
 
-	for {
-		currentMemoryMB := s.hypervisor.GetTotalMemoryMB(ctx)
+	// If the target memory is zero or not above the current VM memory, there is
+	// nothing to hotplug. This happens for BestEffort pods when default_memory=0
+	// and the VM was booted from a template at a baseline size.
+	currentMemoryMB := s.hypervisor.GetTotalMemoryMB(ctx)
+	if finalMemoryMB <= currentMemoryMB {
+		s.Logger().WithFields(logrus.Fields{
+			"target-memory-mb":  finalMemoryMB,
+			"current-memory-mb": currentMemoryMB,
+		}).Debug("target memory does not exceed current VM memory; skipping memory hotplug")
+	} else {
+		for {
+			currentMemoryMB = s.hypervisor.GetTotalMemoryMB(ctx)
 
-		maxhotPluggableMemoryMB := currentMemoryMB * acpiMemoryHotplugFactor
+			maxhotPluggableMemoryMB := currentMemoryMB * acpiMemoryHotplugFactor
 
-		// In the case of virtio-mem, we don't have a restriction on how much can be hotplugged at
-		// a single time. As a result, the max hotpluggable is only limited by the maximum memory size
-		// of the guest.
-		if hconfig.VirtioMem {
-			maxhotPluggableMemoryMB = uint32(hconfig.DefaultMaxMemorySize) - currentMemoryMB
-		}
+			// In the case of virtio-mem, we don't have a restriction on how much can be hotplugged at
+			// a single time. As a result, the max hotpluggable is only limited by the maximum memory size
+			// of the guest.
+			if hconfig.VirtioMem {
+				maxhotPluggableMemoryMB = uint32(hconfig.DefaultMaxMemorySize) - currentMemoryMB
+			}
 
-		deltaMB := int32(finalMemoryMB - currentMemoryMB)
+			deltaMB := int32(finalMemoryMB - currentMemoryMB)
 
-		if deltaMB > int32(maxhotPluggableMemoryMB) {
-			s.Logger().Warnf("Large hotplug. Adding %d MB of %d total memory", maxhotPluggableMemoryMB, deltaMB)
-			newMemoryMB = currentMemoryMB + maxhotPluggableMemoryMB
-		} else {
-			newMemoryMB = finalMemoryMB
-		}
+			if deltaMB > int32(maxhotPluggableMemoryMB) {
+				s.Logger().Warnf("Large hotplug. Adding %d MB of %d total memory", maxhotPluggableMemoryMB, deltaMB)
+				newMemoryMB = currentMemoryMB + maxhotPluggableMemoryMB
+			} else {
+				newMemoryMB = finalMemoryMB
+			}
 
-		// Add the memory to the guest and online the memory:
-		if err := s.updateMemory(ctx, newMemoryMB); err != nil {
-			return err
-		}
+			// Add the memory to the guest and online the memory:
+			if err := s.updateMemory(ctx, newMemoryMB); err != nil {
+				return err
+			}
 
-		if newMemoryMB == finalMemoryMB {
-			break
+			if newMemoryMB == finalMemoryMB {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
This has two staged changes on top of the upstreamed clh-go templating support PR https://github.com/microsoft/kata-containers/pull/461

1. Hotplugging memory into VMs with zoned memory. This enables us to resize a templated VM to the workload size. Should also be cherry-picked and sent upstream.
2. Msft-only change to hook up the fork's static_resource_* configs to the template paths. Upstream doesn't have/use these configs.

End result is that we can have default_* configs = 0, static_resource_management=true, AND VM templating enabled. This means we get VM templating with no changes to our VM size model.

In the templating configuration we can restore from the default size (512Mi) and resize UP to match the deployment's required size. What we do lose is the ability to deploy with limits less than the default size (< 512Mi).