### PR TITLE
ci: baseline control run - DO NOT MERGE

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2557,6 +2557,7 @@ impl agent_ttrpc::AgentService for AgentService {
             is_allowed(&req).await?;
 
             // Potentially untrustworthy data from the host needs to go into the shared dir.
+            // (baseline CI control - do not merge)
             let root_path = PathBuf::from(KATA_GUEST_SHARE_DIR);
             do_copy_file(&req, &root_path).map_ttrpc_err(same)?;
 


### PR DESCRIPTION
Comment-only change on the tip of `manifold-cc`, opened purely to obtain a baseline **Kata Containers CI** run.

The full CI workflow only runs on PRs carrying the `ok-to-test` label (`ci-on-push.yaml` gates the `skipper` job on it), so a number of jobs have not executed on this branch in a long time. Two pre-existing breaks (#525, #526) were only discovered because of that.

This PR exists to tell regressions apart from pre-existing failures on #522. **Do not merge** - close once the run completes.