### PR TITLE
sr: Handle restore transaction atomically

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -298,6 +298,18 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 	return container, nil
 }
 
+func isRestoreCreateRequest(s *service, r *taskAPI.CreateTaskRequest) bool {
+	if s.restoredSandbox {
+		return true
+	}
+	ociSpec, _, err := loadSpec(r)
+	if err != nil {
+		return false
+	}
+	_, restore := ociSpec.Annotations[annotations.RestoreFrom]
+	return restore
+}
+
 func loadSpec(r *taskAPI.CreateTaskRequest) (*specs.Spec, string, error) {
 	// Checks the MUST and MUST NOT from OCI runtime specification
 	bundlePath, err := validBundle(r.ID, r.Bundle)

--- a/src/runtime/pkg/containerd-shim-v2/create_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/create_test.go
@@ -8,10 +8,12 @@ package containerdshim
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/containerd/namespaces"
@@ -19,6 +21,7 @@ import (
 	crioption "github.com/containerd/cri-containerd/pkg/api/runtimeoptions/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	ktu "github.com/kata-containers/kata-containers/src/runtime/pkg/katatestutils"
@@ -218,6 +221,124 @@ func TestCreateContainerSuccess(t *testing.T) {
 	ctx := namespaces.WithNamespace(context.Background(), "UnitTest")
 	_, err = s.Create(ctx, req)
 	assert.NoError(err)
+}
+
+func TestCreateRestoredContainerIsNotAbandonedOnCancellation(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	stopped := false
+	deleted := false
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
+		RestoreContainerFunc: func(containerConfig vc.ContainerConfig) (vc.VCContainer, error) {
+			close(entered)
+			<-release
+			return &vcmock.Container{}, nil
+		},
+		AbortRestoreFunc: func() error {
+			stopped = true
+			return nil
+		},
+		DeleteFunc: func() error {
+			deleted = true
+			return nil
+		},
+	}
+
+	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
+	runtimeConfig, err := newTestRuntimeConfig(tmpdir, true)
+	require.NoError(t, err)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
+	require.NoError(t, err)
+	spec.Annotations = map[string]string{
+		testContainerTypeAnnotation: testContainerTypeContainer,
+		testSandboxIDAnnotation:     testSandboxID,
+	}
+	require.NoError(t, ktu.WriteOCIConfigFile(spec, ociConfigFile))
+
+	s := &service{
+		id:              testSandboxID,
+		sandbox:         sandbox,
+		restoredSandbox: true,
+		containers:      make(map[string]*container),
+		config:          &runtimeConfig,
+		ctx:             context.Background(),
+	}
+	req := &taskAPI.CreateTaskRequest{ID: testContainerID, Bundle: bundlePath, Terminal: true}
+	ctx, cancel := context.WithCancel(namespaces.WithNamespace(context.Background(), "UnitTest"))
+	result := make(chan error, 1)
+	go func() {
+		_, createErr := s.Create(ctx, req)
+		result <- createErr
+	}()
+
+	<-entered
+	cancel()
+	select {
+	case createErr := <-result:
+		t.Fatalf("restore Create returned before its sandbox mutation completed: %v", createErr)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(release)
+	createErr := <-result
+	require.Error(t, createErr)
+	assert.ErrorIs(t, createErr, context.Canceled)
+	assert.True(t, s.restoreFailed)
+	assert.True(t, stopped)
+	assert.True(t, deleted)
+	assert.NotContains(t, s.containers, testContainerID)
+}
+
+func TestCreateRestoredContainerAdoptionErrorFailsSandbox(t *testing.T) {
+	adoptionErr := errors.New("kata restore failed: workload \"busybox\" is already adopted")
+	stopped := false
+	deleted := false
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
+		RestoreContainerFunc: func(vc.ContainerConfig) (vc.VCContainer, error) {
+			return nil, adoptionErr
+		},
+		AbortRestoreFunc: func() error {
+			stopped = true
+			return nil
+		},
+		DeleteFunc: func() error {
+			deleted = true
+			return nil
+		},
+	}
+
+	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
+	runtimeConfig, err := newTestRuntimeConfig(tmpdir, true)
+	require.NoError(t, err)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
+	require.NoError(t, err)
+	spec.Annotations = map[string]string{
+		testContainerTypeAnnotation: testContainerTypeContainer,
+		testSandboxIDAnnotation:     testSandboxID,
+	}
+	require.NoError(t, ktu.WriteOCIConfigFile(spec, ociConfigFile))
+
+	s := &service{
+		id:              testSandboxID,
+		sandbox:         sandbox,
+		restoredSandbox: true,
+		containers:      make(map[string]*container),
+		config:          &runtimeConfig,
+		ctx:             context.Background(),
+	}
+	_, err = s.Create(namespaces.WithNamespace(context.Background(), "UnitTest"), &taskAPI.CreateTaskRequest{
+		ID: testContainerID, Bundle: bundlePath, Terminal: true,
+	})
+	require.ErrorContains(t, err, "already adopted")
+	assert.True(t, s.restoreFailed)
+	assert.True(t, stopped)
+	assert.True(t, deleted)
+
+	_, err = s.Create(namespaces.WithNamespace(context.Background(), "UnitTest"), &taskAPI.CreateTaskRequest{
+		ID: "retry-container", Bundle: bundlePath, Terminal: true,
+	})
+	assert.ErrorContains(t, err, "pod sandbox restore is terminal")
 }
 
 func TestCreateContainerFail(t *testing.T) {

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -123,8 +123,9 @@ type exit struct {
 type service struct {
 	sandbox vc.VCSandbox
 
-	restoredSandbox bool
+	restoredSandbox  bool
 	restoreFinalized bool
+	restoreFailed    bool
 
 	ctx      context.Context
 	rootCtx  context.Context // root context for tracing
@@ -421,47 +422,68 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 	if err := katautils.VerifyContainerID(r.ID); err != nil {
 		return nil, err
 	}
+	if s.restoreFailed {
+		return nil, fmt.Errorf("kata restore failed: pod sandbox restore is terminal; recreate the pod sandbox")
+	}
 
 	type Result struct {
 		container *container
 		err       error
 	}
-	ch := make(chan Result, 1)
-	go func() {
-		container, err := create(ctx, s, r)
-		ch <- Result{container, err}
-	}()
+	restoreCreate := isRestoreCreateRequest(s, r)
+	var res Result
+	if restoreCreate {
+		// Restore mutates persistent sandbox ownership. Do not let the RPC
+		// timeout abandon that mutation in a goroutine with no result consumer.
+		res.container, res.err = create(ctx, s, r)
+	} else {
+		ch := make(chan Result, 1)
+		go func() {
+			container, err := create(ctx, s, r)
+			ch <- Result{container, err}
+		}()
 
-	select {
-	case <-ctx.Done():
-		return nil, errors.Errorf("create container timeout: %v", r.ID)
-	case res := <-ch:
-		if res.err != nil {
-			return nil, res.err
+		select {
+		case <-ctx.Done():
+			return nil, errors.Errorf("create container timeout: %v", r.ID)
+		case res = <-ch:
 		}
-		container := res.container
-		container.status = task.Status_CREATED
-
-		s.containers[r.ID] = container
-
-		s.send(&eventstypes.TaskCreate{
-			ContainerID: r.ID,
-			Bundle:      r.Bundle,
-			Rootfs:      r.Rootfs,
-			IO: &eventstypes.TaskIO{
-				Stdin:    r.Stdin,
-				Stdout:   r.Stdout,
-				Stderr:   r.Stderr,
-				Terminal: r.Terminal,
-			},
-			Checkpoint: r.Checkpoint,
-			Pid:        s.hpid,
-		})
-
-		return &taskAPI.CreateTaskResponse{
-			Pid: s.hpid,
-		}, nil
 	}
+	if res.err != nil {
+		if s.restoredSandbox {
+			s.failRestoredSandbox(res.err)
+		}
+		return nil, res.err
+	}
+	if restoreCreate && ctx.Err() != nil {
+		err := errors.Wrapf(ctx.Err(), "kata restore failed: create result for %s could not be committed", r.ID)
+		if s.restoredSandbox {
+			s.failRestoredSandbox(err)
+		}
+		return nil, err
+	}
+	container := res.container
+	container.status = task.Status_CREATED
+
+	s.containers[r.ID] = container
+
+	s.send(&eventstypes.TaskCreate{
+		ContainerID: r.ID,
+		Bundle:      r.Bundle,
+		Rootfs:      r.Rootfs,
+		IO: &eventstypes.TaskIO{
+			Stdin:    r.Stdin,
+			Stdout:   r.Stdout,
+			Stderr:   r.Stderr,
+			Terminal: r.Terminal,
+		},
+		Checkpoint: r.Checkpoint,
+		Pid:        s.hpid,
+	})
+
+	return &taskAPI.CreateTaskResponse{
+		Pid: s.hpid,
+	}, nil
 }
 
 // Start a process

--- a/src/runtime/pkg/containerd-shim-v2/start.go
+++ b/src/runtime/pkg/containerd-shim-v2/start.go
@@ -8,9 +8,12 @@ package containerdshim
 import (
 	"context"
 	"fmt"
+	"time"
 
+	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/types/task"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
 )
@@ -20,7 +23,10 @@ func startContainer(ctx context.Context, s *service, c *container) (retErr error
 	defer func() {
 		if retErr != nil {
 			// notify the wait goroutine to continue
-			c.exitCh <- exitCode255
+			select {
+			case c.exitCh <- exitCode255:
+			default:
+			}
 		}
 	}()
 	// start a container
@@ -32,6 +38,9 @@ func startContainer(ctx context.Context, s *service, c *container) (retErr error
 	if s.sandbox == nil {
 		err := fmt.Errorf("Bug, the sandbox hasn't been created for this container %s", c.id)
 		return err
+	}
+	if s.restoreFailed {
+		return fmt.Errorf("kata restore failed: pod sandbox restore is terminal; recreate the pod sandbox")
 	}
 
 	if c.cType.IsSandbox() && s.restoredSandbox {
@@ -69,6 +78,11 @@ func startContainer(ctx context.Context, s *service, c *container) (retErr error
 		// The first workload start resumes the VM and restores its network
 		// identity; later workload starts find the guest already live.
 		if !s.restoreFinalized {
+			defer func() {
+				if retErr != nil && !s.restoreFinalized {
+					s.failRestoredSandbox(retErr)
+				}
+			}()
 			if err := s.sandbox.FinalizeRestoreNetwork(ctx); err != nil {
 				return err
 			}
@@ -126,6 +140,54 @@ func startContainer(ctx context.Context, s *service, c *container) (retErr error
 	go wait(ctx, s, c, "")
 
 	return nil
+}
+
+const restoredSandboxFailureCleanupTimeout = 30 * time.Second
+
+// failRestoredSandbox makes a failed first workload start fatal to the pause
+// task. CRI must recreate the pod sandbox rather than retry adoption in a VM
+// that has already been stopped.
+func (s *service) failRestoredSandbox(cause error) {
+	if s.restoreFailed {
+		return
+	}
+	s.restoreFailed = true
+
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), restoredSandboxFailureCleanupTimeout)
+	defer cancel()
+	shimLog.WithError(cause).Error("restored sandbox failed before first workload start completed")
+	abortErr := s.sandbox.AbortRestore(cleanupCtx)
+	if abortErr != nil {
+		shimLog.WithError(abortErr).Warn("failed to abort terminal restored sandbox")
+		return
+	}
+	if err := s.sandbox.Delete(cleanupCtx); err != nil {
+		shimLog.WithError(err).Warn("failed to delete terminal restored sandbox")
+	}
+
+	exitedAt := time.Now()
+	var pauseTask *container
+	for _, taskContainer := range s.containers {
+		taskContainer.status = task.Status_STOPPED
+		taskContainer.exit = exitCode255
+		taskContainer.exitTime = exitedAt
+		select {
+		case taskContainer.exitCh <- exitCode255:
+		default:
+		}
+		if taskContainer.cType.IsSandbox() {
+			pauseTask = taskContainer
+		}
+	}
+	if pauseTask != nil {
+		s.send(&eventstypes.TaskExit{
+			ContainerID: pauseTask.id,
+			ID:          pauseTask.id,
+			Pid:         s.hpid,
+			ExitStatus:  exitCode255,
+			ExitedAt:    timestamppb.New(exitedAt),
+		})
+	}
 }
 
 // armDeferredRestoredPauseTask attaches pause-task I/O after the restored VM is resumed.

--- a/src/runtime/pkg/containerd-shim-v2/start_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/start_test.go
@@ -8,9 +8,12 @@ package containerdshim
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	eventstypes "github.com/containerd/containerd/api/events"
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
+	"github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/namespaces"
 
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
@@ -18,7 +21,98 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/vcmock"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestStartRestoredWorkloadFailureExitsSandbox(t *testing.T) {
+	finalizeErr := errors.New("restore network rewiring failed")
+	stopped := false
+	deleted := false
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
+		FinalizeRestoreNetworkFunc: func() error {
+			return finalizeErr
+		},
+		AbortRestoreFunc: func() error {
+			stopped = true
+			return nil
+		},
+		DeleteFunc: func() error {
+			deleted = true
+			return nil
+		},
+	}
+	s := &service{
+		id:              testSandboxID,
+		sandbox:         sandbox,
+		restoredSandbox: true,
+		containers:      make(map[string]*container),
+		events:          make(chan interface{}, 1),
+		ctx:             namespaces.WithNamespace(context.Background(), "UnitTest"),
+		hpid:            1234,
+	}
+
+	pause, err := newContainer(s, &taskAPI.CreateTaskRequest{ID: testSandboxID}, vc.PodSandbox, nil, false)
+	require.NoError(t, err)
+	pause.status = task.Status_CREATED
+	workload, err := newContainer(s, &taskAPI.CreateTaskRequest{ID: testContainerID}, vc.PodContainer, nil, false)
+	require.NoError(t, err)
+	s.containers[pause.id] = pause
+	s.containers[workload.id] = workload
+
+	err = startContainer(context.Background(), s, workload)
+	require.ErrorIs(t, err, finalizeErr)
+	assert.True(t, s.restoreFailed)
+	assert.True(t, stopped)
+	assert.True(t, deleted)
+	assert.Equal(t, task.Status_STOPPED, pause.status)
+	assert.Equal(t, task.Status_STOPPED, workload.status)
+
+	event := <-s.events
+	exitEvent, ok := event.(*eventstypes.TaskExit)
+	require.True(t, ok)
+	assert.Equal(t, testSandboxID, exitEvent.ContainerID)
+	assert.Equal(t, uint32(exitCode255), exitEvent.ExitStatus)
+
+	err = startContainer(context.Background(), s, workload)
+	assert.ErrorContains(t, err, "pod sandbox restore is terminal")
+}
+
+func TestFailedRestoredSandboxDoesNotPublishExitWhenStopFails(t *testing.T) {
+	stopErr := errors.New("VMM could not be stopped")
+	sandbox := &vcmock.Sandbox{
+		MockID: testSandboxID,
+		FinalizeRestoreNetworkFunc: func() error {
+			return errors.New("restore network rewiring failed")
+		},
+		AbortRestoreFunc: func() error {
+			return stopErr
+		},
+	}
+	s := &service{
+		id:              testSandboxID,
+		sandbox:         sandbox,
+		restoredSandbox: true,
+		containers:      make(map[string]*container),
+		events:          make(chan interface{}, 1),
+		ctx:             namespaces.WithNamespace(context.Background(), "UnitTest"),
+	}
+	pause, err := newContainer(s, &taskAPI.CreateTaskRequest{ID: testSandboxID}, vc.PodSandbox, nil, false)
+	require.NoError(t, err)
+	workload, err := newContainer(s, &taskAPI.CreateTaskRequest{ID: testContainerID}, vc.PodContainer, nil, false)
+	require.NoError(t, err)
+	s.containers[pause.id] = pause
+	s.containers[workload.id] = workload
+
+	require.Error(t, startContainer(context.Background(), s, workload))
+	assert.True(t, s.restoreFailed)
+	assert.Equal(t, task.Status_CREATED, pause.status)
+	select {
+	case event := <-s.events:
+		t.Fatalf("published false terminal event while VMM stop failed: %T", event)
+	default:
+	}
+}
 
 func TestStartStartSandboxSuccess(t *testing.T) {
 	assert := assert.New(t)

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -2009,18 +2009,23 @@ func (clh *cloudHypervisor) terminate(ctx context.Context, waitOnly bool) (err e
 
 	clh.Logger().Debug("Stopping Cloud Hypervisor")
 
+	var shutdownErr error
 	if pidRunning && !waitOnly {
 		clhRunning, _ := clh.isClhRunning(uint(clh.getClhStopSandboxTimeout()))
 		if clhRunning {
 			ctx, cancel := context.WithTimeout(context.Background(), clh.getClhStopSandboxTimeout()*time.Second)
-			defer cancel()
-			if _, err = clh.client().ShutdownVMM(ctx); err != nil {
-				return err
+			_, shutdownErr = clh.client().ShutdownVMM(ctx)
+			cancel()
+			if shutdownErr != nil {
+				clh.Logger().WithError(shutdownErr).Warn("graceful VMM shutdown failed; waiting for process exit")
 			}
 		}
 	}
 
 	if err = utils.WaitLocalProcess(pid, uint(clh.getClhStopSandboxTimeout()), syscall.Signal(0), clh.Logger()); err != nil {
+		if shutdownErr != nil {
+			return fmt.Errorf("graceful VMM shutdown failed: %v; wait for VMM process: %w", shutdownErr, err)
+		}
 		return err
 	}
 

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -13,9 +13,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
@@ -79,6 +81,7 @@ type clhClientMock struct {
 	vmInfo          chclient.VmInfo
 	restoreRequest  *chclient.RestoreConfig
 	snapshotRequest *chclient.VmSnapshotConfig
+	shutdownVMM     func() error
 }
 
 func (c *clhClientMock) VmmPingGet(ctx context.Context) (chclient.VmmPingResponse, *http.Response, error) {
@@ -86,7 +89,46 @@ func (c *clhClientMock) VmmPingGet(ctx context.Context) (chclient.VmmPingRespons
 }
 
 func (c *clhClientMock) ShutdownVMM(ctx context.Context) (*http.Response, error) {
+	if c.shutdownVMM != nil {
+		return nil, c.shutdownVMM()
+	}
 	return nil, nil
+}
+
+func TestClhTerminateReapsProcessWhenShutdownRequestFails(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	require.NoError(t, cmd.Start())
+	reaped := false
+	t.Cleanup(func() {
+		if !reaped {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+
+	shutdownErr := errors.New("VMM disconnected during shutdown")
+	mockClient := &clhClientMock{
+		shutdownVMM: func() error {
+			require.NoError(t, cmd.Process.Kill())
+			return shutdownErr
+		},
+	}
+	clh := &cloudHypervisor{
+		id:        "reap-after-shutdown-error",
+		APIClient: mockClient,
+		state: CloudHypervisorState{
+			PID: cmd.Process.Pid,
+		},
+		config: HypervisorConfig{
+			VMStorePath: t.TempDir(),
+			SharedFS:    config.NoSharedFS,
+		},
+	}
+
+	require.NoError(t, clh.StopVM(context.Background(), false))
+	_, waitErr := syscall.Wait4(cmd.Process.Pid, nil, syscall.WNOHANG, nil)
+	assert.ErrorIs(t, waitErr, syscall.ECHILD)
+	reaped = true
 }
 
 func (c *clhClientMock) CreateVM(ctx context.Context, vmConfig chclient.VmConfig) (*http.Response, error) {

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -49,6 +49,7 @@ type VCSandbox interface {
 	CreateContainer(ctx context.Context, contConfig ContainerConfig) (VCContainer, error)
 	RestoreContainer(ctx context.Context, contConfig ContainerConfig) (VCContainer, error)
 	FinalizeRestoreNetwork(ctx context.Context) error
+	AbortRestore(ctx context.Context) error
 	DeleteContainer(ctx context.Context, containerID string) (VCContainer, error)
 	StartContainer(ctx context.Context, containerID string) (VCContainer, error)
 	StopContainer(ctx context.Context, containerID string, force bool) (VCContainer, error)

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -1196,6 +1196,9 @@ func activateRestoreTCFence(ctx context.Context, endpoint Endpoint) (err error) 
 // cleanupRestoreTCFence releases restore TAP FDs and removes its redirects and link.
 func cleanupRestoreTCFence(endpoint Endpoint) {
 	netPair := endpoint.NetworkPair()
+	if netPair == nil {
+		return
+	}
 	for _, fd := range netPair.VMFds {
 		if fd != nil {
 			_ = fd.Close()

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -92,6 +92,9 @@ func (s *Sandbox) Resume() error {
 
 // Delete implements the VCSandbox function of the same name.
 func (s *Sandbox) Delete(ctx context.Context) error {
+	if s.DeleteFunc != nil {
+		return s.DeleteFunc()
+	}
 	return nil
 }
 
@@ -115,6 +118,14 @@ func (s *Sandbox) RestoreContainer(ctx context.Context, conf vc.ContainerConfig)
 func (s *Sandbox) FinalizeRestoreNetwork(ctx context.Context) error {
 	if s.FinalizeRestoreNetworkFunc != nil {
 		return s.FinalizeRestoreNetworkFunc()
+	}
+	return fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), s, s.MockID)
+}
+
+// AbortRestore implements the VCSandbox function of the same name.
+func (s *Sandbox) AbortRestore(ctx context.Context) error {
+	if s.AbortRestoreFunc != nil {
+		return s.AbortRestoreFunc()
 	}
 	return fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), s, s.MockID)
 }

--- a/src/runtime/virtcontainers/pkg/vcmock/types.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/types.go
@@ -44,6 +44,7 @@ type Sandbox struct {
 	CreateContainerFunc      func(conf vc.ContainerConfig) (vc.VCContainer, error)
 	RestoreContainerFunc     func(conf vc.ContainerConfig) (vc.VCContainer, error)
 	FinalizeRestoreNetworkFunc func() error
+	AbortRestoreFunc         func() error
 	DeleteContainerFunc      func(contID string) (vc.VCContainer, error)
 	StartContainerFunc       func(contID string) (vc.VCContainer, error)
 	StopContainerFunc        func(contID string, force bool) (vc.VCContainer, error)

--- a/src/runtime/virtcontainers/restore.go
+++ b/src/runtime/virtcontainers/restore.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist"
 	persistapi "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/api"
@@ -66,8 +67,9 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 	if drv == nil {
 		return nil, fmt.Errorf("restore: nil persist driver")
 	}
+	cleanupSafe := true
 	defer func() {
-		if err != nil {
+		if err != nil && cleanupSafe {
 			_ = drv.Destroy(newID)
 		}
 	}()
@@ -104,8 +106,14 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 	}
 	defer func() {
 		if err != nil {
+			if !cleanupSafe {
+				s.Logger().WithError(err).Error("preserving restore resources because VMM stop was not confirmed")
+				return
+			}
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), restoreFailureCleanupTimeout)
+			defer cancel()
 			if s.restoreNetFence {
-				_ = s.network.Run(ctx, func() error {
+				_ = s.network.Run(cleanupCtx, func() error {
 					for _, ep := range s.network.Endpoints() {
 						cleanupRestoreTCFence(ep)
 					}
@@ -114,7 +122,7 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 			}
 			// Delete accepts only terminal or pre-running states.
 			s.state.State = types.StateStopped
-			s.Delete(ctx)
+			s.Delete(cleanupCtx)
 		}
 	}()
 
@@ -171,10 +179,18 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 	vmAssigned := false
 	defer func() {
 		if err != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), restoreFailureCleanupTimeout)
+			defer cancel()
 			if vmAssigned {
-				s.stopVM(ctx)
+				if abortErr := s.AbortRestore(cleanupCtx); abortErr != nil {
+					cleanupSafe = false
+					s.Logger().WithError(abortErr).Error("failed to abort partially restored sandbox")
+				}
 			} else {
-				vm.Stop(ctx)
+				if stopErr := vm.Stop(cleanupCtx); stopErr != nil {
+					cleanupSafe = false
+					s.Logger().WithError(stopErr).Error("failed to stop unassigned restored VM")
+				}
 			}
 		}
 	}()
@@ -183,6 +199,7 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 		return nil, fmt.Errorf("assign restored vm to sandbox: %w", err)
 	}
 	vmAssigned = true
+	s.restoredVM = vm
 
 	if err = adoptPauseContainer(s, origSandboxID); err != nil {
 		return nil, fmt.Errorf("adopt restored pause container: %w", err)
@@ -194,22 +211,28 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 
 // FinalizeRestoreNetwork replaces guest identity before enabling TC redirects.
 func (s *Sandbox) FinalizeRestoreNetwork(ctx context.Context) (err error) {
-	// Keep forwarding closed on failure.
+	defer func() {
+		if err != nil {
+			s.cleanupFailedRestore(err)
+		}
+	}()
+
 	eps := s.network.Endpoints()
 	if len(eps) != 1 {
 		return fmt.Errorf("kata restore failed: expected exactly one adopted CNI endpoint, found %d", len(eps))
 	}
-	defer func() {
-		if err != nil {
-			_ = s.network.Run(ctx, func() error {
-				cleanupRestoreTCFence(eps[0])
-				return nil
-			})
-		}
-	}()
+	if s.restoredVM == nil {
+		return fmt.Errorf("kata restore failed: restored VM lifecycle is unavailable")
+	}
 
-	if err = s.hypervisor.ResumeVM(ctx); err != nil {
+	if err = s.restoredVM.Resume(ctx); err != nil {
 		return fmt.Errorf("kata restore failed: resume: %w", err)
+	}
+	if err = s.restoredVM.ReseedRNG(ctx); err != nil {
+		return fmt.Errorf("kata restore failed: reseed guest RNG: %w", err)
+	}
+	if err = s.restoredVM.SyncTime(ctx); err != nil {
+		return fmt.Errorf("kata restore failed: sync guest time: %w", err)
 	}
 
 	// The restored NIC still has the source identity, so select it by name.
@@ -327,7 +350,51 @@ func (s *Sandbox) FinalizeRestoreNetwork(ctx context.Context) (err error) {
 		return fmt.Errorf("kata restore failed: mark adopted workloads running: %w", serr)
 	}
 	s.restoreActivated = true
+	s.restoredVM = nil
 	s.Logger().WithField("guest-nic", guestNICName).Info("restored network activated")
+	return nil
+}
+
+const restoreFailureCleanupTimeout = 30 * time.Second
+
+// cleanupFailedRestore stops the VMM before releasing the TAP resources it is
+// using. Cleanup must not inherit a failed or canceled task RPC context.
+func (s *Sandbox) cleanupFailedRestore(cause error) {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), restoreFailureCleanupTimeout)
+	defer cancel()
+
+	s.Logger().WithError(cause).Error("restore finalization failed; stopping restored VM")
+	if abortErr := s.AbortRestore(cleanupCtx); abortErr != nil {
+		s.Logger().WithError(abortErr).Error("failed to abort restored VM after finalization error")
+	}
+}
+
+// AbortRestore makes a failed restore terminal. The VMM is stopped and reaped
+// before any TAP descriptor or link is released.
+func (s *Sandbox) AbortRestore(ctx context.Context) error {
+	if stopErr := s.hypervisor.StopVM(ctx, false); stopErr != nil {
+		return fmt.Errorf("stop restored VM: %w", stopErr)
+	}
+	s.restoredVM = nil
+	for _, c := range s.containers {
+		c.state.State = types.StateStopped
+	}
+	s.state.State = types.StateStopped
+
+	if cleanupErr := s.network.Run(ctx, func() error {
+		for _, endpoint := range s.network.Endpoints() {
+			cleanupRestoreTCFence(endpoint)
+		}
+		return nil
+	}); cleanupErr != nil {
+		s.Logger().WithError(cleanupErr).Error("failed to clean restore network fence")
+	}
+	if cleanupErr := s.network.RemoveEndpoints(ctx, s, nil, false); cleanupErr != nil {
+		s.Logger().WithError(cleanupErr).Error("failed to remove restore network endpoints")
+	}
+	if releaseErr := s.Release(ctx); releaseErr != nil {
+		s.Logger().WithError(releaseErr).Warn("failed to release sandbox after aborting restore")
+	}
 	return nil
 }
 
@@ -363,7 +430,10 @@ func adoptPauseContainer(s *Sandbox, origSandboxID string) error {
 }
 
 // RestoreContainer adopts the persisted workload whose CRI container name matches the target's.
-func (s *Sandbox) RestoreContainer(_ context.Context, contConfig ContainerConfig) (VCContainer, error) {
+func (s *Sandbox) RestoreContainer(ctx context.Context, contConfig ContainerConfig) (VCContainer, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("kata restore failed: workload adoption canceled: %w", err)
+	}
 	if spec := contConfig.CustomSpec; spec != nil && spec.Hooks != nil {
 		h := spec.Hooks
 		if len(h.Prestart) > 0 || len(h.CreateRuntime) > 0 || len(h.CreateContainer) > 0 ||

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -275,8 +275,9 @@ type Sandbox struct {
 	// containers.
 	hotplugNetworkConfigApplied bool
 
-	restoreNetFence bool
+	restoreNetFence  bool
 	restoreActivated bool
+	restoredVM       *VM
 }
 
 // ID returns the sandbox identifier string.
@@ -2138,8 +2139,12 @@ func (s *Sandbox) Stop(ctx context.Context, force bool) error {
 		}
 	}
 
-	if err := s.stopVM(ctx); err != nil && !force {
-		return err
+	if err := s.stopVM(ctx); err != nil {
+		// A restored VMM may still own out-of-band TAP FDs. Never tear down
+		// that network while the process could still be alive.
+		if s.restoreNetFence || !force {
+			return err
+		}
 	}
 
 	// shutdown console watcher if exists

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -23,6 +23,8 @@ import (
 // Mutable and not constant so we can mock in tests
 var urandomDev = "/dev/urandom"
 
+const failedVMCreationCleanupTimeout = 30 * time.Second
+
 // VM is abstraction of a virtual machine.
 type VM struct {
 	hypervisor Hypervisor
@@ -143,7 +145,11 @@ func newVM(ctx context.Context, config VMConfig, restoreSnapshotDir string) (*VM
 	defer func() {
 		if err != nil {
 			virtLog.WithField("vm", id).WithError(err).Info("clean up vm")
-			hypervisor.StopVM(ctx, false)
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), failedVMCreationCleanupTimeout)
+			defer cancel()
+			if stopErr := hypervisor.StopVM(cleanupCtx, false); stopErr != nil {
+				virtLog.WithField("vm", id).WithError(stopErr).Error("failed to stop VM after creation error")
+			}
 		}
 	}()
 

--- a/src/runtime/virtcontainers/vm_test.go
+++ b/src/runtime/virtcontainers/vm_test.go
@@ -70,6 +70,8 @@ func TestNewVM(t *testing.T) {
 
 	err = vm.ReseedRNG(context.Background())
 	assert.Nil(err)
+	err = vm.SyncTime(context.Background())
+	assert.Nil(err)
 
 	// restore a VM from a snapshot
 	vmFromSnapshot, err := NewVMFromSnapshot(ctx, config, testDir)


### PR DESCRIPTION
We have several lifecycle bugs where, if any operation times out or otherwise fails during the sandbox or workload adoption, we don't exit gracefully and leave a stuck shim + clh process on the node.

Handle these by making failures during the restore path fatal, exiting the shim with errors.

Currently a failure during CreateContainer is handled as a sandbox-level fault and the whole shim exits as well. Possibly we'll have to refine this to allow CreateContainer retries.