### PR TITLE
agent: pin content-channel mount rewrites in the plan binding

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -4262,8 +4262,34 @@ fn enforce_plan_binding(
     executed_oci: &Spec,
     executed_oci_digest: &str,
 ) -> Result<()> {
+    // Content-channel mounts are the one authorized entry the guest is required to
+    // rewrite: the host names a guest-side identifier (`single-files/<sid>/<name>`
+    // or a volume id) and never a path, precisely so it cannot choose where the
+    // content lands. `translate_bind_safer_path_mounts` resolves that identifier
+    // under the guest's own share directory after the authorized spec was captured,
+    // so the authorized entry cannot survive verbatim and every container carrying
+    // one -- network files and watchable volumes today, whenever `copy_volumes`
+    // names them -- would otherwise be refused.
+    //
+    // The rewrite is *waived* nowhere: it is deterministic and derived by the guest
+    // alone, so the same translation is applied to a copy of the authorized spec and
+    // the executed side is held to that value. This is the treatment `/root/path`
+    // already gets, and for the same reason -- computing the expected value is
+    // strictly stronger than permitting the field to differ. An in-guest transform
+    // that pointed a content-channel mount anywhere else still fails the binding.
+    let mut authorized_resolved = authorized_oci.clone();
+    translate_bind_safer_path_mounts(&mut authorized_resolved).inspect_err(|e| {
+        error!(
+            sl(),
+            "FR-3: refusing to create container; an authorized content-channel \
+             mount cannot be resolved to the path the guest derives";
+            "container-id" => cid,
+            "violation" => e.to_string(),
+        );
+    })?;
+
     crate::plan_binding::assert_within_resolution_bounds(
-        authorized_oci,
+        &authorized_resolved,
         executed_oci,
         &container_rootfs_path(cid),
     )
@@ -6541,6 +6567,86 @@ COMMIT
 
             bind(authorized_spec(), executed)
                 .expect("trusted in-guest transforms must not fail the create");
+        }
+
+        /// A host-supplied `bind-safer-path` mount is rewritten in place by
+        /// `translate_bind_safer_path_mounts`, which runs *after* the authorized
+        /// spec is captured. The rewrite is one of the trusted in-guest
+        /// transforms and its result is derived by the guest alone, so it must
+        /// not fail the create.
+        ///
+        /// Every content-channel mount takes this path -- network files and
+        /// watchable volumes -- so a binding that refuses it refuses every
+        /// container that has one.
+        #[test]
+        #[serial_test::serial]
+        fn a_translated_bind_safer_path_mount_is_still_the_authorized_plan() {
+            let _temp_dir = setup_watchable_rpc_test();
+
+            let mut safer = oci::Mount::default();
+            safer.set_destination(PathBuf::from("/dev/termination-log"));
+            safer.set_typ(Some("bind-safer-path".to_string()));
+            safer.set_source(Some(PathBuf::from("single-files/sandbox-id/empty-file")));
+
+            let mut authorized = spec_of(authorized_spec());
+            authorized.mounts_mut().as_mut().unwrap().push(safer);
+
+            let mut executed = authorized.clone();
+            let mut root = executed.root().clone().unwrap();
+            root.set_path(container_rootfs_path(BOUND_CID));
+            executed.set_root(Some(root));
+            translate_bind_safer_path_mounts(&mut executed)
+                .expect("the translation itself must succeed");
+
+            enforce_plan_binding(
+                BOUND_CID,
+                &authorized,
+                &plan_digest(&authorized),
+                &executed,
+                &plan_digest(&executed),
+            )
+            .expect("a guest-derived content-channel mount rewrite must not fail the create");
+        }
+
+        /// The rewrite is pinned, not waived: resolving the identifier is the
+        /// guest's job, but only to the path the guest itself derives. A
+        /// transform that redirected the mount elsewhere -- to a path outside
+        /// the share directory, say -- must still fail the create.
+        #[test]
+        #[serial_test::serial]
+        fn a_redirected_content_channel_mount_still_fails_the_create() {
+            let _temp_dir = setup_watchable_rpc_test();
+
+            let mut safer = oci::Mount::default();
+            safer.set_destination(PathBuf::from("/dev/termination-log"));
+            safer.set_typ(Some("bind-safer-path".to_string()));
+            safer.set_source(Some(PathBuf::from("single-files/sandbox-id/empty-file")));
+
+            let mut authorized = spec_of(authorized_spec());
+            authorized.mounts_mut().as_mut().unwrap().push(safer);
+
+            let mut executed = authorized.clone();
+            let mut root = executed.root().clone().unwrap();
+            root.set_path(container_rootfs_path(BOUND_CID));
+            executed.set_root(Some(root));
+            translate_bind_safer_path_mounts(&mut executed)
+                .expect("the translation itself must succeed");
+            executed.mounts_mut().as_mut().unwrap()[1]
+                .set_source(Some(PathBuf::from("/etc/shadow")));
+
+            let err = enforce_plan_binding(
+                BOUND_CID,
+                &authorized,
+                &plan_digest(&authorized),
+                &executed,
+                &plan_digest(&executed),
+            )
+            .expect_err("a content-channel mount resolved elsewhere must fail the create");
+            assert!(
+                err.to_string().contains("plan binding violation"),
+                "unexpected error: {}",
+                err
+            );
         }
 
         #[test]

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -3990,6 +3990,19 @@ fn translate_bind_safer_path_mounts(oci: &mut Spec) -> Result<()> {
                 "bind-safer-path source must be relative: {source:?}"
             ));
         }
+        // The host chooses this string, and the policy does not constrain it: the
+        // `bind-safer-path` case of `mount_source_allows` in rules.rego matches any source,
+        // because the guest mints watchable volume ids and genpolicy cannot predict them. The
+        // policy therefore pins the destination but not the source, which leaves the agent as
+        // the only check between a host-supplied path and a bind mount. Reject anything that
+        // is not a plain relative path, before the branch below so that both translations are
+        // covered: `join` does not normalise `..`, so the kernel would resolve it at mount
+        // time and the mount would escape the directory the branch selected.
+        if !is_safe_relative_path(source) {
+            return Err(anyhow!(
+                "bind-safer-path source must not contain '..' components: {source:?}"
+            ));
+        }
 
         let translated = if source
             .components()
@@ -4852,6 +4865,37 @@ mod tests {
             mounts[1].source().as_ref().unwrap(),
             &share_dir.join("watchable-volumes/watchable-volume-id")
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_translate_bind_safer_path_mounts_rejects_traversal() {
+        let _temp_dir = setup_watchable_rpc_test();
+
+        // The policy does not pin the source of a bind-safer-path mount, so these strings
+        // reach the agent under host control. Both translation branches must reject a
+        // source that walks out of the directory the branch selected -- `join` keeps `..`
+        // and the kernel would resolve it when the bind mount is performed.
+        for source in [
+            "single-files/../../../../etc/shadow",
+            "single-files/sandbox-id/../../../etc/shadow",
+            "../../etc/shadow",
+            "watchable-volumes/../../etc/shadow",
+        ] {
+            let mut mount = oci::Mount::default();
+            mount.set_destination(PathBuf::from("/etc/resolv.conf"));
+            mount.set_typ(Some("bind-safer-path".to_string()));
+            mount.set_source(Some(PathBuf::from(source)));
+
+            let mut spec = Spec::default();
+            spec.set_mounts(Some(vec![mount]));
+
+            assert!(
+                translate_bind_safer_path_mounts(&mut spec).is_err(),
+                "expected {} to be rejected",
+                source
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`translate_bind_safer_path_mounts` resolves a host-supplied guest-side identifier
(`single-files/<sid>/<name>`, or a volume id) into a path under the guest's own share
directory. It runs **after** the authorized spec is captured:

| `src/agent/src/rpc.rs` | |
|---|---|
| `:321` | `let authorized_oci_digest = plan_digest(&oci);` |
| `:409` | `translate_bind_safer_path_mounts(&mut oci)?;` |
| `:464` | `enforce_plan_binding(...)` |

The plan binding had no rule for that rewrite, so `assert_append_only` saw the authorized
mount as removed and refused the create.

## This is reachable today, not latent

`configuration-qemu-coco-dev-runtime-rs.toml.in` ships a `copy_volumes` list. Any pod
carrying a volume it names gets a `bind-safer-path` mount and fails `CreateContainer`:

```
plan binding violation: in-guest resolution removed, reordered,
or rewrote the authorized entry at /mounts/6
```

Reproduced on SEV-SNP hardware (`ccpolicy-snp`, stage 05 smoke test): pod never leaves
`ContainerCreating`, 501 violations in the journal.

## The rewrite is pinned, not waived

The translation is deterministic and derived by the guest alone, so the same translation is
applied to a copy of the *authorized* spec and the executed side is held to that value.

This is exactly the treatment `/root/path` already gets, and for the same reason: computing
the expected value is strictly stronger than permitting the field to differ. An in-guest
transform that resolved a content-channel mount anywhere else still fails the binding.

## Tests

Two new tests in `rpc::tests::srm_integration`:

- `a_translated_bind_safer_path_mount_is_still_the_authorized_plan` — the rewrite must not
  fail the create.
- `a_redirected_content_channel_mount_still_fails_the_create` — redirecting the mount to
  `/etc/shadow` after translation **must** still fail.

**Proven in both directions.** With the pin removed from the tree and the tests untouched:

```
test rpc::tests::srm_integration::a_translated_bind_safer_path_mount_is_still_the_authorized_plan ... FAILED
panicked at src/agent/src/rpc.rs:6609:
  a guest-derived content-channel mount rewrite must not fail the create:
  plan binding violation: in-guest resolution removed, reordered, or rewrote
  the authorized entry at /mounts/1
```

— the same error string observed on hardware.

## Validation

- `cargo test --features strict-policy` — **477 passed, 0 failed**
- `cargo fmt --check` — clean
- `cargo clippy --features strict-policy --all-targets` — no new warnings

## Stacking

Based on #523 (`agent: validate every bind-safer-path mount source`). Review that one first;
this PR's diff against it is a single commit.

#522 (the port of Dan's empty-file/empty-directory work) is blocked on **both**: with those
commits, the empty stand-ins fire regardless of `copy_volumes`, so *every* container carries a
content-channel mount and hits this. Verified on hardware with `copy_volumes` unset.
