### PR TITLE
docs/cc/e2e: load erofs and dm_verity before containerd starts

### DIFF
--- a/docs/cc/e2e/platform-clh-snp.sh
+++ b/docs/cc/e2e/platform-clh-snp.sh
@@ -101,9 +101,15 @@ Note /dev/sev does NOT appear on the host — MSHV owns the PSP, so /dev/mshv is
 the indicator to check."
 }
 
-clh_assert_snp_host() {
-  [[ -e /dev/mshv ]] \
-    || die "no /dev/mshv — this node is not running as an MSHV Dom0. Re-run stage 02, then reboot."
+# Both modules have to be present *before* containerd starts, so this runs during
+# bootstrap rather than at first use. containerd's erofs differ probes for
+# dm-verity at plugin-load time, and if the probe fails it does not merely
+# disable verity — it fails the differ, which cascades into the diff service,
+# the CRI image service and finally the whole CRI plugin. The node then looks
+# like containerd is up while kubelet cannot talk to it at all, and stage 03's
+# 'kubeadm init' dies in preflight with an opaque "unknown service
+# runtime.v1.RuntimeService".
+clh_load_storage_modules() {
   sudo modprobe erofs 2>/dev/null || true
   grep -qw erofs /proc/filesystems \
     || die "the running host kernel has no EROFS support — the erofs snapshotter cannot mount layers.
@@ -116,22 +122,30 @@ Install the EROFS-enabled kernel-mshv build and reboot."
     echo erofs | sudo tee /etc/modules-load.d/erofs.conf >/dev/null
   fi
 
-  # dm-verity is the other module this stack needs early. containerd's erofs
-  # differ probes for it at plugin-load time, and if it is missing the probe
-  # does not merely disable verity — it fails the differ, which cascades into
-  # the diff service, the CRI image service and finally the whole CRI plugin.
-  # The node then looks like containerd is up while kubelet cannot talk to it
-  # at all. Load it before containerd is configured, and persist it.
   sudo modprobe dm-verity 2>/dev/null || true
-  grep -qw dm_verity /proc/modules \
-    || die "the running host kernel has no dm-verity support — containerd's erofs
+  # Probe the device-mapper target, not just the module list: with
+  # CONFIG_DM_VERITY=y the target is available but nothing appears in
+  # /proc/modules. (The EROFS check above is already builtin-safe because
+  # /proc/filesystems lists built-in filesystems too.)
+  if ! sudo dmsetup targets 2>/dev/null | grep -qw verity \
+     && ! grep -qw dm_verity /proc/modules; then
+    die "the running host kernel has no dm-verity support — containerd's erofs
 differ cannot compute per-layer hash trees, so no layer will carry the
 X-containerd.dmverity annotation and any policy asking for
 image_layer_verification = host-erofs-dm-verity will refuse every container."
-  if ! grep -qx dm-verity /etc/modules-load.d/dm-verity.conf 2>/dev/null; then
+  fi
+  # Only worth persisting when it is a loadable module; a built-in target needs
+  # no modules-load.d entry.
+  if grep -qw dm_verity /proc/modules \
+     && ! grep -qx dm-verity /etc/modules-load.d/dm-verity.conf 2>/dev/null; then
     echo dm-verity | sudo tee /etc/modules-load.d/dm-verity.conf >/dev/null
   fi
+}
 
+clh_assert_snp_host() {
+  [[ -e /dev/mshv ]] \
+    || die "no /dev/mshv — this node is not running as an MSHV Dom0. Re-run stage 02, then reboot."
+  clh_load_storage_modules
   ok "MSHV Dom0 with EROFS ($(uname -r))"
 }
 
@@ -152,9 +166,14 @@ clh_bootstrap_node() {
       || warn "cargo resolves to ${resolved}, not the rustup toolchain — prepend \$HOME/.cargo/bin to PATH if the build fails on a version requirement"
   fi
 
+  # Bring the node to Dom0 first. On the pre-reboot pass this deliberately dies
+  # asking for a reboot, so the module checks and containerd land on the MSHV
+  # kernel that will actually run the stack — not on the stock kernel, whose
+  # EROFS support is not this suite's to guarantee.
+  clh_enable_dom0
+  clh_load_storage_modules
   clh_install_containerd
   clh_configure_containerd
-  clh_enable_dom0
   ok "node bootstrapped for clh-snp"
 }
 
@@ -245,7 +264,7 @@ version = 3
   # If it is missing, the probe does not merely disable verity -- it fails the
   # differ, the diff service, the CRI image service and finally the whole CRI
   # plugin, leaving a node where containerd is "active" but kubelet cannot talk
-  # to it. clh_assert_snp_host() loads and persists the module first.
+  # to it. clh_load_storage_modules() loads and persists the module first.
   enable_dmverity = true
   # These three must match erofs_mkfs_options() in
   # tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs, because


### PR DESCRIPTION
## Problem

On a genuinely fresh `clh-snp` node the e2e suite fails in stage 03 with an opaque `kubeadm` preflight error:

```
[ERROR CRI]: could not connect to the container runtime: failed to create new CRI runtime service:
validate service connection: validate CRI v1 runtime API for endpoint
"unix:///run/containerd/containerd.sock": rpc error: code = Unimplemented
desc = unknown service runtime.v1.RuntimeService
```

The cause is ordering, not a broken runtime. containerd's EROFS differ probes for the `dm_verity` kernel module at plugin-load time, and a failed probe does not merely disable verity — it fails the differ, which cascades:

```
io.containerd.differ.v1.erofs        dm-verity support check failed
  -> io.containerd.service.v1.diff-service
    -> io.containerd.cri.v1.images
      -> io.containerd.grpc.v1.cri     unable to load CRI image service plugin dependency
```

The node is left with `systemctl status containerd` reporting **active** while kubelet cannot talk to it at all.

`erofs` and `dm_verity` were only loaded and persisted by `clh_assert_snp_host()`, which is called from **stage 04**. But containerd is installed and configured in **stage 02**, and **stage 03**'s `kubeadm init` needs a working CRI. Nodes that happened to have the modules already loaded from an earlier run masked this, which is why it only showed up on a brand-new VM.

## Change

- Extract the module loading and persistence into `clh_load_storage_modules()`. `clh_assert_snp_host()` keeps its `/dev/mshv` check and reuses the helper, so stage 04 still validates the running host.
- In `clh_bootstrap_node()`, run `clh_enable_dom0()` **first**, then load the modules, then install containerd. Bringing the node to Dom0 first matters: on the pre-reboot pass `clh_enable_dom0()` deliberately dies asking for a reboot, so the module checks and containerd now land on the MSHV kernel that will actually run the stack, rather than on the stock kernel whose EROFS support is not this suite's to guarantee.
- Probe dm-verity via `dmsetup targets` with `/proc/modules` as a fallback, so a kernel built with `CONFIG_DM_VERITY=y` is not misreported as lacking verity support, and only write a `modules-load.d` entry when it is genuinely a loadable module.

## Validation

Full suite on a fresh `Standard_DC32as_cc_v6` MSHV Dom0 node (belgiumcentral), `manifold-cc` @ `847c2c97cd`:

```
02-bootstrap-node        PASS
03-deploy-cluster        PASS
04-build-guest-stack     PASS
05-smoke-test            PASS
06-policy-fragment-e2e   PASS
07-fragment-bootpull     PASS
08-lifecycle-gates       PASS
total: 2509s
```

Both probe paths were also checked directly on that node (`dmsetup targets` reports `verity v1.9.0`; `/proc/modules` lists `dm_verity`), and the patched `clh_load_storage_modules()` / `clh_assert_snp_host()` were run against the live host.

Note this is the same cascade flagged during review of the AKS strict-mode image build — worth carrying the `modules-load.d` persistence into any node image that runs this stack.
