### PR TITLE
osbuilder: restore copy_mkfs_ext4_runtime_deps for the NVIDIA rootfs

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -382,18 +382,34 @@ copy_cdh_runtime_deps() {
 	cp -a "${stage_one}/${libdir}"/libpcre2-8.so.0*        "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libcap.so.2*            "${libdir}/."
 
+	copy_mkfs_ext4_runtime_deps
+
+	# cryptsetup and dd are used by CDH secure_mount.
+	mkdir -p sbin bin
+	cp -a "${stage_one}/sbin/cryptsetup" sbin/.
+	cp -a "${stage_one}/usr/bin/dd" bin/.
+}
+
+# The e2fsprogs tooling the agent and CDH shell out to when formatting scratch
+# (block emptyDir) volumes. Kept self-contained so it can also be called on its
+# own from the chiseled layouts, where cryptsetup and its libraries are absent.
+copy_mkfs_ext4_runtime_deps() {
+	local libdir="lib/${machine_arch}-linux-gnu"
+
+	mkdir -p "${libdir}"
+
 	# e2fsprogs (mke2fs/mkfs.ext4) runtime libs
+	cp -a "${stage_one}/${libdir}"/libuuid.so.1*           "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libblkid.so.1*          "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libext2fs.so.2*         "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libcom_err.so.2*        "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libe2p.so.2*            "${libdir}/."
 
-	# cryptsetup, mkfs.ext4, and dd are used by CDH secure_mount.
-	mkdir -p sbin etc bin
-	cp -a "${stage_one}/sbin/cryptsetup" sbin/.
+	# The agent uses mkfs.ext4 for block-plain emptyDir volumes.
+	mkdir -p sbin etc
 	cp -a "${stage_one}/sbin/mke2fs" sbin/.
 	cp -a "${stage_one}/sbin/mkfs.ext4" sbin/.
 	cp -a "${stage_one}/etc/mke2fs.conf" etc/.
-	cp -a "${stage_one}/usr/bin/dd" bin/.
 }
 
 coco_guest_components() {


### PR DESCRIPTION
The NVIDIA rootfs build fails on both amd64 and arm64:

```
Failed at 747: copy_mkfs_ext4_runtime_deps
make: *** [...] Error 127
```

`nvidia_rootfs.sh` calls `copy_mkfs_ext4_runtime_deps` at the end of
`setup_nvidia_gpu_rootfs_stage_two`, but **the function is not defined anywhere in the tree**, so the call exits 127 (command not found).

### Root cause

The caller was introduced by bb0aaaa9d0 ("build: split NVIDIA rootfs into nvidia base image + gpu extension"), while the definition came from 023620f880 ("osbuilder: add mkfs.ext4 for NVIDIA rootfs") — which is **not an ancestor of `manifold-cc`**. A merge brought in the caller without the callee, leaving `copy_cdh_runtime_deps` still carrying the pre-split, inlined copy of the same logic.

This is pre-existing on `manifold-cc` and unrelated to any in-flight PR. It only surfaced now because the "Kata Containers CI" workflow had been `skipped` on recent pull requests.

### Fix

Restore the function exactly as 023620f880 defined it, extracting the e2fsprogs pieces out of `copy_cdh_runtime_deps` so both callers share one copy instead of drifting.

One deliberate difference from the original: the restored function does `mkdir -p "${libdir}"` before copying. It is now also reached for the `monolith` layout, which runs neither `chisseled_veritysetup` nor `chisseled_storage`, so the library directory is not guaranteed to already exist.

### Why the tooling is still needed

EROFS covers the read-only *container rootfs*; `mkfs.ext4` formats *writable scratch* (block `emptyDir`) volumes — different concerns. Both agent paths need it present in the guest:

- plain path: the agent execs `mkfs.ext4` directly (`src/agent/src/storage/block_handler.rs`, `ensure_ext4_filesystem`)
- encrypted path: CDH `secure_mount` shells out to it with `mkfsOpts`

### Verification

- `bash -n` and `shellcheck -S error` clean.
- The function now resolves: defined at :396, called at :385 and :763.
- A local `make DEPS= rootfs-image-nvidia-gpu-tarball` could **not** exercise the change — it fails earlier, at line 117, unpacking `kata-static-kernel-nvidia-gpu-modules.tar.zst`, an artifact CI downloads from the `build-asset` job and which is not available locally. So this relies on CI for end-to-end confirmation rather than a local repro.

Note: `build-kata-deploy-components` will still fail here; that is a separate pre-existing break fixed by #525.

Signed-off-by: Jiri Appl <jiria@microsoft.com>
