### PR TITLE
agent: restore the strict-policy gate on parse_extra_receipts

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2932,14 +2932,6 @@ impl health_ttrpc::Health for HealthService {
     }
 }
 
-/// FR-1f (trust list): parse `extra_receipts` wire entries of the form `<ledger>=<hex sig>`.
-///
-/// Ledger and signature are carried in one string rather than as parallel lists so the two
-/// cannot be misaligned by a truncated or reordered request — a mismatch would silently
-/// check a signature against the wrong ledger's keys. A malformed entry is rejected rather
-/// than skipped: dropping it would quietly weaken a conjunctive requirement into one the
-/// remaining receipts happen to satisfy.
-#[cfg(feature = "strict-policy")]
 /// F-151: the name of the first signed field the caller tried to describe, if any.
 ///
 /// Every field here is covered by the issuer signature and is derived from the COSE_Sign1
@@ -2970,6 +2962,14 @@ fn caller_described_fragment_field(
     .find_map(|&(name, present)| present.then_some(name))
 }
 
+/// FR-1f (trust list): parse `extra_receipts` wire entries of the form `<ledger>=<hex sig>`.
+///
+/// Ledger and signature are carried in one string rather than as parallel lists so the two
+/// cannot be misaligned by a truncated or reordered request — a mismatch would silently
+/// check a signature against the wrong ledger's keys. A malformed entry is rejected rather
+/// than skipped: dropping it would quietly weaken a conjunctive requirement into one the
+/// remaining receipts happen to satisfy.
+#[cfg(feature = "strict-policy")]
 fn parse_extra_receipts(entries: &[String]) -> ttrpc::Result<Vec<(String, String)>> {
     entries
         .iter()


### PR DESCRIPTION
## What

Restores the `#[cfg(feature = "strict-policy")]` gate on `parse_extra_receipts` in `src/agent/src/rpc.rs`.

## Why — `manifold-cc` does not currently build

`parse_extra_receipts` is only reachable from `LoadPolicyFragmentRequest`, which is compiled under `strict-policy`. Its gate was separated from it when `caller_described_fragment_field` was inserted **between the attribute and the function it applied to**. The attribute landed on the new function — which already carried its own identical one — and `parse_extra_receipts` was left ungated.

So a default build compiles the function with its only call site configured out. `-D warnings` promotes the resulting lint to an error:

```
error: function `parse_extra_receipts` is never used
    --> src/agent/src/rpc.rs:2973:4
```

The FR-1f doc comment travelled with the attribute, so it was documenting `caller_described_fragment_field` — whose own F-151 comment followed it. One function ended up with two unrelated doc blocks and the other with none.

## Change

Moved the doc comment and the `#[cfg]` back onto `parse_extra_receipts`, and dropped the now-duplicate attribute on `caller_described_fragment_field`.

**No behaviour change.** `parse_extra_receipts` was already unreachable in default builds; under `strict-policy` it and its call site compile exactly as before.

## Verification

On an SNP node, `cargo check --release --no-default-features`:

| features | before | after |
|---|---|---|
| `agent-policy` | `function parse_extra_receipts is never used` | clean |
| `agent-policy,strict-policy` | clean | clean |

Found while running `make check` for unrelated work — worth landing on its own since it blocks the agent build for everyone on the branch.
