### PR TITLE
runtime-rs: support SNP guests across v5 and v6 skus

### DIFF
--- a/cloud-hypervisor-mshv-vmdk-compat.patch
+++ b/cloud-hypervisor-mshv-vmdk-compat.patch
@@ -1,47 +1,5 @@
-diff --git a/arch/src/lib.rs b/arch/src/lib.rs
-index 7e60a406..473c7df0 100644
---- a/arch/src/lib.rs
-+++ b/arch/src/lib.rs
-@@ -126,8 +126,8 @@ pub mod x86_64;
- pub use x86_64::{
-     _NSIG, CpuidConfig, CpuidFeatureEntry, EntryPoint, arch_memory_regions, configure_system,
-     configure_vcpu, cpu_profile::CpuProfile, generate_common_cpuid, generate_ram_ranges,
--    get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
--    layout::CMDLINE_START, regs,
-+    get_host_cpu_phys_bits, get_host_cpu_phys_bits_reduction, initramfs_load_addr, layout,
-+    layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, regs,
- };
- 
- /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.
-diff --git a/arch/src/x86_64/mod.rs b/arch/src/x86_64/mod.rs
-index e065b84f..2a7bb70c 100644
---- a/arch/src/x86_64/mod.rs
-+++ b/arch/src/x86_64/mod.rs
-@@ -1539,6 +1539,22 @@ pub fn get_host_cpu_phys_bits(_hypervisor: &dyn hypervisor::Hypervisor) -> u8 {
-     }
- }
- 
-+pub fn get_host_cpu_phys_bits_reduction(hypervisor: &dyn hypervisor::Hypervisor) -> u8 {
-+    // SAFETY: call cpuid with valid leaves
-+    #[allow(unused_unsafe)]
-+    unsafe {
-+        let leaf = x86_64::__cpuid(0x8000_0000);
-+        if leaf.eax >= 0x8000_001f
-+            && matches!(hypervisor.get_cpu_vendor(), CpuVendor::AMD)
-+            && x86_64::__cpuid(0x8000_001f).eax & 0x1 != 0
-+        {
-+            ((x86_64::__cpuid(0x8000_001f).ebx >> 6) & 0x3f) as u8
-+        } else {
-+            0
-+        }
-+    }
-+}
-+
- fn update_cpuid_topology(
-     cpuid: &mut Vec<CpuIdEntry>,
-     threads_per_core: u16,
 diff --git a/vmm/src/vm.rs b/vmm/src/vm.rs
-index 12a9fe0a..92879cba 100644
+index 12a9fe0a..23718712 100644
 --- a/vmm/src/vm.rs
 +++ b/vmm/src/vm.rs
 @@ -478,7 +478,6 @@ impl VmOps for VmOpsHandler {
@@ -52,17 +10,3 @@ index 12a9fe0a..92879cba 100644
          }
          Ok(())
      }
-@@ -527,6 +526,13 @@ impl VmOps for VmOpsHandler {
- pub fn physical_bits(hypervisor: &dyn hypervisor::Hypervisor, max_phys_bits: u8) -> u8 {
-     let host_phys_bits = get_host_cpu_phys_bits(hypervisor);
- 
-+    #[cfg(feature = "mshv")]
-+    let host_phys_bits = if hypervisor.hypervisor_type() == hypervisor::HypervisorType::Mshv {
-+        host_phys_bits.saturating_sub(arch::get_host_cpu_phys_bits_reduction(hypervisor))
-+    } else {
-+        host_phys_bits
-+    };
-+
-     cmp::min(host_phys_bits, max_phys_bits)
- }
- 

--- a/docs/design/erofs-cloud-hypervisor-investigation.md
+++ b/docs/design/erofs-cloud-hypervisor-investigation.md
@@ -53,8 +53,8 @@ Before `4091e965`, the zero-initialized emulator buffer remained unchanged.
 The working prototype:
 
 - reverts `4091e965`, restoring the previous missing-MMIO behavior;
-- applies AMD SME physical-address reduction only for the MSHV backend, leaving
-  KVM behavior unchanged.
+- caps the Kata-CC SNP guest physical address width at 43 bits, matching the
+  static platform-device addresses in the IGVM ACPI tables.
 
 With these changes, single-layer BusyBox and eight-layer `nginx:alpine`
 GPT+VMDK EROFS workloads both complete in approximately 11 seconds. The

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -680,6 +680,11 @@ pub struct CpuInfo {
     /// - On ARM with GICv2, max is 8
     #[serde(default)]
     pub default_maxvcpus: u32,
+
+    /// Maximum guest physical address width. Unspecified or `0` uses the
+    /// hypervisor-specific default.
+    #[serde(default)]
+    pub max_phys_bits: u8,
 }
 
 impl CpuInfo {
@@ -2032,11 +2037,13 @@ mod tests {
                     cpu_features: "".to_string(),
                     default_vcpus: 0.0,
                     default_maxvcpus: 0,
+                    max_phys_bits: 0,
                 },
                 output: CpuInfo {
                     cpu_features: "".to_string(),
                     default_vcpus,
                     default_maxvcpus: node_cpus as u32,
+                    max_phys_bits: 0,
                 },
             },
             TestData {
@@ -2045,11 +2052,13 @@ mod tests {
                     cpu_features: "a,b,c".to_string(),
                     default_vcpus: 9999999.0,
                     default_maxvcpus: 9999999,
+                    max_phys_bits: 0,
                 },
                 output: CpuInfo {
                     cpu_features: "a,b,c".to_string(),
                     default_vcpus: node_cpus,
                     default_maxvcpus: node_cpus as u32,
+                    max_phys_bits: 0,
                 },
             },
             TestData {
@@ -2058,11 +2067,13 @@ mod tests {
                     cpu_features: "a, b ,c".to_string(),
                     default_vcpus: -1.0,
                     default_maxvcpus: 1,
+                    max_phys_bits: 0,
                 },
                 output: CpuInfo {
                     cpu_features: "a,b,c".to_string(),
                     default_vcpus: 1.0,
                     default_maxvcpus: 1,
+                    max_phys_bits: 0,
                 },
             },
         ];

--- a/src/runtime-rs/config/configuration-clh-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-snp-runtime-rs.toml.in
@@ -90,6 +90,11 @@ default_vcpus = @DEFVCPUS@
 # unless you know what are you doing.
 default_maxvcpus = 1
 
+# Keep the guest address layout consistent with the static ACPI addresses in
+# the IGVM across Milan and Genoa confidential-child hosts.
+# TODO: 46 also passes on both when the IGVM ACPI layout matches.
+max_phys_bits = 43
+
 # Default memory size in MiB for SB/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
 default_memory = @DEFMEMSZ@

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -368,7 +368,11 @@ impl TryFrom<(CpuInfo, GuestProtection)> for CpusConfig {
             packages: 1,
         };
 
-        let max_phys_bits = DEFAULT_CH_MAX_PHYS_BITS;
+        let max_phys_bits = if cpu.max_phys_bits == 0 {
+            DEFAULT_CH_MAX_PHYS_BITS
+        } else {
+            cpu.max_phys_bits
+        };
 
         let features = CpuFeatures::from(cpu.cpu_features);
 
@@ -1338,6 +1342,31 @@ mod tests {
                         ..topology
                     }),
                     max_phys_bits: DEFAULT_CH_MAX_PHYS_BITS,
+
+                    ..Default::default()
+                }),
+            },
+            TestData {
+                cpu_info: CpuInfo {
+                    default_vcpus: 1.0,
+                    default_maxvcpus: 13,
+                    max_phys_bits: 43,
+                    ..Default::default()
+                },
+                guest_protection: GuestProtection::Snp(SevSnpDetails {
+                    cbitpos: 51,
+                    phys_addr_reduction: 5,
+                }),
+                result: Ok(CpusConfig {
+                    boot_vcpus: 1,
+                    max_vcpus: 1,
+                    nested: cpu_nested_config(),
+                    topology: Some(CpuTopology {
+                        cores_per_die: 1,
+
+                        ..topology
+                    }),
+                    max_phys_bits: 43,
 
                     ..Default::default()
                 }),

--- a/tools/osbuilder/igvm-builder/azure-linux/igvm-tooling-cpuid.patch
+++ b/tools/osbuilder/igvm-builder/azure-linux/igvm-tooling-cpuid.patch
@@ -1,0 +1,13 @@
+diff --git a/src/igvm/igvmfile.py b/src/igvm/igvmfile.py
+--- a/src/igvm/igvmfile.py
++++ b/src/igvm/igvmfile.py
+@@ -489,9 +489,6 @@ class IGVMFile:
+                         (CpuIdFunctionExtendedStateEnumeration, 2),
+                         (CpuIdFunctionExtendedStateEnumeration, 3),
+                         (CpuIdFunctionExtendedStateEnumeration, 4),
+-                        (CpuIdFunctionExtendedStateEnumeration, 5),
+-                        (CpuIdFunctionExtendedStateEnumeration, 6),
+-                        (CpuIdFunctionExtendedStateEnumeration, 7),
+                         (CpuIdFunctionExtendedStateEnumeration, 8),
+                         (CpuIdFunctionExtendedBrandingString1, 0),
+                         (CpuIdFunctionExtendedBrandingString2, 0),

--- a/tools/osbuilder/igvm-builder/azure-linux/igvm_lib.sh
+++ b/tools/osbuilder/igvm-builder/azure-linux/igvm_lib.sh
@@ -9,20 +9,26 @@
 install_igvm_tool()
 {
 	echo "Installing IGVM tool"
-	if [[ -d "${IGVM_EXTRACT_FOLDER}" ]]; then
-		echo "${IGVM_EXTRACT_FOLDER} folder already exists, assuming tool is already installed"
-		return
+	if [[ ! -d "${IGVM_EXTRACT_FOLDER}" ]]; then
+		# the igvm tool on Azure Linux will soon be properly installed through dnf via kata-packages-uvm-build
+		# as of now, even when installing with pip3, we cannot delete the source folder as the ACPI tables are not being installed anywhere, hence relying on this folder
+		echo "Determining and downloading latest IGVM tooling release, and extracting including ACPI tables"
+		IGVM_VER=$(curl -sL "https://api.github.com/repos/microsoft/igvm-tooling/releases/latest" | jq -r .tag_name | sed 's/^v//')
+		curl -sL "https://github.com/microsoft/igvm-tooling/archive/refs/tags/${IGVM_VER}.tar.gz" | tar --no-same-owner -xz
+		mv "igvm-tooling-${IGVM_VER}" "${IGVM_EXTRACT_FOLDER}"
+	else
+		echo "Using existing IGVM tooling source from ${IGVM_EXTRACT_FOLDER}"
 	fi
 
-	# the igvm tool on Azure Linux will soon be properly installed through dnf via kata-packages-uvm-build
-	# as of now, even when installing with pip3, we cannot delete the source folder as the ACPI tables are not being installed anywhere, hence relying on this folder
-	echo "Determining and downloading latest IGVM tooling release, and extracting including ACPI tables"
-	IGVM_VER=$(curl -sL "https://api.github.com/repos/microsoft/igvm-tooling/releases/latest" | jq -r .tag_name | sed 's/^v//')
-	curl -sL "https://github.com/microsoft/igvm-tooling/archive/refs/tags/${IGVM_VER}.tar.gz" | tar --no-same-owner -xz
-	mv "igvm-tooling-${IGVM_VER}" "${IGVM_EXTRACT_FOLDER}"
-	patch -d "${IGVM_EXTRACT_FOLDER}" -p1 < "${distro_config_dir}/igvm-tooling-cpuid.patch"
+	local patch_file="${distro_config_dir}/igvm-tooling-cpuid.patch"
+	if patch --batch --forward --dry-run -d "${IGVM_EXTRACT_FOLDER}" -p1 < "${patch_file}"; then
+		patch --batch --forward -d "${IGVM_EXTRACT_FOLDER}" -p1 < "${patch_file}"
+	elif ! patch --batch --reverse --dry-run -d "${IGVM_EXTRACT_FOLDER}" -p1 < "${patch_file}"; then
+		echo "IGVM tooling CPUID patch is incompatible"
+		return 1
+	fi
 
-	echo "Installing IGVM module msigvm (${IGVM_VER}) via pip3"
+	echo "Installing IGVM module msigvm via pip3"
 	pushd "${IGVM_EXTRACT_FOLDER}/src" || exit
 	pip3 install --no-deps ./
 	popd || exit

--- a/tools/osbuilder/igvm-builder/azure-linux/igvm_lib.sh
+++ b/tools/osbuilder/igvm-builder/azure-linux/igvm_lib.sh
@@ -20,6 +20,7 @@ install_igvm_tool()
 	IGVM_VER=$(curl -sL "https://api.github.com/repos/microsoft/igvm-tooling/releases/latest" | jq -r .tag_name | sed 's/^v//')
 	curl -sL "https://github.com/microsoft/igvm-tooling/archive/refs/tags/${IGVM_VER}.tar.gz" | tar --no-same-owner -xz
 	mv "igvm-tooling-${IGVM_VER}" "${IGVM_EXTRACT_FOLDER}"
+	patch -d "${IGVM_EXTRACT_FOLDER}" -p1 < "${distro_config_dir}/igvm-tooling-cpuid.patch"
 
 	echo "Installing IGVM module msigvm (${IGVM_VER}) via pip3"
 	pushd "${IGVM_EXTRACT_FOLDER}/src" || exit

--- a/tools/osbuilder/node-builder/azure-linux/README.md
+++ b/tools/osbuilder/node-builder/azure-linux/README.md
@@ -10,7 +10,7 @@ The guide provides the steps for two different environments:
 - Azure Linux 3 based systems, such as Azure VMs
   - Variant I: Utilize released components
   - Variant II: Build components from source
-- AKS nodes (based on Azure Linux 2 as of today)
+- AKS nodes based on Azure Linux 3
 
 # Steps for Azure Linux 3 based environments
 
@@ -123,7 +123,10 @@ sudo ./igvm_builder.sh -i
 popd
 ```
 
-This command installs the latest release of the [IGVM tooling](https://github.com/microsoft/igvm-tooling/) using `pip3 install`. The tool can be uninstalled at any time by calling the script using the -u parameter instead.
+This command installs the latest release of the [IGVM tooling](https://github.com/microsoft/igvm-tooling/) using `pip3 install`. The repository applies
+`igvm-tooling-cpuid.patch` during installation to omit CPUID entries that are
+not portable across MSHV-backed SNP hosts. The tool can be uninstalled at any
+time by calling the script using the `-u` parameter instead.
 
 ## Prepare SEV-SNP build inputs
 
@@ -145,8 +148,9 @@ popd
 ```
 
 The compatibility patch fully reverts Cloud Hypervisor commit `4091e965`
-(`vmm: return all-ones for unregistered MMIO reads`) and applies AMD SME
-physical-address reduction only to the MSHV backend.
+(`vmm: return all-ones for unregistered MMIO reads`). The Kata-CC SNP
+configuration explicitly caps the guest physical address width at 43 bits so
+the runtime and the static IGVM ACPI platform addresses use the same layout.
 
 For the single-layer EROFS flow, install containerd 2.3.3:
 
@@ -368,8 +372,21 @@ For further usage, refer to the upstream `ctr` documentation.
 
 ## Run via Kubernetes
 
-After configuring containerd's `kata-cc` handler to use the EROFS snapshotter,
-register a RuntimeClass from the machine that holds the cluster kubeconfig:
+On each target node, configure the existing `kata-cc` handler to use EROFS and
+the deployed runtime-rs configuration:
+
+```bash
+sudo sed -i \
+  '/runtimes.kata-cc/,/runtimes.kata-cc.options/ s/snapshotter = "tardev"/snapshotter = "erofs"/' \
+  /etc/containerd/config.toml
+sudo sed -i \
+  's|ConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/configuration-clh-snp.toml"|ConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/runtime-rs/configuration.toml"|' \
+  /etc/containerd/config.toml
+sudo containerd config dump >/dev/null
+sudo systemctl restart containerd
+```
+
+Then register a RuntimeClass from the machine that holds the cluster kubeconfig:
 
 ```yaml
 apiVersion: node.k8s.io/v1

--- a/tools/osbuilder/node-builder/azure-linux/README.md
+++ b/tools/osbuilder/node-builder/azure-linux/README.md
@@ -377,7 +377,8 @@ the deployed runtime-rs configuration:
 
 ```bash
 sudo sed -i \
-  '/runtimes.kata-cc/,/runtimes.kata-cc.options/ s/snapshotter = "tardev"/snapshotter = "erofs"/' \
+  -e '/runtimes.kata-cc/,/runtimes.kata-cc.options/ {/^[[:space:]]*snapshotter = /d;}' \
+  -e '/runtimes.kata-cc]$/a\  snapshotter = "erofs"' \
   /etc/containerd/config.toml
 sudo sed -i \
   's|ConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/configuration-clh-snp.toml"|ConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/runtime-rs/configuration.toml"|' \

--- a/tools/osbuilder/node-builder/azure-linux/package_tools_install.sh
+++ b/tools/osbuilder/node-builder/azure-linux/package_tools_install.sh
@@ -63,6 +63,7 @@ if [[ "${CONF_PODS}" == "yes" ]]; then
 	cp -a --backup=numbered tools/osbuilder/igvm-builder/igvm_builder.sh "${PREFIX}/${UVM_TOOLS_PATH_OSB}/igvm-builder/"
 	cp -a --backup=numbered tools/osbuilder/igvm-builder/azure-linux/config.sh "${PREFIX}/${UVM_TOOLS_PATH_OSB}/igvm-builder/azure-linux/"
 	cp -a --backup=numbered tools/osbuilder/igvm-builder/azure-linux/igvm_lib.sh "${PREFIX}/${UVM_TOOLS_PATH_OSB}/igvm-builder/azure-linux/"
+	cp -a --backup=numbered tools/osbuilder/igvm-builder/azure-linux/igvm-tooling-cpuid.patch "${PREFIX}/${UVM_TOOLS_PATH_OSB}/igvm-builder/azure-linux/"
 	if [[ "${BUILD_TARFS}" == "yes" ]]; then
 		cp -a --backup=numbered src/tarfs/Makefile "${PREFIX}/${UVM_TOOLS_PATH_SRC}/tarfs/"
 		cp -a --backup=numbered src/tarfs/tarfs.c "${PREFIX}/${UVM_TOOLS_PATH_SRC}/tarfs/"


### PR DESCRIPTION
    Expose a configurable guest physical address width and use a 43-bit
    layout for the Cloud Hypervisor SNP configuration so the VMM and the
    static IGVM ACPI device addresses agree across both host generations.

    Stop deriving the guest layout from the host SME physical-address
    reduction. Patch the downloaded IGVM tooling to omit XSAVE state
    subleaves 5-7, which Genoa MSHV rejects in the SNP CPUID page.