### PR TITLE
packaging: copy third_party into the kata-deploy build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 # Context for tools/packaging/kata-deploy/Dockerfile (build from repo root: -f tools/packaging/kata-deploy/Dockerfile .)
 #
-# The Dockerfile only needs: Cargo.toml, Cargo.lock, src/, tools/packaging/kata-deploy/,
-# and versions.yaml. Exclude heavy or irrelevant trees to keep context small.
+# The Dockerfile only needs: Cargo.toml, Cargo.lock, src/, third_party/,
+# tools/packaging/kata-deploy/, and versions.yaml. Exclude heavy or irrelevant trees to keep context small.
 .git
 .github
 target

--- a/tools/packaging/kata-deploy/Dockerfile.components
+++ b/tools/packaging/kata-deploy/Dockerfile.components
@@ -55,6 +55,7 @@ RUN \
 WORKDIR /kata
 
 COPY Cargo.toml Cargo.lock ./
+COPY third_party ./third_party
 COPY src ./src
 COPY tools/packaging/kata-deploy/binary ./tools/packaging/kata-deploy/binary
 COPY tools/packaging/kata-deploy/job-dispatcher ./tools/packaging/kata-deploy/job-dispatcher


### PR DESCRIPTION
The `kata-deploy` component image build has been broken since commit
f7aef27f43 ("build: vendor patched pathrs"), which added

```toml
[patch.crates-io]
pathrs = { path = "third_party/pathrs" }
```

to the workspace root `Cargo.toml`. `Dockerfile.components` copies
`Cargo.toml`/`Cargo.lock` and `src/` into the build context but never copies
`third_party/`, so cargo cannot resolve the patched dependency:

```
error: failed to load source for dependency `pathrs`
  failed to read /kata/third_party/pathrs/Cargo.toml
  No such file or directory (os error 2)
```

This did not surface until now because the "Kata Containers CI" workflow was
`skipped` on the recent pull requests, so the job never actually ran.

Fix: copy `third_party/` into the image alongside `Cargo.toml`/`Cargo.lock`.
`.dockerignore` never excluded the directory, so the missing `COPY` was the
only cause; its header comment is updated to reflect what the build context
now needs.

Verified on a 16-core builder with the same toolchain CI uses
(`--build-arg RUST_TOOLCHAIN=1.94`, from `versions.yaml`):

- On the unmodified `manifold-cc` baseline the build fails at the
  `cargo fmt`/`clippy` stage with the `failed to load source for dependency
  'pathrs'` error above.
- With this change the `rust-builder` target builds to completion.

Signed-off-by: Jiri Appl <jiria@microsoft.com>
