### PR TITLE
ci: build erofs-utils from source for the genpolicy checks

### DIFF
--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -79,6 +79,7 @@ jobs:
             path: src/tools/genpolicy
             needs:
               - rust
+              - erofs-utils
               - protobuf-compiler
         instance:
           - ${{ inputs.instance }}
@@ -136,6 +137,15 @@ jobs:
           echo "Set environment variables for the libseccomp crate to link the libseccomp library statically"
           echo "LIBSECCOMP_LINK_TYPE=static" >> "$GITHUB_ENV"
           echo "LIBSECCOMP_LIB_PATH=${libseccomp_install_dir}/lib" >> "$GITHUB_ENV"
+      - name: Install erofs-utils
+        if: contains(matrix.component.needs, 'erofs-utils') && matrix.command != 'make check'
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install --no-install-recommends \
+            autoconf automake libtool pkg-config liblz4-dev uuid-dev
+          erofs_utils_install_dir=$(mktemp -d -t erofs-utils.XXXXXXXXXX)
+          ./ci/install_erofs_utils.sh "${erofs_utils_install_dir}"
+          echo "${erofs_utils_install_dir}/bin" >> "$GITHUB_PATH"
       - name: Install protobuf-compiler
         if: contains(matrix.component.needs, 'protobuf-compiler')
         run: sudo apt-get update && sudo apt-get -y install protobuf-compiler

--- a/ci/install_erofs_utils.sh
+++ b/ci/install_erofs_utils.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and install erofs-utils, which provides mkfs.erofs.
+#
+# genpolicy reproduces containerd's EROFS layer images byte for byte in order to
+# compute their dm-verity root hashes, so it invokes mkfs.erofs with containerd's
+# own option set. That set needs a version far newer than the distributions the
+# CI runners use ship: Ubuntu 22.04 carries 1.4 and 24.04 carries 1.7.1, while
+# --tar=f, -T0, --mkfs-time and --sort=none require >= 1.8.2. Building the pinned
+# release from source keeps the version identical across every runner image and
+# independent of what the distribution happens to carry.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=/dev/null
+source "${script_dir}/../tests/common.bash"
+
+# These change the behaviour of the configure script and would make the build
+# install somewhere other than the requested directory.
+unset PREFIX DESTDIR
+
+workdir="$(mktemp -d --tmpdir build-erofs-utils.XXXXX)"
+
+erofs_utils_version="${EROFS_UTILS_VERSION:-""}"
+if [[ -z "${erofs_utils_version}" ]]; then
+	erofs_utils_version=$(get_from_kata_deps ".externals.erofs-utils.version")
+fi
+erofs_utils_url="${EROFS_UTILS_URL:-""}"
+if [[ -z "${erofs_utils_url}" ]]; then
+	erofs_utils_url=$(get_from_kata_deps ".externals.erofs-utils.url")
+fi
+
+erofs_utils_tarball="erofs-utils-${erofs_utils_version}.tar.gz"
+erofs_utils_tarball_url="${erofs_utils_url}/snapshot/${erofs_utils_tarball}"
+
+die() {
+	msg="$*"
+	echo "[Error] ${msg}" >&2
+	exit 1
+}
+
+finish() {
+	rm -rf "${workdir}"
+}
+
+trap finish EXIT
+
+build_and_install_erofs_utils() {
+	echo "Build and install erofs-utils version ${erofs_utils_version}"
+	mkdir -p "${erofs_utils_install_dir}"
+
+	curl -sLO "${erofs_utils_tarball_url}"
+	tar -xf "${erofs_utils_tarball}"
+	pushd "erofs-utils-${erofs_utils_version}"
+
+	# The git snapshot ships no configure script.
+	./autogen.sh
+
+	# lz4 is what containerd's differ compresses with, so it has to be enabled
+	# for the images genpolicy rebuilds to match byte for byte. libuuid is
+	# likewise required rather than optional: the images carry the filesystem
+	# UUID containerd derives per layer, which mkfs.erofs can only set with -U.
+	# Fail loudly if either is missing rather than silently producing a
+	# mkfs.erofs that cannot reproduce them.
+	./configure --prefix="${erofs_utils_install_dir}" --enable-lz4
+
+	make
+	make install
+	popd
+
+	local installed
+	installed="$("${erofs_utils_install_dir}/bin/mkfs.erofs" --version 2>&1 | head -1)"
+	echo "erofs-utils installed successfully: ${installed}"
+}
+
+main() {
+	local erofs_utils_install_dir="${1:-}"
+
+	if [[ -z "${erofs_utils_install_dir}" ]]; then
+		die "Usage: ${0} <erofs-utils-install-dir>"
+	fi
+
+	pushd "${workdir}"
+	build_and_install_erofs_utils
+	popd
+}
+
+main "$@"

--- a/versions.yaml
+++ b/versions.yaml
@@ -337,6 +337,12 @@ externals:
     url: "https://gitlab.com/cryptsetup/cryptsetup"
     version: "v2.8.1"
 
+  erofs-utils:
+    description: "Userspace tools for the EROFS filesystem, providing mkfs.erofs"
+    notes: "genpolicy rebuilds layer images with containerd's own mkfs.erofs invocation, which needs >= 1.8.2 for --tar=f, -T0, --mkfs-time and --sort. Keep in sync with the floor enforced in tools/packaging/kata-deploy/binary/src/main.rs."
+    url: "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git"
+    version: "1.8.5"
+
   gperf:
     description: "GNU gperf is a perfect hash function generator"
     url: "https://ftp.gnu.org.uk/gnu/gperf/"


### PR DESCRIPTION
## What

Builds `erofs-utils` from a pinned source release in the `build-checks`
workflow, so `genpolicy` has an `mkfs.erofs` new enough to run its tests.

## Why

`genpolicy` reproduces containerd's EROFS layer images byte for byte in order
to compute their dm-verity root hashes, so it shells out to `mkfs.erofs` with
containerd's own option set (`--tar=f`, `--aufs`, `-Enoinline_data`, `-b4096`,
`-T0`, `--mkfs-time`, `--sort=none`). Those options require erofs-utils
**>= 1.8.2** — the same floor `kata-deploy` already enforces at
`tools/packaging/kata-deploy/binary/src/main.rs`.

`build-checks` runs on `ubuntu-22.04`, which ships erofs-utils **1.4**. The
binary is therefore absent or too old, and the two `genpolicy` `make test`
jobs fail on **every** pull request:

```
tests::test_create_container_erofs_layers ... FAILED
```

This is a pre-existing failure unrelated to whatever a given PR changes, so it
costs a triage cycle on each one.

## How

Follows the idiom the repo already uses for `libseccomp`:

- `versions.yaml` — new `externals.erofs-utils` entry pinned to **1.8.5**,
  with a note pointing at the `kata-deploy` floor it must stay in sync with.
- `ci/install_erofs_utils.sh` — new, mirroring `ci/install_libseccomp.sh`:
  reads the version and URL through `get_from_kata_deps`, fetches the release
  snapshot, runs `./autogen.sh` (git snapshots ship no `configure`), builds,
  installs into a caller-supplied prefix, and prints the installed version.
- `.github/workflows/build-checks.yaml` — `erofs-utils` added to `genpolicy`'s
  `needs`, plus a conditional install step that prepends the install prefix to
  `$GITHUB_PATH`.

Pinning and building from source rather than installing a distribution package
keeps the version identical across every runner image, and means the tests do
not start failing again the next time the runner image moves.

`--enable-lz4` and libuuid are configured rather than left optional. The layer
images carry the compression containerd's differ applies, and the per-layer
filesystem UUID that `mkfs.erofs` can only set through `-U`; a build without
either cannot reproduce them byte for byte.

## Validation

Built and installed the pinned release on a clean prefix:

```
erofs-utils installed successfully: mkfs.erofs (erofs-utils) 1.8.5
```

With only that build on `PATH`, the previously failing test passes:

```
test tests::test_create_container_erofs_layers ... ok
test result: ok. 1 passed; 0 failed
...
test result: ok. 13 passed; 0 failed   # policy::tests::erofs_*
```

`shellcheck` 0.11.0 on the new script: clean, no findings.

## Scope

CI only — no runtime, agent, or policy code is touched.