### PR TITLE
Michaelx/up/3.32.0/snapshot restore feature disks

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -225,6 +225,7 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 				KernelPath:     s.config.HypervisorConfig.KernelPath,
 				ImagePath:      s.config.HypervisorConfig.ImagePath,
 				NetNSPath:      netNSPath,
+				DisableSeccomp: s.config.HypervisorConfig.DisableSeccomp,
 			})
 		} else {
 			sandbox, _, err = katautils.CreateSandbox(s.ctx, vci, *ociSpec, *s.config, rootFs, r.ID, bundlePath, disableOutput, false)

--- a/src/runtime/pkg/containerd-shim-v2/shim_management.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management.go
@@ -529,44 +529,8 @@ func packageErofsSnapshotDisks(destDir string, cfg map[string]interface{}) (bool
 	return changed, nil
 }
 
-func copySnapshotFile(sourcePath, destinationPath string) (err error) {
-	source, err := os.Open(sourcePath)
-	if err != nil {
-		return err
-	}
-	defer source.Close()
-
-	info, err := source.Stat()
-	if err != nil {
-		return err
-	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("source is not a regular file")
-	}
-
-	temporary, err := os.CreateTemp(filepath.Dir(destinationPath), ".snapshot-disk-")
-	if err != nil {
-		return err
-	}
-	temporaryPath := temporary.Name()
-	defer func() {
-		_ = temporary.Close()
-		_ = os.Remove(temporaryPath)
-	}()
-
-	if err := temporary.Chmod(info.Mode().Perm()); err != nil {
-		return err
-	}
-	if _, err := io.Copy(temporary, source); err != nil {
-		return err
-	}
-	if err := temporary.Sync(); err != nil {
-		return err
-	}
-	if err := temporary.Close(); err != nil {
-		return err
-	}
-	return os.Rename(temporaryPath, destinationPath)
+func copySnapshotFile(sourcePath, destinationPath string) error {
+	return mutils.CopyFileSparse(sourcePath, destinationPath)
 }
 
 // copyPersistInto copies /run/vc/sbs/<id>/persist.json into destDir.

--- a/src/runtime/pkg/containerd-shim-v2/shim_management.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management.go
@@ -432,10 +432,8 @@ func (s *service) doSnapshot(ctx context.Context, destDir string) error {
 	if err := s.sandbox.SaveVM(destDir); err != nil {
 		return err
 	}
-	// repoint config.json's memory zone file at the in-dir memory-ranges so the
-	// snapshot is self-contained for memory (the source path it inherits is the
-	// shared template/source memory, outside this dir). without this, a restore
-	// that reads config.json mmaps the wrong file (or fails if it is gone).
+	// Finalize config.json with snapshot-owned memory and EROFS disk paths. A
+	// restore copies this finalized config before applying per-VM changes.
 	if err := makeConfigSelfContained(destDir); err != nil {
 		return err
 	}
@@ -446,21 +444,12 @@ func (s *service) doSnapshot(ctx context.Context, destDir string) error {
 	return s.writeSnapshotManifest(destDir)
 }
 
-// makeConfigSelfContained rewrites config.json's memory zone backing-file paths
-// to point at the memory-ranges file inside destDir. cloud-hypervisor writes the
-// snapshot's config.json from the live VmConfig, whose memory.zones[].file still
-// names the source memory path (e.g. /run/vc/vm/template/memory) outside destDir.
-// On restore CLH opens that path to back the memory zone, so a relocated snapshot
-// (or a GC'd source) would fail. Pointing it at the in-dir memory-ranges makes the
-// snapshot dir's memory self-contained. (Disks are not rewritten here; that is
-// separate, larger work for cross-host portability.)
+// makeConfigSelfContained rewrites config.json to use snapshot-owned memory and
+// EROFS disk files. cloud-hypervisor otherwise records the live backing paths,
+// which disappear when containerd removes the source snapshots.
 func makeConfigSelfContained(destDir string) error {
 	configPath := filepath.Join(destDir, "config.json")
 	memoryRanges := filepath.Join(destDir, "memory-ranges")
-	if _, err := os.Stat(memoryRanges); err != nil {
-		// no memory-ranges file: nothing to repoint, leave config as-is.
-		return nil
-	}
 	raw, err := os.ReadFile(configPath)
 	if err != nil {
 		return err
@@ -469,24 +458,115 @@ func makeConfigSelfContained(destDir string) error {
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return err
 	}
-	mem, ok := cfg["memory"].(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	zones, ok := mem["zones"].([]interface{})
-	if !ok {
-		return nil
-	}
-	for _, z := range zones {
-		if zm, ok := z.(map[string]interface{}); ok {
-			zm["file"] = memoryRanges
+
+	changed := false
+	if _, err := os.Stat(memoryRanges); err == nil {
+		if mem, ok := cfg["memory"].(map[string]interface{}); ok {
+			if zones, ok := mem["zones"].([]interface{}); ok {
+				for _, zone := range zones {
+					if zoneMap, ok := zone.(map[string]interface{}); ok {
+						zoneMap["file"] = memoryRanges
+						changed = true
+					}
+				}
+			}
 		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat snapshot memory file %s: %w", memoryRanges, err)
 	}
+
+	disksChanged, err := packageErofsSnapshotDisks(destDir, cfg)
+	if err != nil {
+		return err
+	}
+	changed = changed || disksChanged
+	if !changed {
+		return nil
+	}
+
 	out, err := json.Marshal(cfg)
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(configPath, out, 0600)
+}
+
+func packageErofsSnapshotDisks(destDir string, cfg map[string]interface{}) (bool, error) {
+	disks, ok := cfg["disks"].([]interface{})
+	if !ok {
+		return false, nil
+	}
+
+	diskDir := filepath.Join(destDir, "disks")
+	changed := false
+	for index, entry := range disks {
+		disk, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		sourcePath, ok := disk["path"].(string)
+		if !ok || sourcePath == "" {
+			continue
+		}
+		baseName := filepath.Base(sourcePath)
+		if baseName != "layer.erofs" && baseName != "rwlayer.img" {
+			continue
+		}
+
+		if err := os.MkdirAll(diskDir, 0700); err != nil {
+			return false, fmt.Errorf("create snapshot disk directory: %w", err)
+		}
+		destinationPath := filepath.Join(diskDir, fmt.Sprintf("%d-%s", index, baseName))
+		if filepath.Clean(sourcePath) != filepath.Clean(destinationPath) {
+			if err := copySnapshotFile(sourcePath, destinationPath); err != nil {
+				return false, fmt.Errorf("package snapshot disk %q from %s: %w", disk["id"], sourcePath, err)
+			}
+		}
+		disk["path"] = destinationPath
+		changed = true
+	}
+
+	return changed, nil
+}
+
+func copySnapshotFile(sourcePath, destinationPath string) (err error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	info, err := source.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("source is not a regular file")
+	}
+
+	temporary, err := os.CreateTemp(filepath.Dir(destinationPath), ".snapshot-disk-")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		_ = temporary.Close()
+		_ = os.Remove(temporaryPath)
+	}()
+
+	if err := temporary.Chmod(info.Mode().Perm()); err != nil {
+		return err
+	}
+	if _, err := io.Copy(temporary, source); err != nil {
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, destinationPath)
 }
 
 // copyPersistInto copies /run/vc/sbs/<id>/persist.json into destDir.

--- a/src/runtime/pkg/containerd-shim-v2/shim_management_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management_test.go
@@ -6,15 +6,19 @@
 package containerdshim
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/vcmock"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServeMetrics(t *testing.T) {
@@ -60,4 +64,68 @@ go_threads 23
 	assert.Equal(200, rr.Code, "response code should be 200")
 	body = rr.Body.String()
 	assert.Equal(true, len(strings.Split(body, "\n")) > 0)
+}
+
+func TestMakeConfigSelfContainedPackagesErofsDisks(t *testing.T) {
+	snapshotDir := t.TempDir()
+	erofsDir := t.TempDir()
+	stableDir := t.TempDir()
+
+	memoryRanges := filepath.Join(snapshotDir, "memory-ranges")
+	stableDisk := filepath.Join(stableDir, "kata-containers.img")
+	lowerDisk := filepath.Join(erofsDir, "layer.erofs")
+	writableDisk := filepath.Join(erofsDir, "rwlayer.img")
+	require.NoError(t, os.WriteFile(memoryRanges, []byte("memory"), 0o600))
+	require.NoError(t, os.WriteFile(stableDisk, []byte("base image"), 0o600))
+	require.NoError(t, os.WriteFile(lowerDisk, []byte("read-only layer"), 0o600))
+	require.NoError(t, os.WriteFile(writableDisk, []byte("writable layer"), 0o600))
+
+	config := map[string]interface{}{
+		"memory": map[string]interface{}{
+			"zones": []interface{}{map[string]interface{}{"file": "/old/memory"}},
+		},
+		"disks": []interface{}{
+			map[string]interface{}{"id": "_disk0", "path": stableDisk},
+			map[string]interface{}{"id": "_disk3", "path": lowerDisk},
+			map[string]interface{}{"id": "_disk4", "path": writableDisk},
+		},
+	}
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+	configPath := filepath.Join(snapshotDir, "config.json")
+	require.NoError(t, os.WriteFile(configPath, configJSON, 0o600))
+
+	require.NoError(t, makeConfigSelfContained(snapshotDir))
+
+	var restoredConfig struct {
+		Memory struct {
+			Zones []struct {
+				File string `json:"file"`
+			} `json:"zones"`
+		} `json:"memory"`
+		Disks []struct {
+			ID   string `json:"id"`
+			Path string `json:"path"`
+		} `json:"disks"`
+	}
+	updatedConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(updatedConfig, &restoredConfig))
+	require.Len(t, restoredConfig.Memory.Zones, 1)
+	assert.Equal(t, memoryRanges, restoredConfig.Memory.Zones[0].File)
+	require.Len(t, restoredConfig.Disks, 3)
+	assert.Equal(t, stableDisk, restoredConfig.Disks[0].Path)
+
+	expectedLowerDisk := filepath.Join(snapshotDir, "disks", "1-layer.erofs")
+	expectedWritableDisk := filepath.Join(snapshotDir, "disks", "2-rwlayer.img")
+	assert.Equal(t, expectedLowerDisk, restoredConfig.Disks[1].Path)
+	assert.Equal(t, expectedWritableDisk, restoredConfig.Disks[2].Path)
+
+	require.NoError(t, os.RemoveAll(erofsDir))
+	lowerContent, err := os.ReadFile(expectedLowerDisk)
+	require.NoError(t, err)
+	assert.Equal(t, "read-only layer", string(lowerContent))
+	writableContent, err := os.ReadFile(expectedWritableDisk)
+	require.NoError(t, err)
+	assert.Equal(t, "writable layer", string(writableContent))
 }

--- a/src/runtime/pkg/utils/copy_file.go
+++ b/src/runtime/pkg/utils/copy_file.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const sparseCopyCommand = "/bin/cp"
+
+// CopyFileSparse atomically copies a regular file while preserving holes.
+func CopyFileSparse(sourcePath, destinationPath string) error {
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("source %s is not a regular file", sourcePath)
+	}
+
+	temporary, err := os.CreateTemp(filepath.Dir(destinationPath), ".sparse-copy-")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		_ = os.Remove(temporaryPath)
+	}()
+
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	output, err := exec.Command(sparseCopyCommand, "--sparse=always", "--preserve=mode", "--", sourcePath, temporaryPath).CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail != "" {
+			return fmt.Errorf("sparse copy %s to %s: %w: %s", sourcePath, destinationPath, err, detail)
+		}
+		return fmt.Errorf("sparse copy %s to %s: %w", sourcePath, destinationPath, err)
+	}
+
+	copied, err := os.OpenFile(temporaryPath, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	syncErr := copied.Sync()
+	closeErr := copied.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	return os.Rename(temporaryPath, destinationPath)
+}

--- a/src/runtime/pkg/utils/copy_file_test.go
+++ b/src/runtime/pkg/utils/copy_file_test.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyFileSparse(t *testing.T) {
+	directory := t.TempDir()
+	sourcePath := filepath.Join(directory, "source.img")
+	destinationPath := filepath.Join(directory, "destination.img")
+
+	const fileSize = int64(32 * 1024 * 1024)
+	source, err := os.OpenFile(sourcePath, os.O_CREATE|os.O_RDWR, 0o640)
+	require.NoError(t, err)
+	require.NoError(t, source.Truncate(fileSize))
+	requireWriteAt(t, source, []byte("beginning"), 0)
+	requireWriteAt(t, source, make([]byte, 128*1024), fileSize/4)
+	requireWriteAt(t, source, []byte("middle"), fileSize/2)
+	requireWriteAt(t, source, []byte("end"), fileSize-3)
+	require.NoError(t, source.Close())
+	require.NoError(t, os.WriteFile(destinationPath, []byte("old destination"), 0o600))
+
+	require.NoError(t, CopyFileSparse(sourcePath, destinationPath))
+
+	destinationInfo, err := os.Stat(destinationPath)
+	require.NoError(t, err)
+	assert.Equal(t, fileSize, destinationInfo.Size())
+	assert.Equal(t, os.FileMode(0o640), destinationInfo.Mode().Perm())
+
+	destination, err := os.Open(destinationPath)
+	require.NoError(t, err)
+	defer destination.Close()
+	assertReadAt(t, destination, []byte("beginning"), 0)
+	assertReadAt(t, destination, []byte("middle"), fileSize/2)
+	assertReadAt(t, destination, []byte("end"), fileSize-3)
+	assertReadAt(t, destination, make([]byte, 16), fileSize/4)
+
+	stat, ok := destinationInfo.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	assert.Less(t, stat.Blocks*512, fileSize/4, "destination should remain sparse")
+
+	require.NoError(t, os.WriteFile(destinationPath, []byte("private"), 0o640))
+	sourceContent := make([]byte, len("beginning"))
+	source, err = os.Open(sourcePath)
+	require.NoError(t, err)
+	defer source.Close()
+	_, err = source.ReadAt(sourceContent, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "beginning", string(sourceContent))
+}
+
+func requireWriteAt(t *testing.T, file *os.File, data []byte, offset int64) {
+	t.Helper()
+	written, err := file.WriteAt(data, offset)
+	require.NoError(t, err)
+	require.Equal(t, len(data), written)
+}
+
+func assertReadAt(t *testing.T, file *os.File, expected []byte, offset int64) {
+	t.Helper()
+	actual := make([]byte, len(expected))
+	read, err := file.ReadAt(actual, offset)
+	require.NoError(t, err)
+	require.Equal(t, len(expected), read)
+	assert.Equal(t, expected, actual)
+}

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -895,6 +895,9 @@ func (clh *cloudHypervisor) preparePrivateRestoreConfig(configPath, vmID string)
 			}
 		}
 	}
+	if err := clh.preparePrivateRestoreDisks(config, configPath); err != nil {
+		return err
+	}
 
 	nets, _ := config["net"].([]interface{})
 	if len(clh.restoreNetFds) > 0 {
@@ -947,6 +950,56 @@ func (clh *cloudHypervisor) preparePrivateRestoreConfig(configPath, vmID string)
 	}
 
 	return os.WriteFile(configPath, updatedConfig, 0600)
+}
+
+func (clh *cloudHypervisor) preparePrivateRestoreDisks(config map[string]interface{}, configPath string) error {
+	disks, ok := config["disks"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	privateDiskDir := filepath.Join(filepath.Dir(configPath), "disks")
+	for index, entry := range disks {
+		disk, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		sourcePath, ok := disk["path"].(string)
+		if !ok || sourcePath == "" {
+			continue
+		}
+		diskID, _ := disk["id"].(string)
+		if diskID == "" {
+			diskID = fmt.Sprintf("disk[%d]", index)
+		}
+
+		info, err := os.Stat(sourcePath)
+		if err != nil {
+			return fmt.Errorf("kata restore failed: snapshot disk %q path %s is unavailable: %w", diskID, sourcePath, err)
+		}
+		readonly, _ := disk["readonly"].(bool)
+		if readonly {
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("kata restore failed: writable snapshot disk %q path %s is not a regular file", diskID, sourcePath)
+		}
+
+		if err := os.MkdirAll(privateDiskDir, DirMode); err != nil {
+			return fmt.Errorf("kata restore failed: create private disk directory: %w", err)
+		}
+		privatePath := filepath.Join(privateDiskDir, fmt.Sprintf("%d-%s", index, filepath.Base(sourcePath)))
+		if err := clh.copyFile(sourcePath, privatePath); err != nil {
+			return fmt.Errorf("kata restore failed: copy writable snapshot disk %q from %s: %w", diskID, sourcePath, err)
+		}
+		disk["path"] = privatePath
+		clh.Logger().WithFields(log.Fields{
+			"disk-id":      diskID,
+			"private-path": privatePath,
+		}).Debug("restore: copied writable snapshot disk into private VM directory")
+	}
+
+	return nil
 }
 
 // setupInitdata prepares and attaches the initdata disk if present.

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -989,7 +989,7 @@ func (clh *cloudHypervisor) preparePrivateRestoreDisks(config map[string]interfa
 			return fmt.Errorf("kata restore failed: create private disk directory: %w", err)
 		}
 		privatePath := filepath.Join(privateDiskDir, fmt.Sprintf("%d-%s", index, filepath.Base(sourcePath)))
-		if err := clh.copyFile(sourcePath, privatePath); err != nil {
+		if err := pkgUtils.CopyFileSparse(sourcePath, privatePath); err != nil {
 			return fmt.Errorf("kata restore failed: copy writable snapshot disk %q from %s: %w", diskID, sourcePath, err)
 		}
 		disk["path"] = privatePath

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -9,6 +9,7 @@ package virtcontainers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -593,6 +595,121 @@ func TestClhRestoreVM(t *testing.T) {
 	info, err := clh.vmInfo()
 	assert.NoError(err)
 	assert.Equal(clhStatePaused, info.State)
+}
+
+func TestClhPrepareRestoreFilesKeepsSnapshotPrivate(t *testing.T) {
+	snapshotDir := t.TempDir()
+	vmStoreDir := t.TempDir()
+	vmID := "restored-vm"
+	snapshotDiskDir := filepath.Join(snapshotDir, "disks")
+	require.NoError(t, os.MkdirAll(snapshotDiskDir, 0o700))
+
+	readonlyDisk := filepath.Join(snapshotDiskDir, "1-layer.erofs")
+	writableDisk := filepath.Join(snapshotDiskDir, "2-rwlayer.img")
+	require.NoError(t, os.WriteFile(readonlyDisk, []byte("read-only layer"), 0o600))
+	require.NoError(t, os.WriteFile(writableDisk, []byte("writable layer"), 0o600))
+
+	snapshotConfig := map[string]interface{}{
+		"vsock": map[string]interface{}{"socket": "/source/clh.sock"},
+		"memory": map[string]interface{}{
+			"shared": true,
+			"zones":  []interface{}{map[string]interface{}{"shared": true}},
+		},
+		"disks": []interface{}{
+			map[string]interface{}{"id": "_disk3", "path": readonlyDisk, "readonly": true},
+			map[string]interface{}{"id": "_disk4", "path": writableDisk, "readonly": false},
+		},
+	}
+	snapshotConfigJSON, err := json.Marshal(snapshotConfig)
+	require.NoError(t, err)
+	snapshotConfigPath := filepath.Join(snapshotDir, "config.json")
+	require.NoError(t, os.WriteFile(snapshotConfigPath, snapshotConfigJSON, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(snapshotDir, "state.json"), []byte("{}"), 0o600))
+
+	clh := &cloudHypervisor{
+		id: vmID,
+		config: HypervisorConfig{
+			VMStorePath: vmStoreDir,
+		},
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(vmStoreDir, vmID), 0o700))
+	require.NoError(t, clh.prepareRestoreFiles(snapshotDir))
+
+	canonicalConfig, err := os.ReadFile(snapshotConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, snapshotConfigJSON, canonicalConfig)
+
+	privateConfigPath := filepath.Join(vmStoreDir, vmID, "config.json")
+	canonicalConfigInfo, err := os.Stat(snapshotConfigPath)
+	require.NoError(t, err)
+	privateConfigInfo, err := os.Stat(privateConfigPath)
+	require.NoError(t, err)
+	assert.False(t, os.SameFile(canonicalConfigInfo, privateConfigInfo))
+
+	privateConfigJSON, err := os.ReadFile(privateConfigPath)
+	require.NoError(t, err)
+	var privateConfig struct {
+		Vsock struct {
+			Socket string `json:"socket"`
+		} `json:"vsock"`
+		Disks []struct {
+			Path     string `json:"path"`
+			Readonly bool   `json:"readonly"`
+		} `json:"disks"`
+	}
+	require.NoError(t, json.Unmarshal(privateConfigJSON, &privateConfig))
+	require.Len(t, privateConfig.Disks, 2)
+	assert.Equal(t, filepath.Join(vmStoreDir, vmID, clhSocket), privateConfig.Vsock.Socket)
+	assert.Equal(t, readonlyDisk, privateConfig.Disks[0].Path)
+	privateWritableDisk := filepath.Join(vmStoreDir, vmID, "disks", "1-2-rwlayer.img")
+	assert.Equal(t, privateWritableDisk, privateConfig.Disks[1].Path)
+
+	privateConfig.Disks = append(privateConfig.Disks, struct {
+		Path     string `json:"path"`
+		Readonly bool   `json:"readonly"`
+	}{Path: "/first-restore/extra-disk"})
+	mutatedPrivateConfig, err := json.Marshal(privateConfig)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(privateConfigPath, mutatedPrivateConfig, 0o600))
+	require.NoError(t, os.WriteFile(privateWritableDisk, []byte("first restore changed this"), 0o600))
+
+	secondVMID := "second-restored-vm"
+	secondVMDir := filepath.Join(vmStoreDir, secondVMID)
+	require.NoError(t, os.MkdirAll(secondVMDir, 0o700))
+	secondClh := &cloudHypervisor{
+		id: secondVMID,
+		config: HypervisorConfig{
+			VMStorePath: vmStoreDir,
+		},
+	}
+	require.NoError(t, secondClh.prepareRestoreFiles(snapshotDir))
+
+	canonicalConfig, err = os.ReadFile(snapshotConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, snapshotConfigJSON, canonicalConfig)
+	secondPrivateConfigJSON, err := os.ReadFile(filepath.Join(secondVMDir, "config.json"))
+	require.NoError(t, err)
+	var secondPrivateConfig struct {
+		Disks []struct {
+			Path     string `json:"path"`
+			Readonly bool   `json:"readonly"`
+		} `json:"disks"`
+	}
+	require.NoError(t, json.Unmarshal(secondPrivateConfigJSON, &secondPrivateConfig))
+	require.Len(t, secondPrivateConfig.Disks, 2)
+	secondPrivateWritableDisk := filepath.Join(secondVMDir, "disks", "1-2-rwlayer.img")
+	assert.Equal(t, secondPrivateWritableDisk, secondPrivateConfig.Disks[1].Path)
+	secondPrivateDiskContent, err := os.ReadFile(secondPrivateWritableDisk)
+	require.NoError(t, err)
+	assert.Equal(t, "writable layer", string(secondPrivateDiskContent))
+
+	require.NoError(t, os.Remove(writableDisk))
+	firstPrivateDiskContent, err := os.ReadFile(privateWritableDisk)
+	require.NoError(t, err)
+	assert.Equal(t, "first restore changed this", string(firstPrivateDiskContent))
+	secondPrivateDiskContent, err = os.ReadFile(secondPrivateWritableDisk)
+	require.NoError(t, err)
+	assert.Equal(t, "writable layer", string(secondPrivateDiskContent))
 }
 
 func TestClhSaveVM(t *testing.T) {

--- a/src/runtime/virtcontainers/pkg/agent/protocols/client/client_test.go
+++ b/src/runtime/virtcontainers/pkg/agent/protocols/client/client_test.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func startHybridVSockTestServer(t *testing.T, replyAfterAttempt int, replyDelay time.Duration) (string, *atomic.Int32) {
+	t.Helper()
+
+	socketPath := filepath.Join(t.TempDir(), "hybrid-vsock.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var attempts atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			attempt := int(attempts.Add(1))
+			reader := bufio.NewReader(conn)
+			if _, err := reader.ReadString('\n'); err != nil {
+				_ = conn.Close()
+				continue
+			}
+			if replyAfterAttempt > 0 && attempt >= replyAfterAttempt {
+				time.Sleep(replyDelay)
+				_, _ = fmt.Fprint(conn, "OK 1024\n")
+			}
+			_, _ = io.Copy(io.Discard, reader)
+			_ = conn.Close()
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-done
+	})
+
+	return "hvsock:" + socketPath + ":1024", &attempts
+}
+
+func TestHybridVSockDialerRetriesDroppedHandshake(t *testing.T) {
+	socket, attempts := startHybridVSockTestServer(t, 2, 0)
+
+	started := time.Now()
+	conn, err := hybridVSockDialer(context.Background(), socket, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if attempts.Load() < 2 {
+		t.Fatalf("expected a retry after the dropped handshake, got %d attempt(s)", attempts.Load())
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("dropped handshake consumed the full dial timeout: %v", elapsed)
+	}
+}
+
+func TestHybridVSockDialerExpandsHandshakeWindow(t *testing.T) {
+	socket, attempts := startHybridVSockTestServer(t, 2, 40*time.Millisecond)
+
+	conn, err := hybridVSockDialer(context.Background(), socket, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if attempts.Load() < 2 {
+		t.Fatalf("expected a longer retry after the initial handshake window, got %d attempt(s)", attempts.Load())
+	}
+}
+
+func TestHybridVSockDialerHonorsOverallTimeout(t *testing.T) {
+	socket, attempts := startHybridVSockTestServer(t, 0, 0)
+
+	const timeout = 120 * time.Millisecond
+	started := time.Now()
+	conn, err := hybridVSockDialer(context.Background(), socket, timeout)
+	if conn != nil {
+		conn.Close()
+		t.Fatal("expected dialing to fail")
+	}
+	if grpcStatus.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+	if attempts.Load() < 2 {
+		t.Fatalf("expected multiple attempts, got %d", attempts.Load())
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("dial exceeded its overall timeout: %v", elapsed)
+	}
+}

--- a/src/runtime/virtcontainers/restore.go
+++ b/src/runtime/virtcontainers/restore.go
@@ -26,6 +26,23 @@ type RestoreOpts struct {
 	KernelPath     string
 	ImagePath      string
 	NetNSPath      string
+	DisableSeccomp bool
+}
+
+func (opts RestoreOpts) applyHypervisorOverrides(config *HypervisorConfig) {
+	if opts.HypervisorPath != "" {
+		config.HypervisorPath = opts.HypervisorPath
+	}
+	if opts.KernelPath != "" {
+		config.KernelPath = opts.KernelPath
+	}
+	if opts.ImagePath != "" {
+		config.ImagePath = opts.ImagePath
+	}
+
+	// The restored VMM is a new host process, so use the current runtime's
+	// seccomp policy rather than the snapshot's persisted configuration.
+	config.DisableSeccomp = opts.DisableSeccomp
 }
 
 // RestoreSandbox restores a snapshot as a managed, paused sandbox.
@@ -66,15 +83,7 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 	}
 	sandboxConfig.ID = newID
 
-	if opts.HypervisorPath != "" {
-		sandboxConfig.HypervisorConfig.HypervisorPath = opts.HypervisorPath
-	}
-	if opts.KernelPath != "" {
-		sandboxConfig.HypervisorConfig.KernelPath = opts.KernelPath
-	}
-	if opts.ImagePath != "" {
-		sandboxConfig.HypervisorConfig.ImagePath = opts.ImagePath
-	}
+	opts.applyHypervisorOverrides(&sandboxConfig.HypervisorConfig)
 
 	// Keep source memory immutable through a private mapping.
 	sandboxConfig.HypervisorConfig.FileBackedMemory = &FileBackedMemoryConfig{


### PR DESCRIPTION
This PR contains an important fix to the snapshot/restore flow:

Before this change we are depending on two things:
1. The snapshot layers for the container images must still be present on the node (not guaranteed and extremely unsafe to assume, plus it is guaranteed these image layers won't be present in the same spot on a different node)
2. Users not storing any state in the writable layers of the container. The writable layers of the container images were not being stored in the snapshot, leading to potential state loss for the workload. 

To address this, we now include copies of the image layers (ro) and writable layers (rwlayer.img) in the snapshot. The snapshot config.json is now wired such that the layers (present as disks in the clh config.json) for workloads now map to these snapshot instances of the images, not the layers deposited by containerd on the system. 

There is some trickiness with handling the files efficiently as erofs layers (in our current containerd config)  as they are extremely sparse 10G files. So, included in this change is a special helper which ensures these large logical disks are copied sparsely with cp --sparse=always. 

Also batched in this PR are some extra tests for the vsock fix which I forgot to stage when pushing to the branch. 

For debugging I also fixed an issue where the disable_seccomp config wasn't hooked up properly for the restore-from annotation path. Now we can disable seccomp for the restored VMs as well, helping with future debugging efforts if this thing falls over. 
