### PR TITLE
agent: validate every bind-safer-path mount source

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -3990,6 +3990,19 @@ fn translate_bind_safer_path_mounts(oci: &mut Spec) -> Result<()> {
                 "bind-safer-path source must be relative: {source:?}"
             ));
         }
+        // The host chooses this string, and the policy does not constrain it: the
+        // `bind-safer-path` case of `mount_source_allows` in rules.rego matches any source,
+        // because the guest mints watchable volume ids and genpolicy cannot predict them. The
+        // policy therefore pins the destination but not the source, which leaves the agent as
+        // the only check between a host-supplied path and a bind mount. Reject anything that
+        // is not a plain relative path, before the branch below so that both translations are
+        // covered: `join` does not normalise `..`, so the kernel would resolve it at mount
+        // time and the mount would escape the directory the branch selected.
+        if !is_safe_relative_path(source) {
+            return Err(anyhow!(
+                "bind-safer-path source must not contain '..' components: {source:?}"
+            ));
+        }
 
         let translated = if source
             .components()
@@ -4852,6 +4865,37 @@ mod tests {
             mounts[1].source().as_ref().unwrap(),
             &share_dir.join("watchable-volumes/watchable-volume-id")
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_translate_bind_safer_path_mounts_rejects_traversal() {
+        let _temp_dir = setup_watchable_rpc_test();
+
+        // The policy does not pin the source of a bind-safer-path mount, so these strings
+        // reach the agent under host control. Both translation branches must reject a
+        // source that walks out of the directory the branch selected -- `join` keeps `..`
+        // and the kernel would resolve it when the bind mount is performed.
+        for source in [
+            "single-files/../../../../etc/shadow",
+            "single-files/sandbox-id/../../../etc/shadow",
+            "../../etc/shadow",
+            "watchable-volumes/../../etc/shadow",
+        ] {
+            let mut mount = oci::Mount::default();
+            mount.set_destination(PathBuf::from("/etc/resolv.conf"));
+            mount.set_typ(Some("bind-safer-path".to_string()));
+            mount.set_source(Some(PathBuf::from(source)));
+
+            let mut spec = Spec::default();
+            spec.set_mounts(Some(vec![mount]));
+
+            assert!(
+                translate_bind_safer_path_mounts(&mut spec).is_err(),
+                "expected {} to be rejected",
+                source
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
`translate_bind_safer_path_mounts` turns a host-supplied relative source into a bind mount source, on two branches. They are not equally careful.

```rust
let translated = if source.components().next()
    .is_some_and(|c| c == Component::Normal(OsStr::new("single-files")))
{
    guest_share_dir_path().join(source)   // <- only checked for is_absolute()
} else {
    watchable_root_path(source_id)?       // <- calls is_safe_relative_path()
};
```

The watchable-volume branch rejects a `..` component. The single-files branch joins the host's string straight onto the shared directory. `PathBuf::join` does not normalise `..`, so the kernel resolves it when the bind mount is performed, and the mount lands outside the directory the branch selected.

## Why nothing downstream covers it

The `bind-safer-path` case of `mount_source_allows` in `rules.rego` (1482-1487) matches **any** source:

```rego
mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) if {
    i_mount.type_ == "bind-safer-path"
    p_mount.type_ == "bind"
}
```

That is deliberate — the guest mints watchable volume ids, so genpolicy cannot predict them and cannot pin them. The consequence is that the policy constrains the mount **destination** but not its **source**, which leaves the agent as the only check between a host-supplied path and a bind mount. On the single-files branch there wasn't one.

## The change

One `is_safe_relative_path` guard, hoisted above the branch so both translations are covered and the single-files case cannot drift from its sibling again. The existing absolute-path check is kept for its more specific error message, even though `is_safe_relative_path` subsumes it.

## Scope

This is pre-existing on `manifold-cc` and is deliberately **not** bundled into #522 (the port of Dan's commits), which does not touch this function. #522 should land on top of this.

## Validation

On `ccpolicy-e2e`, `--features agent-policy,strict-policy`:

| Check | Result |
| --- | --- |
| `cargo test` agent | 475 passed, 0 failed (474 baseline + the new test) |
| `cargo fmt --check` | clean |
| `cargo clippy` | no new warnings |

The regression test was proven in both directions, not just asserted:

- **With** the guard: passes.
- **Without** the guard (removed from the tree, test unchanged): fails with `expected single-files/../../../../etc/shadow to be rejected`.

## Note on what is and isn't claimed

I verified the missing check and that the policy does not compensate for it. I did **not** build an end-to-end exploit — reaching it still requires a policy-approved destination and a way to make use of the redirected mount. The fix is warranted on the asymmetry alone: the sibling branch already considered this input untrusted.

One case I initially expected to be rejected, `single-files/./sandbox-id/resolv.conf`, is accepted, and correctly so: Rust's `Components` iterator drops `.`, and `.` is not traversal. The test and the error message were corrected to match, rather than the guard being widened.
