### PR TITLE
e2e: let stage 04 stage a component that is already in place

### DIFF
--- a/docs/cc/e2e/04-build-guest-stack.sh
+++ b/docs/cc/e2e/04-build-guest-stack.sh
@@ -183,7 +183,13 @@ build_component() {
   local t="build/kata-static-$comp.tar.zst"
   if [ -f "$t" ]; then
     mkdir -p "$LB/build"
-    cp "$t" "$LB/build/" || die "could not stage $t for later components"
+    # In some trees `build/` is itself a symlink to $LB/build, so the two paths
+    # name the same file and `cp` refuses. That is the desired end state, not an
+    # error: compare resolved directories and skip the copy rather than failing
+    # the whole guest build for a component already exactly where it needs to be.
+    if [ "$(cd "$(dirname "$t")" && pwd -P)" != "$(cd "$LB/build" && pwd -P)" ]; then
+      cp "$t" "$LB/build/" || die "could not stage $t for later components"
+    fi
   fi
 }
 


### PR DESCRIPTION
One commit that #479 should have carried but didn't — it was written after that PR had already been merged, so it was pushed to a branch nobody was watching.

`build/` is a symlink to `$LB/build` in some trees, so stage 04's staging copy names one file as both source and destination and `cp` refuses. That is the desired end state rather than an error, and failing on it aborts the whole guest build *after* the component has been produced successfully. Compare resolved directories and skip the copy instead.

Ported from `coco-parity` bd87fd8be5.

## Why the SNP run didn't catch it

The `clh-snp` branch of stage 04 returns before `build_component` is reached, so the 04–08 validation in #479 never executed this line. It would still abort the QEMU path.

## Verification

The executable body of `build_component` is now identical to `coco-parity`'s (compared with comments and blank lines stripped — only comment wrapping differs). `bash -n` clean.
