### PR TITLE
agent/srm: gate the formal model in CI and close the model-code drift

### DIFF
--- a/.github/workflows/formal-check.yaml
+++ b/.github/workflows/formal-check.yaml
@@ -1,10 +1,21 @@
 name: Formal model check (SRM)
 
 # FR-15: the security reference monitor's TLA+ model is part of the assurance
-# argument, so it is gated like code rather than run by hand. Path-filtered
-# because it only ever needs to run when the model, its harness, or the Rust it
-# describes changes -- the drift lint reads lib.rs and rpc.rs, so a change to
-# either can invalidate the model without touching `formal/`.
+# argument, so it is gated like code rather than run by hand.
+#
+# Deliberately *not* path-filtered. The obvious filter is the monitor's own
+# directory, but the drift lint reads `src/agent/src/rpc.rs`, which holds five of
+# the six modelled quarantine call sites -- so a filter scoped to the monitor
+# would let exactly the change this gate exists to catch slip past it. Widening
+# the filter to cover both is possible but fragile: the set of files the lint
+# reads is a property of the test, and a filter here silently stops matching it
+# the moment that set grows.
+#
+# The job is also a required check (tools/testing/gatekeeper/required-tests.yaml),
+# and gatekeeper waits for required jobs to report. A path-filtered workflow that
+# does not run produces no report at all, so "required" and "path-filtered" cannot
+# both hold. Running unconditionally is what makes the check enforceable; it costs
+# ~75s on a cached jar, which is cheap for a merge gate.
 
 on:
   workflow_dispatch:
@@ -13,9 +24,6 @@ on:
       - opened
       - reopened
       - synchronize
-    paths:
-      - "src/agent/security-reference-monitor/**"
-      - ".github/workflows/formal-check.yaml"
 
 permissions: {}
 

--- a/.github/workflows/formal-check.yaml
+++ b/.github/workflows/formal-check.yaml
@@ -1,0 +1,82 @@
+name: Formal model check (SRM)
+
+# FR-15: the security reference monitor's TLA+ model is part of the assurance
+# argument, so it is gated like code rather than run by hand. Path-filtered
+# because it only ever needs to run when the model, its harness, or the Rust it
+# describes changes -- the drift lint reads lib.rs and rpc.rs, so a change to
+# either can invalidate the model without touching `formal/`.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - "src/agent/security-reference-monitor/**"
+      - ".github/workflows/formal-check.yaml"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  formal-check:
+    name: TLC + mutation + drift
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Java
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      # tla2tools.jar is pinned by content in run-tlc.sh, so the cache key can
+      # be the digest itself: a cache entry that does not match the pin can
+      # never be served, and changing the pin changes the key.
+      - name: Resolve the pinned tla2tools digest
+        id: tla
+        run: |
+          sha=$(sed -n 's/^TLA2TOOLS_SHA256=//p' \
+            src/agent/security-reference-monitor/formal/run-tlc.sh)
+          test -n "${sha}"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache tla2tools.jar
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: src/agent/security-reference-monitor/formal/tla2tools.jar
+          key: tla2tools-${{ steps.tla.outputs.sha }}
+
+      # Steps 1 and 2 of the aggregate check: model + mutation. Split from the
+      # drift lint so that a failure names which obligation broke without
+      # waiting for the agent's dependencies to install.
+      - name: Model check and mutation test
+        run: ./check-all.sh --model
+        working-directory: src/agent/security-reference-monitor/formal
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install protobuf-compiler clang libdevmapper-dev
+
+      - name: Setup rust
+        run: |
+          ./tests/install_rust.sh
+          echo "${HOME}/.cargo/bin" >> "$GITHUB_PATH"
+
+      # Step 3: the model still describes the code.
+      - name: Model-drift lint
+        run: ./check-all.sh --drift
+        working-directory: src/agent/security-reference-monitor/formal
+        env:
+          RUST_BACKTRACE: "1"

--- a/src/agent/security-reference-monitor/formal/README.md
+++ b/src/agent/security-reference-monitor/formal/README.md
@@ -95,16 +95,78 @@ Action and temporal properties:
 ## Run
 
 ```bash
+./check-all.sh        # the FR-15 gate: all three obligations, one exit code
+./check-all.sh --model   # TLC + mutation only (needs a JRE, no Rust toolchain)
+./check-all.sh --drift   # the Rust drift lint only (no JRE)
+```
+
+`check-all.sh` is what CI runs (`.github/workflows/formal-check.yaml`). FR-15 does not claim
+that a model *exists*; it claims that the model is checked, that the properties it checks are
+falsifiable, and that the model still describes the Rust code. Those are three separate
+obligations, discharged by three different tools, and binding them into one command is how
+they stop being reported green individually while a gap opens between them:
+
+| Obligation                          | Tool                      | Failure it catches                                  |
+| ----------------------------------- | ------------------------- | --------------------------------------------------- |
+| The model holds                     | `run-tlc.sh`              | a property is violated, or an action can never fire |
+| The properties bite                 | `mutation-test.py`        | a property is vacuous, or has no mutant at all      |
+| The model is still true of the code | `../tests/model_drift.rs` | the model and the Rust have drifted apart           |
+
+The individual tools can still be run directly:
+
+```bash
 ./run-tlc.sh          # fetches tla2tools.jar if needed, runs TLC
 ./mutation-test.py    # proves the properties above are not vacuous
 ```
 
+`run-tlc.sh` pins `tla2tools.jar` **by sha256**, not just by version tag. Once this check
+gates the security model in CI, the tool that certifies the model is itself a supply-chain
+input to the assurance argument.
+
 Deadlock checking is disabled because the model legitimately terminates (every operation
 reaches a terminal state or the monitor quarantines), so a "deadlock" is an expected end
 state rather than a defect.
+
+### Action coverage
+
+TLC runs with `-coverage 1` and `run-tlc.sh` **fails** if any action generated zero states.
+An action that never fires is a guard that contradicts itself: every property is then checked
+over a smaller state space than the module claims. That is the same vacuity class
+`mutation-test.py` defends against, seen from the transition side rather than the property
+side, and it is how an earlier revision of `CommitFails` was wrong.
+
+An action that fires but produces no *distinct* state is reported as a **warning**, not a
+failure. `AbandonPrepared` is currently in this category: it is transition-equivalent to
+`Abort` restricted to `"prepared"`. It is kept deliberately — it mirrors a distinct code path
+(`reclaim_orphans`) and is worth the traceability — but it adds no proof obligation, and the
+warning exists so that nobody mistakes its presence for coverage of that path.
+
+### Mutation testing
 
 `mutation-test.py` breaks one implementation-faithful guard at a time and requires TLC to
 report a violation *of the property that mutation targets*. A surviving mutant — or one
 caught only by an unrelated property — means the targeted property is vacuous, which is the
 failure mode an earlier revision of this model actually had, where `TerminalExclusive`
 asserted only that a variable did not hold two values at once.
+
+It also asserts the mapping in **both** directions: every property listed in `SRM.cfg` must be
+the target of at least one mutant, and every mutant target must appear in `SRM.cfg`. A
+property added to the config without a mutant has never been shown to be falsifiable; a
+mutant targeting a property the config does not check can never be caught.
+
+## Drift between the model and the code
+
+A model is a claim about code, and it decays silently. `../tests/model_drift.rs` runs as an
+ordinary `cargo test` and cross-checks three things that the model asserts about the Rust and
+that no compiler would notice going stale:
+
+- every quarantine cause in `SRM.tla`'s `Causes` has a real call site in `lib.rs`/`rpc.rs`,
+  and vice versa;
+- the number of production `quarantine(` call sites matches the number the model declares
+  (test-only calls are excluded, so adding a test cannot mask a new production path);
+- every property defined in `SRM.tla` is actually listed in `SRM.cfg`, so a property cannot
+  be written and then never checked.
+
+The lint reads the Rust sources as text rather than instrumenting them: the point is to fail
+when someone adds a seventh quarantine site without touching the model, which is precisely
+the case no type system catches.

--- a/src/agent/security-reference-monitor/formal/README.md
+++ b/src/agent/security-reference-monitor/formal/README.md
@@ -100,9 +100,16 @@ Action and temporal properties:
 ./check-all.sh --drift   # the Rust drift lint only (no JRE)
 ```
 
-`check-all.sh` is what CI runs (`.github/workflows/formal-check.yaml`). FR-15 does not claim
-that a model *exists*; it claims that the model is checked, that the properties it checks are
-falsifiable, and that the model still describes the Rust code. Those are three separate
+`check-all.sh` is what CI runs (`.github/workflows/formal-check.yaml`), as a **required**
+check (`tools/testing/gatekeeper/required-tests.yaml`). The workflow is deliberately not
+path-filtered: gatekeeper seeds every required job as `EXPECTED` and waits for it to report,
+so a filtered workflow that does not run would block rather than pass. It also could not be
+filtered on the monitor's own directory anyway — the drift lint reads `src/agent/src/rpc.rs`,
+which holds five of the six modelled quarantine call sites.
+
+FR-15 does not claim that a model *exists*; it claims that the model is checked, that the
+properties it checks are falsifiable, and that the model still describes the Rust code. Those
+are three separate
 obligations, discharged by three different tools, and binding them into one command is how
 they stop being reported green individually while a gap opens between them:
 
@@ -121,7 +128,9 @@ The individual tools can still be run directly:
 
 `run-tlc.sh` pins `tla2tools.jar` **by sha256**, not just by version tag. Once this check
 gates the security model in CI, the tool that certifies the model is itself a supply-chain
-input to the assurance argument.
+input to the assurance argument. If neither `sha256sum` nor `shasum` is available the script
+**fails** rather than continuing: "could not verify" and "verified" must not take the same
+branch.
 
 Deadlock checking is disabled because the model legitimately terminates (every operation
 reaches a terminal state or the monitor quarantines), so a "deadlock" is an expected end
@@ -134,6 +143,12 @@ An action that never fires is a guard that contradicts itself: every property is
 over a smaller state space than the module claims. That is the same vacuity class
 `mutation-test.py` defends against, seen from the transition side rather than the property
 side, and it is how an earlier revision of `CommitFails` was wrong.
+
+The check is driven from the action names parsed out of `Next`, and it fails if any of them
+has no coverage row at all. Inspecting only the rows that happen to be present would make the
+gate self-defeating: were TLC's output format to change, or `-coverage` to be dropped, every
+filter would match nothing and the script would report that all actions fired while checking
+none of them — the same vacuity it exists to catch.
 
 An action that fires but produces no *distinct* state is reported as a **warning**, not a
 failure. `AbandonPrepared` is currently in this category: it is transition-equivalent to
@@ -162,10 +177,18 @@ that no compiler would notice going stale:
 
 - every quarantine cause in `SRM.tla`'s `Causes` has a real call site in `lib.rs`/`rpc.rs`,
   and vice versa;
-- the number of production `quarantine(` call sites matches the number the model declares
-  (test-only calls are excluded, so adding a test cannot mask a new production path);
+- every production `quarantine(` call site is claimed by exactly one modelled cause, and each
+  cause claims exactly one site — a bijection, not a count (test-only calls are excluded, so
+  adding a test cannot mask a new production path);
 - every property defined in `SRM.tla` is actually listed in `SRM.cfg`, so a property cannot
   be written and then never checked.
+
+A cause is matched against the reason expression *at its call site*, not against the file as
+a whole. The difference matters: most sites build the reason inline, but the FR-9
+occurrence-divergence site binds `let reason = format!(...)` so it can both log and return
+the same text, and a whole-file search would go on passing if that text were left in the log
+line while the `quarantine()` call itself came to say something else. The lint follows that
+single binding hop, so the cause↔call-site mapping it advertises is the one it enforces.
 
 The lint reads the Rust sources as text rather than instrumenting them: the point is to fail
 when someone adds a seventh quarantine site without touching the model, which is precisely

--- a/src/agent/security-reference-monitor/formal/SRM.tla
+++ b/src/agent/security-reference-monitor/formal/SRM.tla
@@ -88,9 +88,17 @@ States == {"none", "prepared", "executed", "committed"}
 (*   rollback-failed          rollback_policy_state (rpc.rs)               *)
 (*   no-snapshot              rollback_policy_state (rpc.rs)               *)
 (*   abort-failed             abort_or_quarantine   (rpc.rs)               *)
+(*   occurrence-diverged      do_create_container   (rpc.rs, strict-policy)*)
+(*                                                                         *)
+(* This list is checked against the implementation by                      *)
+(* `quarantine_causes_match_the_formal_model` in lib.rs: every production  *)
+(* `quarantine()` call site must map to a member of `Causes` and vice      *)
+(* versa. The sixth cause was added by the agent without being added here, *)
+(* which is the drift that test now prevents.                              *)
 (***************************************************************************)
 Causes == {"none", "commit-failed", "abandoned-after-execute",
-           "rollback-failed", "no-snapshot", "abort-failed"}
+           "rollback-failed", "no-snapshot", "abort-failed",
+           "occurrence-diverged"}
 
 VARIABLES
     state,        \* state[o]     : the lifecycle state of operation o
@@ -326,6 +334,17 @@ SnapshotMissing ==
     /\ Poison("no-snapshot")
     /\ UNCHANGED <<state, authorized, presented, teardown, version, commits>>
 
+(* FR-9: under `strict-policy`, `do_create_container` records the container's
+   occurrence after the transaction has committed. If the occurrence registry
+   refuses the record, the monitor's transaction log and the registry disagree
+   about which containers exist, and neither can be believed. Like the two
+   rollback faults this is not scoped to an operation id -- the divergence is
+   between two whole-sandbox registries, not within one transaction -- so it
+   takes no argument. *)
+OccurrenceDiverged ==
+    /\ Poison("occurrence-diverged")
+    /\ UNCHANGED <<state, authorized, presented, teardown, version, commits>>
+
 Next ==
     \/ \E o \in Ops, d \in Digests, td \in BOOLEAN : Prepare(o, d, td)
     \/ \E o \in Ops, d \in Digests : Execute(o, d)
@@ -338,6 +357,7 @@ Next ==
     \/ \E o \in Ops : AbandonExecuted(o)
     \/ RollbackFailed
     \/ SnapshotMissing
+    \/ OccurrenceDiverged
 
 Spec == Init /\ [][Next]_vars
 
@@ -370,7 +390,7 @@ CommittedIsPlanBound ==
 
 (* Every quarantine has a cause, and a cause implies a quarantine. There is
    no unconditional fail-closed action: the model can only quarantine
-   through one of the five call sites enumerated in `Causes`. *)
+   through one of the six call sites enumerated in `Causes`. *)
 QuarantineHasCause == quarantined <=> (qcause # "none")
 
 (* A monitor whose recorded version no longer matches reality is always

--- a/src/agent/security-reference-monitor/formal/SRM.tla
+++ b/src/agent/security-reference-monitor/formal/SRM.tla
@@ -91,10 +91,11 @@ States == {"none", "prepared", "executed", "committed"}
 (*   occurrence-diverged      do_create_container   (rpc.rs, strict-policy)*)
 (*                                                                         *)
 (* This list is checked against the implementation by                      *)
-(* `quarantine_causes_match_the_formal_model` in lib.rs: every production  *)
-(* `quarantine()` call site must map to a member of `Causes` and vice      *)
-(* versa. The sixth cause was added by the agent without being added here, *)
-(* which is the drift that test now prevents.                              *)
+(* `quarantine_causes_match_the_formal_model` in                           *)
+(* `tests/model_drift.rs`: every production `quarantine()` call site must  *)
+(* map to a member of `Causes` and vice versa. The sixth cause was added   *)
+(* by the agent without being added here, which is the drift that test now *)
+(* prevents.                                                               *)
 (***************************************************************************)
 Causes == {"none", "commit-failed", "abandoned-after-execute",
            "rollback-failed", "no-snapshot", "abort-failed",

--- a/src/agent/security-reference-monitor/formal/check-all.sh
+++ b/src/agent/security-reference-monitor/formal/check-all.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# FR-15 aggregate check: the single command that decides whether the formal
+# argument for the security reference monitor still holds.
+#
+# FR-15 does not claim "a TLA+ model exists". It claims that the model is
+# checked, that the properties it checks are falsifiable, and that the model
+# still describes the Rust code. Those are three separate obligations, and each
+# is discharged by a different tool here. Running them one at a time by hand is
+# how the first two came to be reported green while the third had never run at
+# all, so they are bound together into one gate:
+#
+#   1. run-tlc.sh        the model satisfies its properties, and every action
+#                        it declares can actually fire (coverage gate)
+#   2. mutation-test.py  each property is falsifiable, is caught by the
+#                        specific mutant that targets it, and no property in
+#                        SRM.cfg lacks a mutant
+#   3. cargo test        the Rust side still matches the model: model_drift
+#                        cross-checks the quarantine causes, the call sites and
+#                        the checked-property list against SRM.tla / SRM.cfg
+#
+# Steps 1 and 2 need a JRE; step 3 needs the agent's build dependencies. In CI
+# they run in one container, but the split is honoured here so the script is
+# still useful on a workstation that has only one of the two:
+#
+#   ./check-all.sh              everything
+#   ./check-all.sh --model      steps 1 and 2 only (JRE, no Rust toolchain)
+#   ./check-all.sh --drift      step 3 only (Rust toolchain, no JRE)
+set -euo pipefail
+cd "$(dirname "$0")"
+
+run_model=yes
+run_drift=yes
+case "${1:---all}" in
+  --all) ;;
+  --model) run_drift=no ;;
+  --drift) run_model=no ;;
+  -h|--help) sed -n '7,36p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  *) echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
+esac
+
+failed=()
+
+step() {
+  local name=$1; shift
+  echo
+  echo "=============================================================="
+  echo "  ${name}"
+  echo "=============================================================="
+  if "$@"; then
+    echo "-- ${name}: OK"
+  else
+    echo "-- ${name}: FAILED" >&2
+    failed+=("${name}")
+  fi
+}
+
+if [[ ${run_model} == yes ]]; then
+  step "TLC model check (+ action coverage)" ./run-tlc.sh
+  # mutation-test.py reuses the jar run-tlc.sh fetched and verified, so it must
+  # run second; on its own it would only tell the user to run run-tlc.sh first.
+  step "mutation test (property falsifiability)" ./mutation-test.py
+fi
+
+if [[ ${run_drift} == yes ]]; then
+  # Run from the crate root so this works regardless of where the workspace
+  # target directory is; -p keeps it to the monitor even though the agent
+  # workspace is much larger.
+  step "Rust model-drift lint" \
+    cargo test --manifest-path ../Cargo.toml \
+    -p kata-security-reference-monitor --test model_drift
+fi
+
+echo
+if (( ${#failed[@]} )); then
+  echo "FR-15 aggregate check FAILED (${#failed[@]}):" >&2
+  printf '  - %s\n' "${failed[@]}" >&2
+  exit 1
+fi
+
+echo "FR-15 aggregate check passed."

--- a/src/agent/security-reference-monitor/formal/mutation-test.py
+++ b/src/agent/security-reference-monitor/formal/mutation-test.py
@@ -17,6 +17,11 @@ property is vacuous and the model is not checking the claim it appears to.
 that TLC names the one that fired; a bundled invariant would make the
 per-target assertion below impossible.
 
+Every property `SRM.cfg` asks TLC to check must be the target of at least
+one mutant, and every mutant target must appear in `SRM.cfg`; both
+directions are asserted after the run, so a property added to the config
+without a matching mutant is a failure rather than a silent gap.
+
 Usage:
     ./mutation-test.py          # requires tla2tools.jar (run-tlc.sh fetches it)
 """
@@ -36,9 +41,24 @@ with open(os.path.join(HERE, "SRM.cfg")) as fh:
     CFG = fh.read()
 
 
+class AnchorError(Exception):
+    """A mutation's anchor text is no longer present in SRM.tla.
+
+    Raised instead of `assert` so that the message survives `python -O` and
+    so that an edit to the model which silently disarms a mutant is reported
+    as a hard failure naming the anchor, rather than as an AssertionError
+    with no context.
+    """
+
+
 def action_body(text, header):
     """Return (start, end) offsets of the body of the action `header`."""
-    start = text.index("\n" + header)
+    try:
+        start = text.index("\n" + header)
+    except ValueError:
+        raise AnchorError(
+            "SRM.tla no longer defines %r; the mutant that targets it is "
+            "disarmed. Update mutation-test.py to match the model." % header)
     return start, text.index("\n\n", start)
 
 
@@ -47,7 +67,10 @@ def drop_guard(text, header, guard):
     start, end = action_body(text, header)
     body = text[start:end]
     line = "    /\\ %s\n" % guard
-    assert line in body, "guard not found in %s: %r" % (header, guard)
+    if line not in body:
+        raise AnchorError(
+            "guard %r is no longer a conjunct of %s; the mutant that drops "
+            "it is disarmed." % (guard, header))
     return text[:start] + body.replace(line, "", 1) + text[end:]
 
 
@@ -55,8 +78,41 @@ def replace_in_action(text, header, old, new):
     start, end = action_body(text, header)
     body = text[start:end]
     mutated = body.replace(old, new)
-    assert mutated != body, "no such text in %s: %r" % (header, old)
+    if mutated == body:
+        raise AnchorError(
+            "%s no longer contains %r; the mutant that rewrites it is "
+            "disarmed." % (header, old))
     return text[:start] + mutated + text[end:]
+
+
+def replace_once(text, old, new, what):
+    """Whole-file single replacement with a named anchor."""
+    mutated = text.replace(old, new, 1)
+    if mutated == text:
+        raise AnchorError(
+            "SRM.tla no longer contains the %s anchor; the mutant that "
+            "targets it is disarmed." % what)
+    return mutated
+
+
+def cfg_properties():
+    """Every invariant and property SRM.cfg asks TLC to check."""
+    names = set()
+    section = None
+    for raw in CFG.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("\\*"):
+            continue
+        head = line.split()[0]
+        if head in ("INVARIANTS", "PROPERTIES", "INVARIANT", "PROPERTY"):
+            section = head
+            continue
+        if head in ("SPECIFICATION", "CONSTANTS", "CONSTANT", "INIT", "NEXT"):
+            section = None
+            continue
+        if section and "=" not in line:
+            names.add(line)
+    return names
 
 
 def mutants():
@@ -75,15 +131,15 @@ def mutants():
 
     # Superseding relaxes the anti-clobber rule; it must stay confined to
     # teardown-on-teardown while quarantined, or it is a general clobber.
-    mutated = SRC.replace(
+    mutated = replace_once(
+        SRC,
         """       \\/ /\\ state[o] \\in {"prepared", "executed"}
           /\\ td
           /\\ teardown[o]
           /\\ quarantined
 """,
         """       \\/ /\\ state[o] \\in {"prepared", "executed"}
-""", 1)
-    assert mutated != SRC, "superseding clause not found"
+""", "superseding clause")
     yield ("superseding not confined to teardown-while-quarantined",
            {"SupersedingIsConfined"}, mutated)
 
@@ -129,7 +185,8 @@ def mutants():
     # mutant must be caught by QuarantineSticky ALONE.
     yield ("quarantine can be cleared",
            {"QuarantineSticky"},
-           SRC.replace(
+           replace_once(
+               SRC,
                "Retire(o) ==\n"
                '    /\\ state[o] = "committed"\n'
                "    /\\ Release(o)\n"
@@ -140,7 +197,53 @@ def mutants():
                "    /\\ quarantined' = FALSE\n"
                '    /\\ qcause\' = "none"\n'
                "    /\\ divergent' = FALSE\n"
-               "    /\\ UNCHANGED <<version, commits>>", 1))
+               "    /\\ UNCHANGED <<version, commits>>",
+               "Retire body"))
+
+    # The version is what the monitor hands out as proof of the committed
+    # state; a commit that lands without advancing it makes every later
+    # attestation of that version a lie. `commits` still advances, so
+    # VersionMonotone cannot fire (the version never decreases) -- this
+    # mutant must be caught by VersionCountsAllCommits ALONE.
+    yield ("Commit does not advance the version",
+           {"VersionCountsAllCommits"},
+           replace_in_action(SRC, "Commit(o) ==",
+                             "    /\\ version' = version + 1\n",
+                             "    /\\ version' = version\n"))
+
+    # `quarantine()` records WHY it fired; the cause is what the six call
+    # sites are distinguished by and what an operator sees. Losing it while
+    # still latching `quarantined` leaves a monitor that is failed closed
+    # for no stated reason -- QuarantineHasCause exists to forbid exactly
+    # that, and nothing else can catch it.
+    yield ("Poison forgets to record the cause",
+           {"QuarantineHasCause"},
+           replace_in_action(
+               SRC, "Poison(cause) ==",
+               "    /\\ qcause' = IF quarantined THEN qcause ELSE cause",
+               '    /\\ qcause\' = "none"'))
+
+    # Every cause string must be one of the six the Rust code can emit; a
+    # cause outside `Causes` is precisely the drift that tests/model_drift.rs
+    # guards on the Rust side. TypeOK is the only property that can see it,
+    # which is also this mutant's job: to show TypeOK is not vacuous.
+    yield ("Poison records a cause outside Causes",
+           {"TypeOK"},
+           replace_in_action(
+               SRC, "Poison(cause) ==",
+               "    /\\ qcause' = IF quarantined THEN qcause ELSE cause",
+               '    /\\ qcause\' = "unlisted-cause"'))
+
+    # Phase 1 is what binds an operation to the plan the policy authorized;
+    # an in-flight transaction with no authorization can never be bound to
+    # anything, so execute()'s digest check would be comparing against a
+    # value the policy never approved.
+    yield ("Prepare reserves state without an authorization",
+           {"InFlightIsAuthorized"},
+           replace_in_action(
+               SRC, "Prepare(o, d, td) ==",
+               "    /\\ authorized' = [authorized EXCEPT ![o] = d]",
+               "    /\\ authorized' = [authorized EXCEPT ![o] = NoDigest]"))
 
 
 def check(text):
@@ -184,7 +287,9 @@ def main():
         return 1
 
     failures = 0
+    targeted = set()
     for description, targets, text in mutants():
+        targeted |= targets
         verdict, violated, out = check(text)
         # TLC halts at the first violation, so require the reported set to
         # intersect the targets rather than to contain all of them.
@@ -198,7 +303,24 @@ def main():
         if not hit:
             sys.stderr.write(out[-2500:])
 
-    print("\n%d mutant(s) not caught by the property they target" % failures)
+    # A property TLC checks but no mutant targets has never been shown to be
+    # falsifiable: it may be a tautology that would pass on a model with the
+    # guard it claims to protect removed. Adding a property to SRM.cfg
+    # without a mutant is the drift this catches.
+    untested = cfg_properties() - targeted
+    if untested:
+        failures += len(untested)
+        print("\nFAIL: %d propert(y/ies) in SRM.cfg have no mutant proving "
+              "they can fail: %s" % (len(untested), ", ".join(sorted(untested))))
+    stale = targeted - cfg_properties()
+    if stale:
+        failures += len(stale)
+        print("\nFAIL: %d mutant target(s) are not checked by SRM.cfg, so the "
+              "mutant can never be caught: %s"
+              % (len(stale), ", ".join(sorted(stale))))
+
+    print("\n%d failure(s): mutants not caught by their target property, or "
+          "properties with no mutant" % failures)
     return 1 if failures else 0
 
 

--- a/src/agent/security-reference-monitor/formal/run-tlc.sh
+++ b/src/agent/security-reference-monitor/formal/run-tlc.sh
@@ -9,22 +9,103 @@
 # Requires a Java runtime and tla2tools.jar. In CI this can run in any JRE image:
 #   docker run --rm -v "$PWD:/w" -w /w eclipse-temurin:21-jre ./run-tlc.sh
 #
-# tla2tools.jar is fetched next to this script if absent. Deadlock checking is disabled
-# on purpose: the model legitimately terminates (all operations reach a terminal state,
-# or the monitor quarantines), so a "deadlock" is an expected end state, not a bug. The
-# checked properties are the TypeOK, VersionCountsAllCommits, CommittedIsPlanBound,
-# QuarantineHasCause, DivergenceImpliesQuarantine and InFlightIsAuthorized invariants,
-# plus the QuarantineSticky, QuarantineAdmitsOnlyTeardown, QuarantineGatesExecute,
+# tla2tools.jar is fetched next to this script if absent, and verified against
+# TLA2TOOLS_SHA256 below. Pinning the version is not enough once this check
+# gates the security model in CI: the tool that certifies the model becomes a
+# supply-chain input to the assurance argument, so it is pinned by content.
+#
+# Deadlock checking is disabled on purpose: the model legitimately terminates
+# (all operations reach a terminal state, or the monitor quarantines), so a
+# "deadlock" is an expected end state, not a bug. The checked properties are the
+# TypeOK, VersionCountsAllCommits, CommittedIsPlanBound, QuarantineHasCause,
+# DivergenceImpliesQuarantine and InFlightIsAuthorized invariants, plus the
+# QuarantineSticky, QuarantineAdmitsOnlyTeardown, QuarantineGatesExecute,
 # SupersedingIsConfined and VersionMonotone properties; see README.md. Run
 # ./mutation-test.py afterwards to confirm none of them is vacuous.
+#
+# TLC runs with -coverage and this script FAILS if any action never fired. An
+# action with zero generated states is a guard that contradicts itself: it
+# contributes no behaviour, so every property is checked over a smaller state
+# space than the module claims. That is the vacuity class mutation-test.py
+# defends against, seen from the transition side rather than the property side,
+# and it is how an earlier revision of CommitFails was wrong. An action that
+# fires but adds no *distinct* state is reported as a warning; see below.
 set -euo pipefail
 cd "$(dirname "$0")"
 
+TLA2TOOLS_VERSION=v1.8.0
+TLA2TOOLS_SHA256=eabd140a70f49eb9305a3bd3f3df944eddf87e5a90d329789085f8953a80533a
+
 JAR=${TLA2TOOLS_JAR:-tla2tools.jar}
 if [[ ! -f "${JAR}" ]]; then
-  echo "fetching tla2tools.jar..."
+  echo "fetching tla2tools.jar ${TLA2TOOLS_VERSION}..."
   curl -fsSL -o "${JAR}" \
-    https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+    "https://github.com/tlaplus/tlaplus/releases/download/${TLA2TOOLS_VERSION}/tla2tools.jar"
 fi
 
-exec java -cp "${JAR}" tlc2.TLC -deadlock -config SRM.cfg SRM.tla
+if command -v sha256sum >/dev/null 2>&1; then
+  if ! echo "${TLA2TOOLS_SHA256}  ${JAR}" | sha256sum -c - >/dev/null 2>&1; then
+    echo "ERROR: ${JAR} does not match the pinned sha256." >&2
+    echo "       Delete it to re-fetch, or update TLA2TOOLS_SHA256 if the" >&2
+    echo "       pinned version was changed deliberately." >&2
+    exit 1
+  fi
+else
+  echo "WARNING: sha256sum not found; ${JAR} integrity NOT verified" >&2
+fi
+
+# Keep the raw output: the coverage check parses it, and a failing run must
+# still show TLC's own diagnostics.
+out=$(mktemp)
+trap 'rm -f "${out}"' EXIT
+
+status=0
+java -cp "${JAR}" tlc2.TLC -deadlock -coverage 1 -config SRM.cfg SRM.tla \
+  2>&1 | tee "${out}" || status=$?
+
+if [[ ${status} -ne 0 ]]; then
+  exit "${status}"
+fi
+
+# Action coverage lines look like:
+#   <Prepare line 181, col 1 to line 181, col 17 of module SRM>: 431:6336
+# where the pair is DISTINCT:GENERATED — the states this action generated, and
+# how many of those were new. The two mean different things:
+#
+#   generated == 0  the action never fired at all. That is a guard which
+#                   contradicts itself, and it is a hard failure: every
+#                   property is then checked over a smaller state space than
+#                   the module claims.
+#   distinct  == 0  the action fired, but reached nothing another action does
+#                   not already reach — it is transition-equivalent to some
+#                   other action. Reported as a warning, not a failure: an
+#                   action may legitimately mirror a distinct *code* path whose
+#                   effect coincides (AbandonPrepared vs Abort), which is worth
+#                   keeping for traceability even though it adds no obligation.
+parse='/^<[A-Za-z_][A-Za-z0-9_]* line [0-9]+, col [0-9]+ .* of module SRM>: [0-9]+:[0-9]+$/'
+
+dead=$(awk "${parse}"'{ name = substr($1, 2); split($NF, c, ":"); if (c[2] == 0) print name }' \
+  "${out}" | sort -u)
+redundant=$(awk "${parse}"'{ name = substr($1, 2); split($NF, c, ":"); if (c[1] == 0 && c[2] != 0) print name }' \
+  "${out}" | sort -u)
+
+if [[ -n "${redundant}" ]]; then
+  echo >&2
+  echo "WARNING: these actions generated no state another action does not" >&2
+  echo "         already reach (transition-equivalent, no added obligation):" >&2
+  while IFS= read -r action; do echo "  - ${action}" >&2; done <<<"${redundant}"
+fi
+
+if [[ -n "${dead}" ]]; then
+  echo >&2
+  echo "ERROR: the following actions never fired (zero states generated):" >&2
+  while IFS= read -r action; do echo "  - ${action}" >&2; done <<<"${dead}"
+  echo >&2
+  echo "An action that cannot fire is a guard that contradicts itself. Either" >&2
+  echo "the guard is wrong, or SRM.cfg is too small to reach it. Both make the" >&2
+  echo "checked properties weaker than they appear." >&2
+  exit 1
+fi
+
+echo
+echo "coverage: every action fired at least once"

--- a/src/agent/security-reference-monitor/formal/run-tlc.sh
+++ b/src/agent/security-reference-monitor/formal/run-tlc.sh
@@ -43,15 +43,27 @@ if [[ ! -f "${JAR}" ]]; then
     "https://github.com/tlaplus/tlaplus/releases/download/${TLA2TOOLS_VERSION}/tla2tools.jar"
 fi
 
+# The jar is executable supply-chain input, so a missing checksum tool is a
+# reason to stop, not a reason to continue: "could not verify" and "verified"
+# must never take the same branch. macOS ships `shasum` rather than
+# `sha256sum`, so try both before giving up.
 if command -v sha256sum >/dev/null 2>&1; then
-  if ! echo "${TLA2TOOLS_SHA256}  ${JAR}" | sha256sum -c - >/dev/null 2>&1; then
-    echo "ERROR: ${JAR} does not match the pinned sha256." >&2
-    echo "       Delete it to re-fetch, or update TLA2TOOLS_SHA256 if the" >&2
-    echo "       pinned version was changed deliberately." >&2
-    exit 1
-  fi
+  actual=$(sha256sum "${JAR}" | cut -d' ' -f1)
+elif command -v shasum >/dev/null 2>&1; then
+  actual=$(shasum -a 256 "${JAR}" | cut -d' ' -f1)
 else
-  echo "WARNING: sha256sum not found; ${JAR} integrity NOT verified" >&2
+  echo "ERROR: neither sha256sum nor shasum is available, so ${JAR} cannot be" >&2
+  echo "       verified against its pin. Refusing to run an unverified jar." >&2
+  exit 1
+fi
+
+if [[ "${actual}" != "${TLA2TOOLS_SHA256}" ]]; then
+  echo "ERROR: ${JAR} does not match the pinned sha256." >&2
+  echo "       expected ${TLA2TOOLS_SHA256}" >&2
+  echo "       actual   ${actual}" >&2
+  echo "       Delete it to re-fetch, or update TLA2TOOLS_SHA256 if the" >&2
+  echo "       pinned version was changed deliberately." >&2
+  exit 1
 fi
 
 # Keep the raw output: the coverage check parses it, and a failing run must
@@ -69,8 +81,10 @@ fi
 
 # Action coverage lines look like:
 #   <Prepare line 181, col 1 to line 181, col 17 of module SRM>: 431:6336
-# where the pair is DISTINCT:GENERATED — the states this action generated, and
-# how many of those were new. The two mean different things:
+# where the pair is DISTINCT:GENERATED — how many of the states this action
+# generated were new, and how many it generated in all. (The order is easy to
+# invert; the labels above are TLC's own, and the checks below depend on them.)
+# The two mean different things:
 #
 #   generated == 0  the action never fired at all. That is a guard which
 #                   contradicts itself, and it is a hard failure: every
@@ -83,6 +97,41 @@ fi
 #                   effect coincides (AbandonPrepared vs Abort), which is worth
 #                   keeping for traceability even though it adds no obligation.
 parse='/^<[A-Za-z_][A-Za-z0-9_]* line [0-9]+, col [0-9]+ .* of module SRM>: [0-9]+:[0-9]+$/'
+
+# A coverage check that only inspects the rows it finds cannot tell "every
+# action fired" from "no rows were parsed": if TLC's output format changes, or
+# -coverage stops being passed, every filter below matches nothing and the gate
+# reports success while checking precisely nothing. So derive the actions the
+# module *claims* from `Next`, and require a row for each. This also catches an
+# action that is defined and never disjoined into `Next`, which TLC itself will
+# not report -- the coverage output simply would not mention it.
+expected=$(sed -n '/^Next ==/,/^$/p' SRM.tla |
+  sed -n 's/.*[:/][[:space:]]*\([A-Za-z_][A-Za-z0-9_]*\)[[:space:]]*(\{0,1\}.*/\1/p' | sort -u)
+
+if [[ -z "${expected}" ]]; then
+  echo "ERROR: could not parse any action names out of SRM.tla's \`Next\`." >&2
+  echo "       The coverage gate cannot verify anything without them, so this" >&2
+  echo "       is a failure rather than a skip. Has \`Next\` been reformatted?" >&2
+  exit 1
+fi
+
+missing=()
+while IFS= read -r action; do
+  if ! grep -qE "^<${action} line [0-9]+, col [0-9]+ .* of module SRM>:" "${out}"; then
+    missing+=("${action}")
+  fi
+done <<<"${expected}"
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo >&2
+  echo "ERROR: TLC reported no coverage at all for these actions of \`Next\`:" >&2
+  for action in "${missing[@]}"; do echo "  - ${action}" >&2; done
+  echo >&2
+  echo "Either TLC's coverage output changed shape (in which case this gate was" >&2
+  echo "silently passing and must be repaired), or these actions are named in" >&2
+  echo "\`Next\` but not defined as actions of this module." >&2
+  exit 1
+fi
 
 dead=$(awk "${parse}"'{ name = substr($1, 2); split($NF, c, ":"); if (c[2] == 0) print name }' \
   "${out}" | sort -u)
@@ -108,4 +157,4 @@ if [[ -n "${dead}" ]]; then
 fi
 
 echo
-echo "coverage: every action fired at least once"
+echo "coverage: all $(wc -l <<<"${expected}") actions of \`Next\` fired at least once"

--- a/src/agent/security-reference-monitor/tests/fault_injection.rs
+++ b/src/agent/security-reference-monitor/tests/fault_injection.rs
@@ -230,7 +230,12 @@ fn randomized_sequences_preserve_invariants() {
             }
             assert!(
                 m.transaction_count() <= ids.len(),
-                "seed {seed}: transaction map grew beyond the id space"
+                // Explicit argument: the agent workspace is edition 2018, where
+                // `assert!` with a single string does not treat it as a format
+                // string -- an implicit `{seed}` capture would print the
+                // placeholder and lose the seed that reproduces the failure.
+                "seed {}: transaction map grew beyond the id space",
+                seed
             );
         }
     }

--- a/src/agent/security-reference-monitor/tests/model_drift.rs
+++ b/src/agent/security-reference-monitor/tests/model_drift.rs
@@ -38,8 +38,7 @@ fn repo_path(rel: &str) -> PathBuf {
 
 fn read(rel: &str) -> String {
     let path = repo_path(rel);
-    fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e))
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e))
 }
 
 /// Drop everything from the unit-test module onwards.
@@ -75,43 +74,145 @@ fn production_only(src: &str) -> &str {
     src
 }
 
+/// A production `quarantine()` call, together with the reason expression it passes.
+struct CallSite {
+    line: usize,
+    text: String,
+    /// The reason as written at the call: the argument list itself, or -- when the
+    /// argument is merely a binding -- that binding's initializer.
+    reason: String,
+}
+
+/// The source between `open` (which must index a `(`) and its matching `)`.
+///
+/// String literals are tracked so that parentheses *inside* a reason string cannot
+/// unbalance the scan.
+fn balanced(src: &str, open: usize) -> Option<&str> {
+    let bytes = src.as_bytes();
+    let (mut depth, mut in_str, mut escaped) = (0usize, false, false);
+    for i in open..bytes.len() {
+        let c = bytes[i];
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match c {
+            b'"' => in_str = true,
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&src[open + 1..i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// `s` truncated at the first `;` outside any bracket or string.
+fn until_semicolon(s: &str) -> &str {
+    let (mut depth, mut in_str, mut escaped) = (0i32, false, false);
+    for (i, c) in s.bytes().enumerate() {
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match c {
+            b'"' => in_str = true,
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b';' if depth <= 0 => return &s[..i],
+            _ => {}
+        }
+    }
+    s
+}
+
+/// The reason expression belonging to a `quarantine()` call at `call_at`.
+///
+/// Most call sites build the reason in place (`quarantine(format!("..."))`), so the
+/// argument list already contains it. One does not: the FR-9 occurrence-divergence
+/// site binds `let reason = format!(...)` so it can both log and return the same
+/// text, and calls `quarantine(reason.clone())`. Following that one hop is what
+/// lets the lint insist the reason belongs to *this* call rather than merely
+/// occurring somewhere in the file.
+fn resolve_reason(src: &str, call_at: usize, args: &str) -> String {
+    if args.contains('"') {
+        return args.to_string();
+    }
+    let ident: String = args
+        .trim()
+        .trim_start_matches('&')
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    if ident.is_empty() {
+        return args.to_string();
+    }
+    let head = &src[..call_at];
+    match head.rfind(&format!("let {} =", ident)) {
+        Some(at) => until_semicolon(&head[at..]).to_string(),
+        None => args.to_string(),
+    }
+}
+
 /// Locate call sites of the *method* `quarantine(`, excluding `abort_or_quarantine(`
 /// and `commit_or_quarantine(` (which contain it as a substring), the `fn
 /// quarantine(` definition itself, and mentions inside comments.
 ///
-/// Returns `(line number, trimmed line)` so a failure can name what it found: a
-/// bare count tells a developer that the lint fired but not which call site is new.
-fn quarantine_call_sites(src: &str) -> Vec<(usize, String)> {
+/// Each site carries its line number and text so a failure can name what it found:
+/// a bare count tells a developer that the lint fired but not which call site is new.
+fn quarantine_call_sites(src: &str) -> Vec<CallSite> {
+    let bytes = src.as_bytes();
     let mut sites = Vec::new();
-    for (idx, line) in src.lines().enumerate() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("//") || trimmed.starts_with("*") {
+    let mut from = 0;
+    while let Some(rel) = src[from..].find("quarantine(") {
+        let at = from + rel;
+        from = at + "quarantine(".len();
+        let open = from - 1;
+
+        // Part of a longer identifier (`abort_or_quarantine`).
+        if at > 0 {
+            let p = bytes[at - 1];
+            if p == b'_' || p.is_ascii_alphanumeric() {
+                continue;
+            }
+        }
+        let line_start = src[..at].rfind('\n').map_or(0, |i| i + 1);
+        let line_end = src[at..].find('\n').map_or(src.len(), |i| at + i);
+        let trimmed = src[line_start..line_end].trim();
+        if trimmed.starts_with("//") || trimmed.starts_with('*') {
             continue;
         }
-        let bytes = line.as_bytes();
-        let mut from = 0;
-        while let Some(rel) = line[from..].find("quarantine(") {
-            let at = from + rel;
-            from = at + "quarantine(".len();
-
-            // Part of a longer identifier (`abort_or_quarantine`).
-            if at > 0 && {
-                let p = bytes[at - 1];
-                p == b'_' || p.is_ascii_alphanumeric()
-            } {
-                continue;
-            }
-            // The definition, not a call.
-            if line[..at].contains("fn ") {
-                continue;
-            }
-            // A mention in prose, e.g. `quarantine()` in a doc comment.
-            if line[from..].starts_with(')') {
-                continue;
-            }
-            sites.push((idx + 1, trimmed.to_string()));
-            break;
+        // The definition, not a call.
+        if src[line_start..at].contains("fn ") {
+            continue;
         }
+        // A mention in prose, e.g. `quarantine()` in a doc comment.
+        if src[from..].starts_with(')') {
+            continue;
+        }
+
+        let args = balanced(src, open).unwrap_or("");
+        sites.push(CallSite {
+            line: src[..at].matches('\n').count() + 1,
+            text: trimmed.to_string(),
+            reason: resolve_reason(src, at, args),
+        });
     }
     sites
 }
@@ -184,14 +285,28 @@ fn quarantine_causes_match_the_formal_model() {
             )
         });
         let src = read(file);
-        assert!(
-            production_only(&src).contains(marker),
-            "SRM.tla declares the quarantine cause {:?}, which should come from {} \
-             containing {:?} — but it does not. Either the reason string changed, or \
-             the cause no longer exists and must be removed from the model.",
+        let sites = quarantine_call_sites(production_only(&src));
+        let matched: Vec<&CallSite> = sites.iter().filter(|s| s.reason.contains(marker)).collect();
+
+        assert_eq!(
+            matched.len(),
+            1,
+            "SRM.tla declares the quarantine cause {:?}, which should be raised by \
+             exactly one quarantine() call in {} whose reason contains {:?} — but {} \
+             such calls were found. Searching the reason *at the call* rather than \
+             the whole file is deliberate: leaving the text in a nearby log line \
+             while the call itself says something else is drift, not a match.\n\
+             call sites in {}:\n{}",
             cause,
             file,
-            marker
+            marker,
+            matched.len(),
+            file,
+            sites
+                .iter()
+                .map(|s| format!("  {}:{}  {}", file, s.line, s.text))
+                .collect::<Vec<_>>()
+                .join("\n")
         );
     }
 
@@ -208,21 +323,42 @@ fn quarantine_causes_match_the_formal_model() {
 #[test]
 fn every_quarantine_call_site_is_modelled() {
     let mut found: Vec<String> = Vec::new();
+    let mut unclaimed: Vec<String> = Vec::new();
+
     for file in ["src/lib.rs", "../src/rpc.rs"] {
         let src = read(file);
-        for (line, text) in quarantine_call_sites(production_only(&src)) {
-            found.push(format!("  {}:{}  {}", file, line, text));
+        for site in quarantine_call_sites(production_only(&src)) {
+            let where_ = format!("  {}:{}  {}", file, site.line, site.text);
+            let claims = CAUSE_CALL_SITES
+                .iter()
+                .filter(|(_, f, marker)| *f == file && site.reason.contains(marker))
+                .count();
+            if claims != 1 {
+                unclaimed.push(format!("{}   [{} rows claim it]", where_, claims));
+            }
+            found.push(where_);
         }
     }
+
+    // Counting alone would let a new call site hide behind a deleted one. Each
+    // site must be claimed by exactly one row, and (via the companion test) each
+    // row must claim exactly one site -- together a bijection between the code's
+    // ways of failing closed and the model's `Causes`.
+    assert!(
+        unclaimed.is_empty(),
+        "these production quarantine() call sites are not matched by exactly one row \
+         of CAUSE_CALL_SITES:\n{}\n\nA new call site is a new way for the monitor to \
+         fail closed; it needs a cause in SRM.tla's `Causes`, an action that raises \
+         it, and a row here. (This is exactly the drift that left the model claiming \
+         five causes while the agent had six.)",
+        unclaimed.join("\n")
+    );
 
     assert_eq!(
         found.len(),
         CAUSE_CALL_SITES.len(),
         "the agent has {} production quarantine() call sites but the model accounts for \
-         {}. A new call site is a new way for the monitor to fail closed; it needs a \
-         cause in SRM.tla's `Causes`, an action that raises it, and a row in \
-         CAUSE_CALL_SITES. (This is exactly the drift that left the model claiming five \
-         causes while the agent had six.)\nfound:\n{}",
+         {}.\nfound:\n{}",
         found.len(),
         CAUSE_CALL_SITES.len(),
         found.join("\n")

--- a/src/agent/security-reference-monitor/tests/model_drift.rs
+++ b/src/agent/security-reference-monitor/tests/model_drift.rs
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! FR-15 — keep the TLA+ model and the implementation from drifting apart.
+//!
+//! `formal/SRM.tla` is a snapshot of a belief about `lib.rs` and `rpc.rs`. A model
+//! that is not re-checked against the code it describes decays into documentation
+//! that reads like a proof, and this one has already drifted once: the agent grew a
+//! sixth `quarantine()` call site (the FR-9 occurrence-registry divergence in
+//! `rpc.rs`) while the model still enumerated five causes, and nothing said so.
+//!
+//! These tests are deliberately *lints*, not proofs. They cannot tell whether the
+//! model is faithful — only whether the two artefacts still agree on the facts that
+//! are cheap to check mechanically:
+//!
+//!  1. every production `quarantine()` call site maps to a member of `Causes`, and
+//!     every member of `Causes` is claimed by a call site;
+//!  2. every property the module defines is actually listed in `SRM.cfg`, since a
+//!     property TLC is never told to check is silently not checked.
+//!
+//! Both failure modes are invisible in a green TLC run, which is exactly why they
+//! need a test rather than a review.
+//!
+//! Note on formatting: this crate is edition 2018, where a lone string literal is
+//! *not* treated as a format string, so every message below passes its values as
+//! explicit `format!` arguments. An implicit capture (`{cause:?}`) would print the
+//! placeholder verbatim and lose the very name the failure exists to report — the
+//! same defect FR-15's F-201 records against `fault_injection.rs`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Repository-relative paths, resolved from this crate's manifest directory.
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_path(rel);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e))
+}
+
+/// Drop everything from the unit-test module onwards.
+///
+/// Test code quarantines the monitor freely to set up fixtures, and those call
+/// sites are not part of the protocol the model describes.
+///
+/// The marker is `#[cfg(test)]` on the test *module*, not merely the first
+/// `#[cfg(test)]`: `rpc.rs` carries several test-only items (helpers, mock shims)
+/// long before its test module, and truncating at the first of those hides most of
+/// the production file — which it did, silently reporting 2 call sites instead of 6
+/// on the first run of this lint. Intervening attributes are skipped, because
+/// `rpc.rs` writes `#[cfg(test)] #[allow(dead_code)] mod tests` — requiring
+/// `mod tests` to follow immediately missed the module entirely and swept two test
+/// call sites into the production count.
+fn production_only(src: &str) -> &str {
+    let mut from = 0;
+    while let Some(rel) = src[from..].find("#[cfg(test)]") {
+        let at = from + rel;
+        from = at + "#[cfg(test)]".len();
+
+        let mut rest = src[from..].trim_start();
+        while rest.starts_with("#[") {
+            match rest.find(']') {
+                Some(end) => rest = rest[end + 1..].trim_start(),
+                None => break,
+            }
+        }
+        if rest.starts_with("mod tests") {
+            return &src[..at];
+        }
+    }
+    src
+}
+
+/// Locate call sites of the *method* `quarantine(`, excluding `abort_or_quarantine(`
+/// and `commit_or_quarantine(` (which contain it as a substring), the `fn
+/// quarantine(` definition itself, and mentions inside comments.
+///
+/// Returns `(line number, trimmed line)` so a failure can name what it found: a
+/// bare count tells a developer that the lint fired but not which call site is new.
+fn quarantine_call_sites(src: &str) -> Vec<(usize, String)> {
+    let mut sites = Vec::new();
+    for (idx, line) in src.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("//") || trimmed.starts_with("*") {
+            continue;
+        }
+        let bytes = line.as_bytes();
+        let mut from = 0;
+        while let Some(rel) = line[from..].find("quarantine(") {
+            let at = from + rel;
+            from = at + "quarantine(".len();
+
+            // Part of a longer identifier (`abort_or_quarantine`).
+            if at > 0 && {
+                let p = bytes[at - 1];
+                p == b'_' || p.is_ascii_alphanumeric()
+            } {
+                continue;
+            }
+            // The definition, not a call.
+            if line[..at].contains("fn ") {
+                continue;
+            }
+            // A mention in prose, e.g. `quarantine()` in a doc comment.
+            if line[from..].starts_with(')') {
+                continue;
+            }
+            sites.push((idx + 1, trimmed.to_string()));
+            break;
+        }
+    }
+    sites
+}
+
+/// The `Causes` set as the model declares it, minus the `"none"` sentinel.
+fn model_causes(tla: &str) -> Vec<String> {
+    let start = tla
+        .find("Causes ==")
+        .expect("SRM.tla no longer defines `Causes`");
+    let open = tla[start..].find('{').expect("`Causes` has no set literal") + start;
+    let close = tla[open..].find('}').expect("`Causes` set is unterminated") + open;
+    tla[open + 1..close]
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty() && s != "none")
+        .collect()
+}
+
+/// Each cause in the model, paired with a distinctive fragment of the reason
+/// literal at the call site that produces it.
+///
+/// This table is the part a human must maintain, and it is the point: adding a
+/// `quarantine()` call site without deciding which modelled cause it is now fails
+/// the build instead of silently widening the implementation past the model.
+const CAUSE_CALL_SITES: &[(&str, &str, &str)] = &[
+    (
+        "abandoned-after-execute",
+        "src/lib.rs",
+        "was abandoned after execution",
+    ),
+    (
+        "occurrence-diverged",
+        "../src/rpc.rs",
+        "occurrence registry diverged",
+    ),
+    (
+        "no-snapshot",
+        "../src/rpc.rs",
+        "no policy snapshot available after",
+    ),
+    (
+        "rollback-failed",
+        "../src/rpc.rs",
+        "policy state rollback failed after",
+    ),
+    (
+        "abort-failed",
+        "../src/rpc.rs",
+        "failed with unprovable state",
+    ),
+    (
+        "commit-failed",
+        "../src/rpc.rs",
+        "commit failed after a successful",
+    ),
+];
+
+#[test]
+fn quarantine_causes_match_the_formal_model() {
+    let tla = read("formal/SRM.tla");
+    let declared = model_causes(&tla);
+
+    for cause in &declared {
+        let site = CAUSE_CALL_SITES.iter().find(|(c, _, _)| c == cause);
+        let (_, file, marker) = site.unwrap_or_else(|| {
+            panic!(
+                "SRM.tla declares the quarantine cause {:?}, but tests/model_drift.rs \
+                 does not say which call site produces it. Add it to CAUSE_CALL_SITES.",
+                cause
+            )
+        });
+        let src = read(file);
+        assert!(
+            production_only(&src).contains(marker),
+            "SRM.tla declares the quarantine cause {:?}, which should come from {} \
+             containing {:?} — but it does not. Either the reason string changed, or \
+             the cause no longer exists and must be removed from the model.",
+            cause,
+            file,
+            marker
+        );
+    }
+
+    for (cause, _, _) in CAUSE_CALL_SITES {
+        assert!(
+            declared.iter().any(|d| d == cause),
+            "tests/model_drift.rs claims a call site for the quarantine cause {:?}, \
+             but SRM.tla's `Causes` does not declare it.",
+            cause
+        );
+    }
+}
+
+#[test]
+fn every_quarantine_call_site_is_modelled() {
+    let mut found: Vec<String> = Vec::new();
+    for file in ["src/lib.rs", "../src/rpc.rs"] {
+        let src = read(file);
+        for (line, text) in quarantine_call_sites(production_only(&src)) {
+            found.push(format!("  {}:{}  {}", file, line, text));
+        }
+    }
+
+    assert_eq!(
+        found.len(),
+        CAUSE_CALL_SITES.len(),
+        "the agent has {} production quarantine() call sites but the model accounts for \
+         {}. A new call site is a new way for the monitor to fail closed; it needs a \
+         cause in SRM.tla's `Causes`, an action that raises it, and a row in \
+         CAUSE_CALL_SITES. (This is exactly the drift that left the model claiming five \
+         causes while the agent had six.)\nfound:\n{}",
+        found.len(),
+        CAUSE_CALL_SITES.len(),
+        found.join("\n")
+    );
+}
+
+/// Operators defined in `SRM.tla` that are not properties and so are legitimately
+/// absent from `SRM.cfg`.
+const NOT_CHECKED_PROPERTIES: &[&str] = &["Committed"];
+
+/// Top-level operator definitions at or after the `(* Invariants *)` divider, plus
+/// `TypeOK`, which is defined earlier with the state declarations.
+fn defined_properties(tla: &str) -> Vec<String> {
+    let start = tla
+        .find("(* Invariants *)")
+        .expect("SRM.tla no longer has an `(* Invariants *)` divider; this lint keys off it");
+
+    let mut names = vec!["TypeOK".to_string()];
+    for line in tla[start..].lines() {
+        // A top-level definition starts in column 0 as `Name ==`.
+        if line.starts_with(char::is_whitespace) {
+            continue;
+        }
+        let Some((name, _)) = line.split_once("==") else {
+            continue;
+        };
+        let name = name.trim();
+        if name.is_empty() || name.contains(' ') || !name.starts_with(char::is_alphabetic) {
+            continue;
+        }
+        names.push(name.to_string());
+    }
+    names.retain(|n| !NOT_CHECKED_PROPERTIES.contains(&n.as_str()));
+    names
+}
+
+#[test]
+fn every_defined_property_is_checked_by_the_config() {
+    let tla = read("formal/SRM.tla");
+    let cfg = read("formal/SRM.cfg");
+
+    // Only the INVARIANTS / PROPERTIES sections count. A name that appears solely
+    // in a comment is not something TLC checks.
+    let listed: Vec<&str> = cfg
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.starts_with("\\*"))
+        .collect();
+
+    for name in defined_properties(&tla) {
+        assert!(
+            listed.iter().any(|l| *l == name),
+            "SRM.tla defines {:?} but SRM.cfg does not list it, so TLC never checks it. \
+             A property that is defined and not listed is indistinguishable from one that \
+             holds. Add it to INVARIANTS or PROPERTIES, or add it to NOT_CHECKED_PROPERTIES \
+             with a reason.",
+            name
+        );
+    }
+}

--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -7,6 +7,10 @@ required_tests:
   - GHA security analysis / zizmor
   - Lint GHA workflows / run-actionlint
   - EditorConfig checker / editorconfig-checker
+  # FR-15: the SRM formal model (TLC + mutation + model/code drift). Always
+  # required rather than path-scoped -- see the comment in
+  # .github/workflows/formal-check.yaml for why the workflow cannot be filtered.
+  - Formal model check (SRM) / TLC + mutation + drift
 
 required_regexps:
   # Always required regexps


### PR DESCRIPTION
Makes the SRM formal model a CI gate instead of something run by hand, and fixes the drift that had already accumulated while nobody was running it.

The model claimed **five** quarantine causes. The agent has **six** — the occurrence-registry divergence check in `rpc.rs`. TLC was green the whole time, because a cause the model does not enumerate is not a counterexample; it is simply outside the state space. That is the failure mode a model has and code does not: it keeps certifying a system it no longer describes, and reads like a proof while doing it.

FR-15 does not claim a model *exists*. It claims the model is checked, that the properties it checks are falsifiable, and that it still describes the code. Three obligations, three tools — and run by hand they can each be green while the argument they jointly support has a hole in it.

### Changes

- **`formal/SRM.tla`** — add the sixth cause `"occurrence-diverged"` and an `OccurrenceDiverged` action.
- **`tests/model_drift.rs`** (new) — an ordinary `cargo test` that cross-checks model against code: every `Causes` member maps to a production `quarantine()` call site and back, the call-site *count* matches, and every property defined in `SRM.tla` is listed in `SRM.cfg`. A seventh call site now fails the build.
- **`formal/run-tlc.sh`** — pin `tla2tools.jar` by **sha256**, not just by version tag; run with `-coverage 1` and fail on any action that never fires.
- **`formal/mutation-test.py`** — four new mutants. `VersionCountsAllCommits`, `QuarantineHasCause`, `InFlightIsAuthorized` and `TypeOK` previously had none, so nothing established they were falsifiable. Also asserts the property↔mutant mapping in both directions, so adding a property without a mutant is a failure rather than a silent gap.
- **`formal/check-all.sh`** (new) — binds the three obligations into one exit code. `--model` / `--drift` split the JRE half from the Rust half.
- **`.github/workflows/formal-check.yaml`** (new) — runs it on PRs, path-filtered to the whole SRM crate: the drift lint reads `lib.rs` and `rpc.rs`, so a change to either can invalidate the model without touching a `.tla` file. Closes `docs/cc/backlog.md` CI-3.
- **`tests/fault_injection.rs`** — this workspace is edition 2018, where `assert!` with a lone string is not a format string, so the 200-seed fuzz printed `seed {seed}` verbatim and lost the value that reproduces the failure.

### Notes for review

- `AbandonPrepared` fires but generates no *distinct* state — it is transition-equivalent to `Abort` restricted to `"prepared"`. Kept deliberately (it mirrors a real code path in `reclaim_orphans`) and reported as a **warning**, not an error, so its presence is not mistaken for coverage of that path. Opinions welcome on keeping vs. removing it.
- Coverage lines are `DISTINCT:GENERATED`, not the reverse. Reading them backwards makes every terminal action look dead; the first version of the gate did exactly that.
- The README's cause count is still prose. The lint asserts the call-site count, which is the load-bearing half.

### Testing

All from a clean checkout of the branch tip, with `tla2tools.jar` deleted so the fetch and hash check run too:

- `./check-all.sh` → exit 0. TLC: 41861 generated / 3908 distinct / depth 18, no error. Mutation: 12/12 caught by their target property, 0 coverage failures. Drift lint: 3/3.
- Negative controls: removing the sixth cause makes the drift lint fail naming it; `check-all.sh` then exits 1 with the failing obligation named.
- `cargo test -p kata-security-reference-monitor` → 154 unit + 4 fault-injection + 3 drift.
- actionlint, shellcheck (`--severity=style`) and zizmor (auditor persona) clean on the new workflow and scripts.
- The pinned sha256 verified against a freshly downloaded upstream release.

Pre-existing and untouched: `cargo clippy` reports 45 edition-2018 format-capture errors elsewhere in this crate (40 in `fragments.rs`). Worth a separate PR.
