### PR TITLE
sr: store containerd to restored agent container id mappings in a persisted map

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/shim_management.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management.go
@@ -508,8 +508,8 @@ func packageErofsSnapshotDisks(destDir string, cfg map[string]interface{}) (bool
 		if !ok || sourcePath == "" {
 			continue
 		}
-		baseName := filepath.Base(sourcePath)
-		if baseName != "layer.erofs" && baseName != "rwlayer.img" {
+		baseName, ok := erofsSnapshotDiskBaseName(sourcePath)
+		if !ok {
 			continue
 		}
 
@@ -527,6 +527,21 @@ func packageErofsSnapshotDisks(destDir string, cfg map[string]interface{}) (bool
 	}
 
 	return changed, nil
+}
+
+func erofsSnapshotDiskBaseName(path string) (string, bool) {
+	baseName := filepath.Base(path)
+	for {
+		if baseName == "layer.erofs" || baseName == "rwlayer.img" {
+			return baseName, true
+		}
+
+		prefix, remainder, found := strings.Cut(baseName, "-")
+		if !found || prefix == "" || strings.Trim(prefix, "0123456789") != "" {
+			return "", false
+		}
+		baseName = remainder
+	}
 }
 
 func copySnapshotFile(sourcePath, destinationPath string) error {

--- a/src/runtime/pkg/containerd-shim-v2/shim_management_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management_test.go
@@ -75,10 +75,14 @@ func TestMakeConfigSelfContainedPackagesErofsDisks(t *testing.T) {
 	stableDisk := filepath.Join(stableDir, "kata-containers.img")
 	lowerDisk := filepath.Join(erofsDir, "layer.erofs")
 	writableDisk := filepath.Join(erofsDir, "rwlayer.img")
+	prefixedLowerDisk := filepath.Join(erofsDir, "1-layer.erofs")
+	prefixedWritableDisk := filepath.Join(erofsDir, "3-3-rwlayer.img")
 	require.NoError(t, os.WriteFile(memoryRanges, []byte("memory"), 0o600))
 	require.NoError(t, os.WriteFile(stableDisk, []byte("base image"), 0o600))
 	require.NoError(t, os.WriteFile(lowerDisk, []byte("read-only layer"), 0o600))
 	require.NoError(t, os.WriteFile(writableDisk, []byte("writable layer"), 0o600))
+	require.NoError(t, os.WriteFile(prefixedLowerDisk, []byte("prefixed read-only layer"), 0o600))
+	require.NoError(t, os.WriteFile(prefixedWritableDisk, []byte("prefixed writable layer"), 0o600))
 
 	config := map[string]interface{}{
 		"memory": map[string]interface{}{
@@ -88,6 +92,8 @@ func TestMakeConfigSelfContainedPackagesErofsDisks(t *testing.T) {
 			map[string]interface{}{"id": "_disk0", "path": stableDisk},
 			map[string]interface{}{"id": "_disk3", "path": lowerDisk},
 			map[string]interface{}{"id": "_disk4", "path": writableDisk},
+			map[string]interface{}{"id": "_disk5", "path": prefixedLowerDisk},
+			map[string]interface{}{"id": "_disk6", "path": prefixedWritableDisk},
 		},
 	}
 	configJSON, err := json.Marshal(config)
@@ -113,13 +119,17 @@ func TestMakeConfigSelfContainedPackagesErofsDisks(t *testing.T) {
 	require.NoError(t, json.Unmarshal(updatedConfig, &restoredConfig))
 	require.Len(t, restoredConfig.Memory.Zones, 1)
 	assert.Equal(t, memoryRanges, restoredConfig.Memory.Zones[0].File)
-	require.Len(t, restoredConfig.Disks, 3)
+	require.Len(t, restoredConfig.Disks, 5)
 	assert.Equal(t, stableDisk, restoredConfig.Disks[0].Path)
 
 	expectedLowerDisk := filepath.Join(snapshotDir, "disks", "1-layer.erofs")
 	expectedWritableDisk := filepath.Join(snapshotDir, "disks", "2-rwlayer.img")
+	expectedPrefixedLowerDisk := filepath.Join(snapshotDir, "disks", "3-layer.erofs")
+	expectedPrefixedWritableDisk := filepath.Join(snapshotDir, "disks", "4-rwlayer.img")
 	assert.Equal(t, expectedLowerDisk, restoredConfig.Disks[1].Path)
 	assert.Equal(t, expectedWritableDisk, restoredConfig.Disks[2].Path)
+	assert.Equal(t, expectedPrefixedLowerDisk, restoredConfig.Disks[3].Path)
+	assert.Equal(t, expectedPrefixedWritableDisk, restoredConfig.Disks[4].Path)
 
 	require.NoError(t, os.RemoveAll(erofsDir))
 	lowerContent, err := os.ReadFile(expectedLowerDisk)
@@ -128,4 +138,10 @@ func TestMakeConfigSelfContainedPackagesErofsDisks(t *testing.T) {
 	writableContent, err := os.ReadFile(expectedWritableDisk)
 	require.NoError(t, err)
 	assert.Equal(t, "writable layer", string(writableContent))
+	prefixedLowerContent, err := os.ReadFile(expectedPrefixedLowerDisk)
+	require.NoError(t, err)
+	assert.Equal(t, "prefixed read-only layer", string(prefixedLowerContent))
+	prefixedWritableContent, err := os.ReadFile(expectedPrefixedWritableDisk)
+	require.NoError(t, err)
+	assert.Equal(t, "prefixed writable layer", string(prefixedWritableContent))
 }

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -366,10 +366,13 @@ func (c *Container) ID() string {
 	return c.id
 }
 
-// agentID returns the persisted guest ID when host bookkeeping was rekeyed during restore.
+// agentID returns the canonical guest ID when host bookkeeping was rekeyed during restore.
 func (c *Container) agentID() string {
-	if c.process.Token != "" {
-		return c.process.Token
+	if c.sandbox != nil && c.sandbox.agentContainerIDMap != nil {
+		if agentID, ok := c.sandbox.agentContainerIDMap[c.id]; ok && agentID != "" {
+			return agentID
+		}
+		c.Logger().Warn("container has no canonical agent ID in the agent container ID map")
 	}
 	return c.id
 }

--- a/src/runtime/virtcontainers/persist.go
+++ b/src/runtime/virtcontainers/persist.go
@@ -32,6 +32,7 @@ func (s *Sandbox) dumpVersion(ss *persistapi.SandboxState) {
 
 func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistapi.ContainerState) {
 	ss.SandboxContainer = s.id
+	ss.AgentContainerIDMap = cloneAgentContainerIDMap(s.agentContainerIDMap)
 	ss.GuestMemoryBlockSizeMB = s.state.GuestMemoryBlockSizeMB
 	ss.GuestMemoryHotplugProbe = s.state.GuestMemoryHotplugProbe
 	ss.State = string(s.state.State)
@@ -58,6 +59,18 @@ func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistap
 			delete(cs, id)
 		}
 	}
+}
+
+func cloneAgentContainerIDMap(source map[string]string) map[string]string {
+	if source == nil {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(source))
+	for hostID, agentID := range source {
+		cloned[hostID] = agentID
+	}
+	return cloned
 }
 
 func (s *Sandbox) dumpHypervisor(ss *persistapi.SandboxState) {
@@ -294,6 +307,7 @@ func (s *Sandbox) Save() error {
 
 func (s *Sandbox) loadState(ss persistapi.SandboxState) {
 	s.state.PersistVersion = ss.PersistVersion
+	s.agentContainerIDMap = cloneAgentContainerIDMap(ss.AgentContainerIDMap)
 	s.state.GuestMemoryBlockSizeMB = ss.GuestMemoryBlockSizeMB
 	s.state.BlockIndexMap = ss.HypervisorState.BlockIndexMap
 	s.state.State = types.StateString(ss.State)

--- a/src/runtime/virtcontainers/persist/api/sandbox.go
+++ b/src/runtime/virtcontainers/persist/api/sandbox.go
@@ -35,6 +35,10 @@ type SandboxState struct {
 	// SandboxContainer specifies which container is used to start the sandbox/vm
 	SandboxContainer string
 
+	// AgentContainerIDMap maps current host container IDs to the canonical IDs
+	// held by the agent. It is nil for sandboxes that were not restored.
+	AgentContainerIDMap map[string]string `json:",omitempty"`
+
 	// SandboxCgroupPath is the sandbox cgroup path
 	SandboxCgroupPath string
 

--- a/src/runtime/virtcontainers/persist/api/version.go
+++ b/src/runtime/virtcontainers/persist/api/version.go
@@ -15,5 +15,5 @@ const (
 	// If you can't be sure if the change in persistapi package
 	// requires a bump of CurPersistVersion or not, do it for peace!
 	// --@WeiZhang555
-	CurPersistVersion uint = 2
+	CurPersistVersion uint = 3
 )

--- a/src/runtime/virtcontainers/restore.go
+++ b/src/runtime/virtcontainers/restore.go
@@ -72,8 +72,7 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 		}
 	}()
 
-	origSandboxID, err := seedPersist(snapshotDir, newID, drv)
-	if err != nil {
+	if err := seedPersist(snapshotDir, newID, drv); err != nil {
 		return nil, fmt.Errorf("seed persist for restore: %w", err)
 	}
 
@@ -184,7 +183,7 @@ func RestoreSandbox(ctx context.Context, snapshotDir string, opts RestoreOpts) (
 	}
 	vmAssigned = true
 
-	if err = adoptPauseContainer(s, origSandboxID); err != nil {
+	if err = adoptPauseContainer(s); err != nil {
 		return nil, fmt.Errorf("adopt restored pause container: %w", err)
 	}
 
@@ -334,8 +333,107 @@ func (s *Sandbox) FinalizeRestoreNetwork(ctx context.Context) (err error) {
 // private raw_flags bit for restore-only identity replacement; keep in sync with kata-agent.
 const kataIfaceRestoreReplace uint32 = 0x4000_0000
 
+// rekeySandboxAgentContainerIDMap maintains direct mappings from current host
+// container IDs to the progenitor pod's canonical agent container IDs.
+func rekeySandboxAgentContainerIDMap(state *persistapi.SandboxState, newSandboxID string) error {
+	oldSandboxID := state.SandboxContainer
+	if oldSandboxID == "" {
+		return fmt.Errorf("kata restore failed: snapshot has an empty sandbox container id")
+	}
+
+	containerIDs := make(map[string]struct{}, len(state.Config.ContainerConfigs))
+	// On the first restore, host and agent IDs are still identical.
+	if state.AgentContainerIDMap == nil {
+		state.AgentContainerIDMap = make(map[string]string, len(state.Config.ContainerConfigs))
+		for _, config := range state.Config.ContainerConfigs {
+			if config.ID == "" {
+				return fmt.Errorf("kata restore failed: snapshot has a container with an empty id")
+			}
+			if _, exists := state.AgentContainerIDMap[config.ID]; exists {
+				return fmt.Errorf("kata restore failed: snapshot has duplicate container id %q", config.ID)
+			}
+			state.AgentContainerIDMap[config.ID] = config.ID
+		}
+	}
+
+	// Validate one canonical agent ID for every persisted container ID.
+	for _, config := range state.Config.ContainerConfigs {
+		if _, exists := containerIDs[config.ID]; exists {
+			return fmt.Errorf("kata restore failed: snapshot has duplicate container id %q", config.ID)
+		}
+		containerIDs[config.ID] = struct{}{}
+		agentID, exists := state.AgentContainerIDMap[config.ID]
+		if !exists || agentID == "" {
+			return fmt.Errorf("kata restore failed: container %q has no canonical agent id", config.ID)
+		}
+	}
+	if len(containerIDs) != len(state.AgentContainerIDMap) {
+		return fmt.Errorf("kata restore failed: agent container id map does not match the persisted containers")
+	}
+
+	// Rekey the pause host ID without changing its progenitor agent ID.
+	agentSandboxID, exists := state.AgentContainerIDMap[oldSandboxID]
+	if !exists || agentSandboxID == "" {
+		return fmt.Errorf("kata restore failed: sandbox container %q has no canonical agent id", oldSandboxID)
+	}
+	if oldSandboxID != newSandboxID {
+		if _, exists := state.AgentContainerIDMap[newSandboxID]; exists {
+			return fmt.Errorf("kata restore failed: target sandbox id %q already exists in the agent container id map", newSandboxID)
+		}
+		delete(state.AgentContainerIDMap, oldSandboxID)
+		state.AgentContainerIDMap[newSandboxID] = agentSandboxID
+	}
+
+	// Rewrite the persisted pause config for the current host generation.
+	pauseContainerFound := false
+	for index := range state.Config.ContainerConfigs {
+		config := &state.Config.ContainerConfigs[index]
+		if config.Annotations[criContainerTypeAnnotation] != criSandboxType {
+			continue
+		}
+		if pauseContainerFound || config.ID != oldSandboxID {
+			return fmt.Errorf("kata restore failed: snapshot pause container does not match sandbox id %q", oldSandboxID)
+		}
+		pauseContainerFound = true
+		config.ID = newSandboxID
+		if config.Annotations == nil {
+			config.Annotations = make(map[string]string)
+		}
+		config.Annotations[ociBundlePathAnnotation] = filepath.Join(containerdBundleBase, newSandboxID)
+		config.Annotations[criSandboxIDAnnotation] = newSandboxID
+	}
+	if !pauseContainerFound {
+		return fmt.Errorf("kata restore failed: snapshot has no pause container for sandbox %q", oldSandboxID)
+	}
+
+	state.SandboxContainer = newSandboxID
+	return nil
+}
+
+func (s *Sandbox) rekeyAgentContainerID(oldHostID, newHostID string) (string, error) {
+	if s.agentContainerIDMap == nil {
+		return "", fmt.Errorf("kata restore failed: sandbox has no agent container id map")
+	}
+	agentID, exists := s.agentContainerIDMap[oldHostID]
+	if !exists || agentID == "" {
+		return "", fmt.Errorf("kata restore failed: container %q has no canonical agent id", oldHostID)
+	}
+	if oldHostID != newHostID {
+		if _, exists := s.agentContainerIDMap[newHostID]; exists {
+			return "", fmt.Errorf("kata restore failed: target container id %q already exists in the agent container id map", newHostID)
+		}
+		delete(s.agentContainerIDMap, oldHostID)
+		s.agentContainerIDMap[newHostID] = agentID
+	}
+	return agentID, nil
+}
+
 // adoptPauseContainer rekeys host bookkeeping while preserving the pause process's guest ID.
-func adoptPauseContainer(s *Sandbox, origSandboxID string) error {
+func adoptPauseContainer(s *Sandbox) error {
+	agentID, exists := s.agentContainerIDMap[s.id]
+	if !exists || agentID == "" {
+		return fmt.Errorf("pause container %q has no canonical agent id", s.id)
+	}
 	for i := range s.config.Containers {
 		cc := &s.config.Containers[i]
 		if cc.ID != s.id {
@@ -350,7 +448,7 @@ func adoptPauseContainer(s *Sandbox, origSandboxID string) error {
 		if err != nil {
 			return fmt.Errorf("new pause container: %w", err)
 		}
-		c.process = Process{Token: origSandboxID, Pid: -1}
+		c.process = Process{Token: agentID, Pid: -1}
 		if err := s.addContainer(c); err != nil {
 			return fmt.Errorf("add pause container: %w", err)
 		}
@@ -372,12 +470,9 @@ func (s *Sandbox) RestoreContainer(_ context.Context, contConfig ContainerConfig
 		}
 	}
 
-	idx, guestID, err := guestWorkloadIndexByName(s, contConfig.Annotations[criContainerNameAnnotation])
+	idx, persistedHostID, err := guestWorkloadIndexByName(s, contConfig.Annotations[criContainerNameAnnotation])
 	if err != nil {
 		return nil, err
-	}
-	if guestID == "" {
-		return nil, fmt.Errorf("kata restore failed: persisted workload has an empty guest id")
 	}
 
 	if s.containers[s.id] == nil {
@@ -385,11 +480,17 @@ func (s *Sandbox) RestoreContainer(_ context.Context, contConfig ContainerConfig
 	}
 
 	savedCopy := s.config.Containers[idx]
+	savedIDMap := cloneAgentContainerIDMap(s.agentContainerIDMap)
+	agentID, err := s.rekeyAgentContainerID(persistedHostID, contConfig.ID)
+	if err != nil {
+		return nil, err
+	}
 	s.config.Containers[idx] = contConfig
 	rollback := true
 	defer func() {
 		if rollback {
 			s.config.Containers[idx] = savedCopy
+			s.agentContainerIDMap = savedIDMap
 		}
 	}()
 
@@ -397,7 +498,7 @@ func (s *Sandbox) RestoreContainer(_ context.Context, contConfig ContainerConfig
 	if err != nil {
 		return nil, err
 	}
-	c.process = Process{Token: guestID, Pid: -1}
+	c.process = Process{Token: agentID, Pid: -1}
 	if err = s.addContainer(c); err != nil {
 		return nil, err
 	}
@@ -476,27 +577,25 @@ func (s *Sandbox) markAdoptedWorkloadsRunning() error {
 	return nil
 }
 
-// seedPersist rekeys snapshot state for the new sandbox without changing the guest workload ID.
-func seedPersist(snapshotDir, newID string, store persistapi.PersistDriver) (string, error) {
+// seedPersist rekeys snapshot state for the new sandbox without changing agent IDs.
+func seedPersist(snapshotDir, newID string, store persistapi.PersistDriver) error {
 	raw, err := os.ReadFile(filepath.Join(snapshotDir, "persist.json"))
 	if err != nil {
-		return "", fmt.Errorf("read snapshot persist.json: %w", err)
+		return fmt.Errorf("read snapshot persist.json: %w", err)
 	}
 	var ss persistapi.SandboxState
 	if err := json.Unmarshal(raw, &ss); err != nil {
-		return "", fmt.Errorf("decode snapshot persist.json: %w", err)
+		return fmt.Errorf("decode snapshot persist.json: %w", err)
 	}
 	if HypervisorType(ss.Config.HypervisorType) != ClhHypervisor {
-		return "", fmt.Errorf("kata restore failed: snapshot hypervisor %q is not %q; only cloud-hypervisor restore is supported", ss.Config.HypervisorType, ClhHypervisor)
+		return fmt.Errorf("kata restore failed: snapshot hypervisor %q is not %q; only cloud-hypervisor restore is supported", ss.Config.HypervisorType, ClhHypervisor)
 	}
 
-	origSandboxID := ss.SandboxContainer
-	if origSandboxID == "" {
-		return "", fmt.Errorf("kata restore failed: snapshot has an empty sandbox container id")
+	if err := rekeySandboxAgentContainerIDMap(&ss, newID); err != nil {
+		return err
 	}
 
 	ss.AgentState.URL = fmt.Sprintf("hvsock:///run/vc/vm/%s/clh.sock:1024", newID)
-	ss.SandboxContainer = newID
 	ss.SandboxCgroupPath = ""
 	ss.OverheadCgroupPath = ""
 	ss.CgroupPaths = nil
@@ -505,20 +604,10 @@ func seedPersist(snapshotDir, newID string, store persistapi.PersistDriver) (str
 	ss.HypervisorState.APISocket = ""
 	ss.Config.HypervisorConfig.VMid = ""
 
-	// Rekey only the pause container; workload IDs remain guest-owned.
-	for i := range ss.Config.ContainerConfigs {
-		cc := &ss.Config.ContainerConfigs[i]
-		if cc.Annotations[criContainerTypeAnnotation] == criSandboxType {
-			cc.ID = newID
-			cc.Annotations[ociBundlePathAnnotation] = filepath.Join(containerdBundleBase, newID)
-			cc.Annotations[criSandboxIDAnnotation] = newID
-		}
-	}
-
 	if err := store.ToDisk(ss, map[string]persistapi.ContainerState{}); err != nil {
-		return "", err
+		return err
 	}
-	return origSandboxID, nil
+	return nil
 }
 
 const (

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -251,7 +251,8 @@ type Sandbox struct {
 	sandboxController  resCtrl.ResourceController
 	overheadController resCtrl.ResourceController
 
-	containers map[string]*Container
+	containers          map[string]*Container
+	agentContainerIDMap map[string]string
 
 	id string
 
@@ -1853,6 +1854,9 @@ func (s *Sandbox) DeleteContainer(ctx context.Context, containerID string) (VCCo
 	for idx, contConfig := range s.config.Containers {
 		if contConfig.ID == containerID {
 			s.config.Containers = append(s.config.Containers[:idx], s.config.Containers[idx+1:]...)
+			if s.agentContainerIDMap != nil {
+				delete(s.agentContainerIDMap, containerID)
+			}
 			break
 		}
 	}

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -839,11 +839,15 @@ func TestRemoveContainerSuccess(t *testing.T) {
 		containers: map[string]*Container{
 			testContainerID: {id: testContainerID},
 		},
+		agentContainerIDMap: map[string]string{
+			testContainerID: "agent-container-id",
+		},
 	}
 	err := sandbox.removeContainer(testContainerID)
 	assert.Nil(t, err, "Should not have returned an error: %v", err)
 
 	assert.Equal(t, len(sandbox.containers), 0, "Containers list from sandbox structure should be empty")
+	assert.Contains(t, sandbox.agentContainerIDMap, testContainerID)
 }
 
 func TestCreateContainer(t *testing.T) {
@@ -875,9 +879,11 @@ func TestDeleteContainer(t *testing.T) {
 	contConfig := newTestContainerConfigNoop(contID)
 	_, err = s.CreateContainer(context.Background(), contConfig)
 	assert.Nil(t, err, "Failed to create container %+v in sandbox %+v: %v", contConfig, s, err)
+	s.agentContainerIDMap = map[string]string{contID: "agent-container-id"}
 
 	_, err = s.DeleteContainer(context.Background(), contID)
 	assert.Nil(t, err, "Failed to delete container %s in sandbox %s: %v", contID, s.ID(), err)
+	assert.NotContains(t, s.agentContainerIDMap, contID)
 }
 
 func TestStartContainer(t *testing.T) {


### PR DESCRIPTION
Fix handling of multiple generations of snapshot/restore. Here we do two things:

1. Minor bugfix to the snapshot packaging so it can find and clone the image layers from the original snapshot. 
2. A beefier change to store the containerd -> restored agent id mappings as a hashmap. This becomes the source of truth for agent ids in subsequent restores, fed in from persist.json. Every generation must reference this map and rekey for their new container ids supplied by containerd, preserving the agent id mappings. 