### PR TITLE
ci: keep the erofs-utils version entry within the yamllint line limit

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -338,8 +338,12 @@ externals:
     version: "v2.8.1"
 
   erofs-utils:
-    description: "Userspace tools for the EROFS filesystem, providing mkfs.erofs"
-    notes: "genpolicy rebuilds layer images with containerd's own mkfs.erofs invocation, which needs >= 1.8.2 for --tar=f, -T0, --mkfs-time and --sort. Keep in sync with the floor enforced in tools/packaging/kata-deploy/binary/src/main.rs."
+    description: "Userspace tools for the EROFS filesystem (mkfs.erofs)"
+    notes: >-
+      genpolicy rebuilds layer images with containerd's own mkfs.erofs
+      invocation, which needs >= 1.8.2 for --tar=f, -T0, --mkfs-time and
+      --sort. Keep in sync with the floor enforced in
+      tools/packaging/kata-deploy/binary/src/main.rs.
     url: "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git"
     version: "1.8.5"
 


### PR DESCRIPTION
## What

Fixes two yamllint `line-length` errors in the `erofs-utils` entry of `versions.yaml`, which are currently breaking `make static-checks` on **`manifold-cc` head**.

```
341:81  error  line too long (81 > 80 characters)   (line-length)
342:81  error  line too long (240 > 80 characters)  (line-length)
```

## Why it slipped through

The entry was added by #503. `static-checks` had already been failing on that PR for an unrelated reason, so the new error did not change the job's outcome and was not visible as a regression. It only became apparent once the branch merged and a later PR rebased onto it.

## The fix

Shortens `description` and folds `notes` onto continuation lines using `>-`, which is the style `versions.yaml` already uses for its `uscan-url` entries. The parsed values are equivalent — no version, URL or semantic change.

The remaining over-length lines in the file are single unbreakable URLs, which yamllint permits by default via `allow-non-breakable-words`.

## Validation

```
yamllint versions.yaml           # before: 2 errors
yamllint versions.yaml           # after:  clean
```

Verified against the same plain `yamllint` invocation `tests/static-checks.sh::static_check_versions` uses.