### PR TITLE
runtime-rs: enable copied volumes in CLH SNP config

### DIFF
--- a/src/runtime-rs/config/configuration-clh-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-snp-runtime-rs.toml.in
@@ -562,3 +562,5 @@ sandbox_bind_mounts = @DEFBINDMOUNTS@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+copy_volumes = ["network-files", "projected-volumes", "configmap-volumes", "secret-volumes", "downward-api-volumes"]


### PR DESCRIPTION
Enable host-to-guest copying when Cloud Hypervisor runs without filesystem sharing.