### PR TITLE
agent/mediation: assert every LifecycleGated RPC opens a transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3959,6 +3959,7 @@ dependencies = [
  "slog-term",
  "strum 0.24.1",
  "strum_macros 0.26.4",
+ "syn 2.0.117",
  "tempfile",
  "test-utils",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,11 @@ slog-stdlog = "4.0.0"
 slog-term = "2.9.0"
 strum = { version = "0.24.0", features = ["derive"] }
 strum_macros = "0.26.2"
+# Test-only: the agent's mediation lint parses rpc.rs to check that every
+# lifecycle-gated RPC opens an SRM transaction. Already in the tree as a
+# proc-macro build dependency; "full" and "visit" are needed to walk function
+# bodies rather than just signatures.
+syn = { version = "2.0", features = ["full", "visit"] }
 tdx = "0.1.1"
 tempfile = "3.19.1"
 thiserror = "1.0.26"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -98,6 +98,7 @@ pv_core = { git = "https://github.com/ibm-s390-linux/s390-tools", rev = "4942504
 tempfile.workspace = true
 which.workspace = true
 rstest.workspace = true
+syn.workspace = true
 
 test-utils.workspace = true
 

--- a/src/agent/security-reference-monitor/src/lib.rs
+++ b/src/agent/security-reference-monitor/src/lib.rs
@@ -194,10 +194,10 @@ impl std::error::Error for SrmError {}
 /// A reservation can only come from `prepare`:
 ///
 /// ```
-/// use kata_security_reference_monitor::ReferenceMonitor;
+/// use kata_security_reference_monitor::{ReferenceMonitor, Reserved};
 ///
 /// let mut m = ReferenceMonitor::new();
-/// let reserved = m.prepare("op1", 0, "d").unwrap().expect_new();
+/// let reserved: Reserved = m.prepare("op1", 0, "d").unwrap().expect_new();
 /// m.execute(&reserved, "d").unwrap();
 /// ```
 ///
@@ -207,13 +207,22 @@ impl std::error::Error for SrmError {}
 /// use kata_security_reference_monitor::{ReferenceMonitor, Reserved};
 ///
 /// let mut m = ReferenceMonitor::new();
-/// m.execute(&Reserved { op_id: "op1".into() }, "d").unwrap();
+/// let reserved: Reserved = m.prepare("op1", 0, "d").unwrap().expect_new();
+/// m.execute(&reserved, "d").unwrap();
+///
+/// // The reservation is spent. Copying its contents into a fresh one to execute
+/// // again is rejected: the field that would have to be copied is private.
+/// let replay = Reserved { ..reserved };
+/// m.execute(&replay, "d").unwrap();
 /// ```
 ///
 /// A `compile_fail` test passes for *any* compilation error, including one caused by
-/// renaming what it references — so it is paired with the example above deliberately.
-/// Both name `ReferenceMonitor` and `execute`; a change that made the negative case fail
-/// for an uninteresting reason would break the positive one and be noticed.
+/// renaming what it references, so it is written to be hard to satisfy accidentally.
+/// It names no private detail — the update syntax asks for the fields without spelling
+/// them, so renaming one cannot turn this into a pass — and everything it does name is
+/// named by the honest example above, which stops compiling if any of it moves. The
+/// error code cannot be pinned instead: rustdoc accepts `compile_fail,E0616` but does
+/// not check the code on stable, so the annotation would assert nothing.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Reserved {
     op_id: OperationId,

--- a/src/agent/security-reference-monitor/src/lib.rs
+++ b/src/agent/security-reference-monitor/src/lib.rs
@@ -58,7 +58,9 @@ pub use did_x509::{DidX509Anchor, DidX509Policy};
 pub use fragments::{FragmentError, FragmentStore, PolicyFragment};
 pub use handle_binding::{CheckedHandle, HandleError};
 pub use network_phase::{NetOp, NetPhaseError, NetworkPhase, NetworkPhaseMachine};
-pub use occurrence::{validate_container_id, Lifecycle, Occurrence, OccurrenceError, OccurrenceRegistry};
+pub use occurrence::{
+    validate_container_id, Lifecycle, Occurrence, OccurrenceError, OccurrenceRegistry,
+};
 pub use resource_graph::{
     verify_ordered_bijection, PresentedResource, ResourceDeclaration, ResourceGraphError,
     ResourceKind, VerifiedResourceHandle,
@@ -177,14 +179,84 @@ impl fmt::Display for SrmError {
 
 impl std::error::Error for SrmError {}
 
+/// Proof that this monitor reserved a transaction for a particular operation id.
+///
+/// The field is private, so the only way to hold one is to have received it from a
+/// successful [`ReferenceMonitor::prepare`]. [`ReferenceMonitor::execute`] takes this
+/// instead of a bare op id, which removes "execute an operation nobody prepared" from
+/// the set of programs that compile, rather than catching it at runtime.
+///
+/// That distinction matters more here than it would elsewhere. The monitor's runtime
+/// answer to a broken invariant is to quarantine, and a quarantined sandbox is a denied
+/// sandbox — so a caller mistake that the type system rejects costs a build, while the
+/// same mistake caught dynamically costs availability.
+///
+/// A reservation can only come from `prepare`:
+///
+/// ```
+/// use kata_security_reference_monitor::ReferenceMonitor;
+///
+/// let mut m = ReferenceMonitor::new();
+/// let reserved = m.prepare("op1", 0, "d").unwrap().expect_new();
+/// m.execute(&reserved, "d").unwrap();
+/// ```
+///
+/// Forging one does not compile, because the field is private:
+///
+/// ```compile_fail
+/// use kata_security_reference_monitor::{ReferenceMonitor, Reserved};
+///
+/// let mut m = ReferenceMonitor::new();
+/// m.execute(&Reserved { op_id: "op1".into() }, "d").unwrap();
+/// ```
+///
+/// A `compile_fail` test passes for *any* compilation error, including one caused by
+/// renaming what it references — so it is paired with the example above deliberately.
+/// Both name `ReferenceMonitor` and `execute`; a change that made the negative case fail
+/// for an uninteresting reason would break the positive one and be noticed.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Reserved {
+    op_id: OperationId,
+}
+
+impl Reserved {
+    /// The operation id this reservation belongs to.
+    pub fn op_id(&self) -> &str {
+        &self.op_id
+    }
+}
+
 /// Result of a `prepare` call.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Prepared {
     /// A fresh transaction was reserved.
-    New,
+    New(Reserved),
     /// The operation was already committed; the retained result is returned
     /// (idempotent replay — the caller must NOT execute again).
+    ///
+    /// No [`Reserved`] accompanies this variant, so "must not execute again" is now a
+    /// property of the type rather than a request in a doc comment: there is nothing to
+    /// hand to `execute`.
     AlreadyCommitted(String),
+}
+
+impl Prepared {
+    /// The reservation from a fresh `prepare`, panicking on an idempotent replay.
+    ///
+    /// For callers that have already established the operation is not a replay — chiefly
+    /// tests. Production paths should match on the variant so the replay is handled.
+    #[track_caller]
+    pub fn expect_new(self) -> Reserved {
+        match self {
+            Prepared::New(reserved) => reserved,
+            Prepared::AlreadyCommitted(result) => {
+                panic!(
+                    "expected a fresh reservation, but the operation was already committed: {}",
+                    result
+                )
+            }
+        }
+    }
 }
 
 /// The universal two-phase transaction manager.
@@ -405,6 +477,9 @@ impl ReferenceMonitor {
             });
         }
 
+        let reserved = Reserved {
+            op_id: op_id.clone(),
+        };
         self.txns.insert(
             op_id.clone(),
             Transaction {
@@ -417,7 +492,7 @@ impl ReferenceMonitor {
                 teardown,
             },
         );
-        Ok(Prepared::New)
+        Ok(Prepared::New(reserved))
     }
 
     /// FR-3: record the digest of the object actually resolved for execution, binding it
@@ -483,7 +558,15 @@ impl ReferenceMonitor {
 
     /// Phase 2a: bind the plan actually being executed. The presented plan digest MUST
     /// equal the authorized one, enforcing authorized == executed.
-    pub fn execute(&mut self, op_id: &str, presented_plan_digest: &str) -> Result<(), SrmError> {
+    ///
+    /// Takes the [`Reserved`] returned by `prepare` rather than an op id, so the
+    /// reservation is a precondition the compiler checks.
+    pub fn execute(
+        &mut self,
+        reserved: &Reserved,
+        presented_plan_digest: &str,
+    ) -> Result<(), SrmError> {
+        let op_id = reserved.op_id.as_str();
         self.reclaim_orphans();
         // RM-8: resolve the transaction before the quarantine gate so a teardown prepared
         // by `prepare_teardown` can still complete. An unknown op id is not a teardown, so
@@ -616,8 +699,8 @@ mod tests {
     fn happy_path_commits_and_advances_version() {
         let mut m = ReferenceMonitor::new();
         assert_eq!(m.state_version(), 0);
-        assert_eq!(m.prepare("op1", 0, "digestA").unwrap(), Prepared::New);
-        m.execute("op1", "digestA").unwrap();
+        let r_op1 = m.prepare("op1", 0, "digestA").unwrap().expect_new();
+        m.execute(&r_op1, "digestA").unwrap();
         m.commit("op1", "container-created").unwrap();
         assert_eq!(m.state_version(), 1);
         assert_eq!(m.transaction("op1").unwrap().state, TxnState::Committed);
@@ -627,8 +710,8 @@ mod tests {
     fn execute_rejects_plan_mismatch() {
         // authorized == executed: a plan different from the authorized one is refused.
         let mut m = ReferenceMonitor::new();
-        m.prepare("op1", 0, "digestA").unwrap();
-        let err = m.execute("op1", "digestB").unwrap_err();
+        let r_op1 = m.prepare("op1", 0, "digestA").unwrap().expect_new();
+        let err = m.execute(&r_op1, "digestB").unwrap_err();
         assert_eq!(
             err,
             SrmError::PlanMismatch {
@@ -641,8 +724,8 @@ mod tests {
     #[test]
     fn idempotent_replay_returns_result_without_reexecuting() {
         let mut m = ReferenceMonitor::new();
-        m.prepare("op1", 0, "d").unwrap();
-        m.execute("op1", "d").unwrap();
+        let r_op1 = m.prepare("op1", 0, "d").unwrap().expect_new();
+        m.execute(&r_op1, "d").unwrap();
         m.commit("op1", "result-1").unwrap();
         let v = m.state_version();
         // Re-preparing the same committed op returns the retained result, no new effect.
@@ -656,8 +739,8 @@ mod tests {
     #[test]
     fn stale_state_version_is_rejected() {
         let mut m = ReferenceMonitor::new();
-        m.prepare("op1", 0, "d").unwrap();
-        m.execute("op1", "d").unwrap();
+        let r_op1 = m.prepare("op1", 0, "d").unwrap().expect_new();
+        m.execute(&r_op1, "d").unwrap();
         m.commit("op1", "r").unwrap(); // version -> 1
         let err = m.prepare("op2", 0, "d").unwrap_err();
         assert_eq!(
@@ -672,8 +755,8 @@ mod tests {
     #[test]
     fn abort_rolls_back_without_advancing_version() {
         let mut m = ReferenceMonitor::new();
-        m.prepare("op1", 0, "d").unwrap();
-        m.execute("op1", "d").unwrap();
+        let r_op1 = m.prepare("op1", 0, "d").unwrap().expect_new();
+        m.execute(&r_op1, "d").unwrap();
         m.abort("op1").unwrap();
         assert_eq!(m.state_version(), 0, "aborted op must not advance state");
         assert!(
@@ -681,7 +764,7 @@ mod tests {
             "aborted transaction must be dropped, not retained"
         );
         // The id is free again, exactly as if it had never been prepared.
-        assert!(matches!(m.prepare("op1", 0, "d"), Ok(Prepared::New)));
+        assert!(matches!(m.prepare("op1", 0, "d"), Ok(Prepared::New(_))));
     }
 
     #[test]
@@ -728,11 +811,11 @@ mod tests {
         ));
 
         // ... but a teardown runs the full prepare → execute → commit path.
-        assert_eq!(
-            m.prepare_teardown("remove/ctr1", 0, "d").unwrap(),
-            Prepared::New
-        );
-        m.execute("remove/ctr1", "d").unwrap();
+        let r_remove_ctr1 = m
+            .prepare_teardown("remove/ctr1", 0, "d")
+            .unwrap()
+            .expect_new();
+        m.execute(&r_remove_ctr1, "d").unwrap();
         m.commit("remove/ctr1", "container-removed").unwrap();
         assert_eq!(
             m.state_version(),
@@ -755,8 +838,11 @@ mod tests {
         let mut m = ReferenceMonitor::new();
 
         let guard = m.guard("remove/4:ctr1");
-        m.prepare_teardown("remove/4:ctr1", 0, "d1").unwrap();
-        m.execute("remove/4:ctr1", "d1").unwrap();
+        let r_remove_4_ctr1 = m
+            .prepare_teardown("remove/4:ctr1", 0, "d1")
+            .unwrap()
+            .expect_new();
+        m.execute(&r_remove_4_ctr1, "d1").unwrap();
         drop(guard); // host abandoned the call mid-flight
 
         m.reclaim_orphans();
@@ -770,13 +856,15 @@ mod tests {
             "the abandoned teardown is parked, not released"
         );
 
-        assert_eq!(
-            m.prepare_teardown("remove/4:ctr1", m.state_version(), "d1")
-                .unwrap(),
-            Prepared::New,
+        let retry = m
+            .prepare_teardown("remove/4:ctr1", m.state_version(), "d1")
+            .unwrap();
+        assert!(
+            matches!(retry, Prepared::New(_)),
             "the retry must supersede the stranded teardown"
         );
-        m.execute("remove/4:ctr1", "d1").unwrap();
+        let r_remove_4_ctr1 = retry.expect_new();
+        m.execute(&r_remove_4_ctr1, "d1").unwrap();
         m.commit("remove/4:ctr1", "container-removed").unwrap();
     }
 
@@ -811,29 +899,39 @@ mod tests {
     #[test]
     fn teardown_exemption_does_not_leak_to_other_transactions() {
         let mut m = ReferenceMonitor::new();
-        m.prepare("create/ctr1", 0, "d1").unwrap();
-        m.prepare_teardown("remove/ctr1", 0, "d2").unwrap();
+        let r_create_ctr1 = m.prepare("create/ctr1", 0, "d1").unwrap().expect_new();
+        let r_remove_ctr1 = m
+            .prepare_teardown("remove/ctr1", 0, "d2")
+            .unwrap()
+            .expect_new();
         m.quarantine("unprovable state");
 
         assert!(
             matches!(
-                m.execute("create/ctr1", "d1"),
+                m.execute(&r_create_ctr1, "d1"),
                 Err(SrmError::Quarantined(_))
             ),
             "a build-up transaction prepared before the quarantine must not execute after it"
         );
-        m.execute("remove/ctr1", "d2")
+        m.execute(&r_remove_ctr1, "d2")
             .expect("teardown must still execute");
     }
 
-    /// An unknown op id must report the quarantine, not a lookup miss: the caller is not
-    /// holding a teardown transaction, so the gate applies.
+    /// An op id the monitor no longer knows must report the quarantine, not a lookup miss:
+    /// the caller is not holding a teardown transaction, so the gate applies.
+    ///
+    /// `execute` now takes the reservation, so "never prepared at all" is no longer a
+    /// program that compiles. The reachable form of the same state is a reservation whose
+    /// transaction has since been released — a use-after-abort — which is the case worth
+    /// pinning in any event.
     #[test]
-    fn execute_of_an_unknown_op_reports_the_quarantine() {
+    fn execute_of_a_released_op_reports_the_quarantine() {
         let mut m = ReferenceMonitor::new();
+        let stale = m.prepare("op1", 0, "d").unwrap().expect_new();
+        m.abort("op1").unwrap();
         m.quarantine("unprovable state");
         assert!(matches!(
-            m.execute("never-prepared", "d"),
+            m.execute(&stale, "d"),
             Err(SrmError::Quarantined(_))
         ));
     }
@@ -852,10 +950,13 @@ mod tests {
             "teardown must still reject a stale expected state version"
         );
 
-        m.prepare_teardown("remove/ctr1", 0, "authorized").unwrap();
+        let r_remove_ctr1 = m
+            .prepare_teardown("remove/ctr1", 0, "authorized")
+            .unwrap()
+            .expect_new();
         assert!(
             matches!(
-                m.execute("remove/ctr1", "tampered"),
+                m.execute(&r_remove_ctr1, "tampered"),
                 Err(SrmError::PlanMismatch { .. })
             ),
             "teardown must still bind the executed plan to the authorized one"
@@ -909,7 +1010,7 @@ mod tests {
         // acted on a state machine that no longer described it. `formal/SRM.tla` requires
         // `state[o] \in {"none", "aborted"}` to prepare; this is that requirement.
         let mut m = ReferenceMonitor::new();
-        m.prepare("op1", 0, "d1").unwrap();
+        let r_op1 = m.prepare("op1", 0, "d1").unwrap().expect_new();
 
         // Prepared: the duplicate is refused, and the original is untouched.
         assert!(matches!(
@@ -922,7 +1023,7 @@ mod tests {
         assert_eq!(m.transaction("op1").unwrap().plan_digest, "d1");
 
         // Executed: still in flight, still refused.
-        m.execute("op1", "d1").unwrap();
+        m.execute(&r_op1, "d1").unwrap();
         assert!(matches!(
             m.prepare("op1", m.state_version(), "d2"),
             Err(SrmError::InvalidState {
@@ -943,10 +1044,10 @@ mod tests {
         m.prepare("op1", 0, "d1").unwrap();
         m.abort("op1").unwrap();
 
-        assert_eq!(
+        assert!(matches!(
             m.prepare("op1", m.state_version(), "d2").unwrap(),
-            Prepared::New
-        );
+            Prepared::New(_)
+        ));
         assert_eq!(m.transaction("op1").unwrap().plan_digest, "d2");
     }
 
@@ -987,13 +1088,13 @@ mod tests {
 
         let winners: Vec<_> = results
             .iter()
-            .filter(|(_, r)| matches!(r, Ok(Prepared::New)))
+            .filter(|(_, r)| matches!(r, Ok(Prepared::New(_))))
             .collect();
         assert_eq!(winners.len(), 1, "exactly one prepare may reserve the id");
 
         let losers: Vec<_> = results
             .iter()
-            .filter(|(_, r)| !matches!(r, Ok(Prepared::New)))
+            .filter(|(_, r)| !matches!(r, Ok(Prepared::New(_))))
             .collect();
         assert_eq!(losers.len(), 1);
         assert!(
@@ -1033,17 +1134,19 @@ mod tests {
         let mut m = ReferenceMonitor::new();
         let op = "signal:ctr1::15";
 
-        m.prepare(op, 0, "d1").unwrap();
-        m.execute(op, "d1").unwrap();
+        let r_op = m.prepare(op, 0, "d1").unwrap().expect_new();
+        m.execute(&r_op, "d1").unwrap();
         m.commit(op, "signal-delivered").unwrap();
         m.retire(op).unwrap();
 
         // Not deduplicated: the monitor has no memory of the first delivery, so an
         // after-the-fact retry is admitted as a new operation and the signal is sent
         // twice. This is the accepted behaviour, not a defect.
-        assert_eq!(
-            m.prepare(op, m.state_version(), "d1").unwrap(),
-            Prepared::New,
+        assert!(
+            matches!(
+                m.prepare(op, m.state_version(), "d1").unwrap(),
+                Prepared::New(_)
+            ),
             "a post-commit repeat is admitted; replay protection is in-flight only"
         );
     }
@@ -1054,8 +1157,8 @@ mod tests {
         // retiring the create transaction, the next create for the same id is answered
         // from the replay cache and the container is never created.
         let mut m = ReferenceMonitor::new();
-        m.prepare("ctr1", 0, "d1").unwrap();
-        m.execute("ctr1", "d1").unwrap();
+        let r_ctr1 = m.prepare("ctr1", 0, "d1").unwrap().expect_new();
+        m.execute(&r_ctr1, "d1").unwrap();
         m.commit("ctr1", "container-created").unwrap();
 
         // Before retiring, a fresh create for the same id is swallowed as a replay.
@@ -1068,10 +1171,10 @@ mod tests {
         assert!(m.transaction("ctr1").is_none());
 
         // After retiring it is a genuinely new transaction again.
-        assert_eq!(
+        assert!(matches!(
             m.prepare("ctr1", m.state_version(), "d2").unwrap(),
-            Prepared::New
-        );
+            Prepared::New(_)
+        ));
     }
 
     #[test]
@@ -1082,12 +1185,12 @@ mod tests {
             Err(SrmError::UnknownOperation(_))
         ));
 
-        m.prepare("op1", 0, "d").unwrap();
+        let r_op1 = m.prepare("op1", 0, "d").unwrap().expect_new();
         assert!(matches!(
             m.retire("op1"),
             Err(SrmError::InvalidState { .. })
         ));
-        m.execute("op1", "d").unwrap();
+        m.execute(&r_op1, "d").unwrap();
         assert!(matches!(
             m.retire("op1"),
             Err(SrmError::InvalidState { .. })
@@ -1132,13 +1235,16 @@ mod tests {
     #[test]
     fn attach_executed_refuses_a_teardown_too_while_quarantined() {
         let mut m = ReferenceMonitor::new();
-        m.prepare_teardown("op1", 0, "authorized").unwrap();
+        let r_op1 = m
+            .prepare_teardown("op1", 0, "authorized")
+            .unwrap()
+            .expect_new();
         m.quarantine("unprovable");
         assert!(matches!(
             m.attach_executed("op1", "executed"),
             Err(SrmError::Quarantined(_))
         ));
-        m.execute("op1", "authorized")
+        m.execute(&r_op1, "authorized")
             .expect("RM-8: teardown must still execute while quarantined");
     }
 
@@ -1147,8 +1253,8 @@ mod tests {
     #[test]
     fn attach_executed_is_refused_once_committed() {
         let mut m = ReferenceMonitor::new();
-        m.prepare("op1", 0, "d").unwrap();
-        m.execute("op1", "d").unwrap();
+        let r_op1 = m.prepare("op1", 0, "d").unwrap().expect_new();
+        m.execute(&r_op1, "d").unwrap();
         m.attach_executed("op1", "executed").unwrap();
         m.commit("op1", "ok").unwrap();
         assert!(matches!(
@@ -1186,11 +1292,17 @@ mod tests {
         );
     }
 
+    /// Executing a reservation whose transaction was released reports the lookup miss.
+    /// Since `execute` no longer accepts a bare op id, this is the only way to reach the
+    /// error — and it is the case that matters: a stale reservation must not resurrect an
+    /// operation that was aborted.
     #[test]
-    fn unknown_operation_errors() {
+    fn executing_a_released_reservation_errors() {
         let mut m = ReferenceMonitor::new();
+        let stale = m.prepare("nope", 0, "d").unwrap().expect_new();
+        m.abort("nope").unwrap();
         assert_eq!(
-            m.execute("nope", "d").unwrap_err(),
+            m.execute(&stale, "d").unwrap_err(),
             SrmError::UnknownOperation("nope".into())
         );
     }
@@ -1208,10 +1320,10 @@ mod tests {
         drop(guard);
 
         // The retry succeeds and the monitor is still usable: nothing had happened yet.
-        assert_eq!(
+        assert!(matches!(
             m.prepare("remove/4:ctr1", m.state_version(), "d1").unwrap(),
-            Prepared::New
-        );
+            Prepared::New(_)
+        ));
         assert!(!m.is_quarantined());
     }
 
@@ -1222,8 +1334,8 @@ mod tests {
     fn an_abandoned_executed_transaction_quarantines() {
         let mut m = ReferenceMonitor::new();
         let guard = m.guard("remove/4:ctr1");
-        m.prepare("remove/4:ctr1", 0, "d1").unwrap();
-        m.execute("remove/4:ctr1", "d1").unwrap();
+        let r_remove_4_ctr1 = m.prepare("remove/4:ctr1", 0, "d1").unwrap().expect_new();
+        m.execute(&r_remove_4_ctr1, "d1").unwrap();
 
         drop(guard);
 
@@ -1240,8 +1352,8 @@ mod tests {
     fn a_disarmed_guard_does_not_report_abandonment() {
         let mut m = ReferenceMonitor::new();
         let guard = m.guard("op1");
-        m.prepare("op1", 0, "d1").unwrap();
-        m.execute("op1", "d1").unwrap();
+        let r_op1 = m.prepare("op1", 0, "d1").unwrap().expect_new();
+        m.execute(&r_op1, "d1").unwrap();
         m.commit("op1", "done").unwrap();
         guard.disarm();
 
@@ -1258,15 +1370,18 @@ mod tests {
     fn execute_also_reclaims_abandoned_transactions() {
         let mut m = ReferenceMonitor::new();
         let live = m.guard("op-live");
-        m.prepare("op-live", 0, "d1").unwrap();
+        let r_op_live = m.prepare("op-live", 0, "d1").unwrap().expect_new();
 
         let abandoned = m.guard("op-gone");
-        m.prepare("op-gone", m.state_version(), "d2").unwrap();
-        m.execute("op-gone", "d2").unwrap();
+        let r_op_gone = m
+            .prepare("op-gone", m.state_version(), "d2")
+            .unwrap()
+            .expect_new();
+        m.execute(&r_op_gone, "d2").unwrap();
         drop(abandoned);
 
         assert!(matches!(
-            m.execute("op-live", "d1"),
+            m.execute(&r_op_live, "d1"),
             Err(SrmError::Quarantined(_))
         ));
         live.disarm();

--- a/src/agent/security-reference-monitor/src/lib.rs
+++ b/src/agent/security-reference-monitor/src/lib.rs
@@ -219,13 +219,6 @@ pub struct Reserved {
     op_id: OperationId,
 }
 
-impl Reserved {
-    /// The operation id this reservation belongs to.
-    pub fn op_id(&self) -> &str {
-        &self.op_id
-    }
-}
-
 /// Result of a `prepare` call.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Prepared {

--- a/src/agent/security-reference-monitor/tests/fault_injection.rs
+++ b/src/agent/security-reference-monitor/tests/fault_injection.rs
@@ -18,7 +18,7 @@
 //!    number of committed operations, every committed operation passed through Executed
 //!    (authorized == executed), and quarantine is sticky and blocks new authorizations.
 
-use kata_security_reference_monitor::{ReferenceMonitor, SrmError, TxnState};
+use kata_security_reference_monitor::{Prepared, ReferenceMonitor, Reserved, SrmError, TxnState};
 
 /// The phase at which a simulated operation's fault is injected.
 #[derive(Debug, Clone, Copy)]
@@ -47,17 +47,17 @@ fn run_with_fault(fp: FaultPoint) {
             assert!(m.transaction(op).is_none(), "no txn on failed prepare");
         }
         FaultPoint::Execute => {
-            m.prepare(op, version_before, digest).unwrap();
+            let reserved = m.prepare(op, version_before, digest).unwrap().expect_new();
             // The plan presented at execution differs from the authorized one.
-            let err = m.execute(op, "tampered-digest").unwrap_err();
+            let err = m.execute(&reserved, "tampered-digest").unwrap_err();
             assert!(matches!(err, SrmError::PlanMismatch { .. }));
             // Reconcile: abort the reserved transaction.
             m.abort(op).unwrap();
             assert!(m.transaction(op).is_none(), "aborted txn must be dropped");
         }
         FaultPoint::RuntimeBeforeCommit => {
-            m.prepare(op, version_before, digest).unwrap();
-            m.execute(op, digest).unwrap();
+            let reserved = m.prepare(op, version_before, digest).unwrap().expect_new();
+            m.execute(&reserved, digest).unwrap();
             // The runtime operation fails; the caller aborts instead of committing.
             m.abort(op).unwrap();
             assert!(m.transaction(op).is_none(), "aborted txn must be dropped");
@@ -91,8 +91,8 @@ fn abort_failure_escalates_to_quarantine() {
     // Model the agent's reconciliation: if a committed op is (incorrectly) asked to abort,
     // abort refuses; the agent then quarantines rather than leaving an unprovable state.
     let mut m = ReferenceMonitor::new();
-    m.prepare("op", 0, "d").unwrap();
-    m.execute("op", "d").unwrap();
+    let reserved = m.prepare("op", 0, "d").unwrap().expect_new();
+    m.execute(&reserved, "d").unwrap();
     m.commit("op", "done").unwrap();
 
     // A late/erroneous abort of a committed op must fail (no undo-to-phantom).
@@ -115,8 +115,8 @@ fn abort_failure_escalates_to_quarantine() {
 fn committed_and_aborted_are_terminal_and_exclusive() {
     // Committed cannot be aborted.
     let mut m = ReferenceMonitor::new();
-    m.prepare("c", 0, "d").unwrap();
-    m.execute("c", "d").unwrap();
+    let reserved = m.prepare("c", 0, "d").unwrap().expect_new();
+    m.execute(&reserved, "d").unwrap();
     m.commit("c", "r").unwrap();
     assert!(m.abort("c").is_err());
 
@@ -153,6 +153,12 @@ fn randomized_sequences_preserve_invariants() {
         // Shadow count of committed operations.
         let mut committed: u64 = 0;
         let ids = ["a", "b", "c", "d"];
+        // Reservations are kept after the transaction they name is committed, aborted or
+        // retired. `execute` now demands one, so this map is what preserves the adversary
+        // the loop is for: replaying a stale reservation is the strongest remaining way to
+        // reach `execute` in a state that never authorized it.
+        let mut reservations: std::collections::HashMap<&str, Reserved> =
+            std::collections::HashMap::new();
 
         for _ in 0..300 {
             let id = ids[rng.below(ids.len() as u64) as usize];
@@ -161,18 +167,24 @@ fn randomized_sequences_preserve_invariants() {
             match action {
                 0 => {
                     // prepare with the current (fresh) version
-                    let _ = m.prepare(id, ver, "digest");
+                    if let Ok(Prepared::New(reserved)) = m.prepare(id, ver, "digest") {
+                        reservations.insert(id, reserved);
+                    }
                 }
                 1 => {
                     // execute with the correct digest
-                    let _ = m.execute(id, "digest");
+                    if let Some(reserved) = reservations.get(id) {
+                        let _ = m.execute(reserved, "digest");
+                    }
                 }
                 2 => {
                     // execute with a wrong digest (must never succeed)
-                    assert!(
-                        m.execute(id, "WRONG").is_err() || m.transaction(id).is_none(),
-                        "execute with mismatched digest must never succeed"
-                    );
+                    if let Some(reserved) = reservations.get(id) {
+                        assert!(
+                            m.execute(reserved, "WRONG").is_err() || m.transaction(id).is_none(),
+                            "execute with mismatched digest must never succeed"
+                        );
+                    }
                 }
                 3 => {
                     // commit; if it succeeds the op must have been Executed first

--- a/src/agent/src/mediation.rs
+++ b/src/agent/src/mediation.rs
@@ -315,6 +315,11 @@ mod tests {
 
     const AGENT_PROTO: &str = include_str!("../../libs/protocols/protos/agent.proto");
 
+    /// The RPC handlers as the compiler sees them. Only the handler *bodies* are read as
+    /// text; the manifest itself is used as data, so a mis-parse cannot silently exempt an
+    /// entry.
+    const RPC_SOURCE: &str = include_str!("rpc.rs");
+
     /// Extract `(method, request type)` for every `rpc <Name>(<Request>)` declared by the
     /// agent proto service.
     fn proto_rpcs() -> Vec<(String, String)> {
@@ -413,6 +418,111 @@ mod tests {
             }
             assert!(enforcement_class(rpc).is_some());
         }
+    }
+
+    /// The body of the handler `async fn <name>(` as written in `rpc.rs`.
+    ///
+    /// Delimited by the *next* method of the same `impl` block rather than by matching
+    /// braces: handler bodies are full of `format!` strings containing `{}`, so a brace
+    /// counter would have to understand Rust string, char and comment syntax before it
+    /// could be trusted. Every handler sits at one indentation level inside its `impl`,
+    /// which makes the next `fn` at that level -- or the end of the block -- an exact and
+    /// far cheaper boundary.
+    ///
+    /// Searching for `fn <name>(` also excludes the inner `do_<name>` helpers for free,
+    /// since `fn do_create_container(` does not contain `fn create_container(`.
+    /// Everything in `rpc.rs` before its unit-test module.
+    ///
+    /// Without this, a test helper could stand in for a production handler that had been
+    /// deleted, and the lint would go on reporting the RPC as mediated. The marker is
+    /// matched at column zero because `#[cfg(test)]` also guards items further up the
+    /// file, so the attribute is not a reliable boundary on its own.
+    const TEST_MODULE: &str = "\nmod tests {";
+
+    fn production_only(src: &str) -> &str {
+        match src.find(TEST_MODULE) {
+            Some(at) => &src[..at],
+            None => src,
+        }
+    }
+
+    fn handler_body<'a>(src: &'a str, name: &str) -> Option<&'a str> {
+        let at = src.find(&format!("fn {}(", name))?;
+        let rest = &src[at..];
+        let end = ["\n    async fn ", "\n    fn ", "\n}"]
+            .iter()
+            .filter_map(|marker| rest.find(marker))
+            .min()
+            .unwrap_or(rest.len());
+        Some(&rest[..end])
+    }
+
+    /// FR-7/FR-9: classifying an RPC `LifecycleGated` is a claim that its handler runs
+    /// under an SRM transaction. Nothing checked that claim, and it has been false in
+    /// production -- `StartContainer` was classified correctly and still mutated sandbox
+    /// state without opening a transaction at all. Classification and mediation are
+    /// separate facts, and only the first one was being enforced.
+    ///
+    /// This is deliberately a shallow check: it proves the call is *written in* the
+    /// handler, not that it is reached on every path. What makes it worth having anyway is
+    /// that it is static over the whole handler set, so it holds for every RPC rather than
+    /// for the configurations a model or a test happens to explore.
+    #[test]
+    fn every_lifecycle_gated_handler_opens_a_transaction() {
+        let mut missing = Vec::new();
+        let mut unknown = Vec::new();
+        let mut checked = 0;
+
+        // If this marker ever stops matching, the scan silently widens back over the test
+        // module instead of failing, so it is checked rather than assumed.
+        assert!(
+            RPC_SOURCE.contains(TEST_MODULE),
+            "rpc.rs no longer contains a `{}` module declaration at column zero, so this \
+             lint would scan test code as if it were production code. Update TEST_MODULE.",
+            TEST_MODULE.trim()
+        );
+        let production = production_only(RPC_SOURCE);
+
+        for (rpc, handler, _, class) in MEDIATION_MANIFEST {
+            if !matches!(class, EnforcementClass::LifecycleGated) {
+                continue;
+            }
+            checked += 1;
+            match handler_body(production, handler) {
+                None => unknown.push(format!("{} ({})", rpc, handler)),
+                Some(body) => {
+                    if !body.contains(".prepare(") && !body.contains(".prepare_teardown(") {
+                        missing.push(format!("{} ({})", rpc, handler));
+                    }
+                }
+            }
+        }
+
+        // A lint that silently checks nothing is worse than no lint: renaming or retiring
+        // the variant would leave this test green while enforcing nothing at all.
+        assert!(
+            checked > 0,
+            "no LifecycleGated entries found in MEDIATION_MANIFEST, so this lint verified \
+             nothing. If the class was renamed, update this test to match rather than \
+             leaving it vacuously green."
+        );
+        assert!(
+            unknown.is_empty(),
+            "the mediation manifest names handler(s) that do not exist in rpc.rs: {:?}. \
+             Either a handler was renamed without updating the manifest, or this lint's \
+             notion of a handler signature has gone stale -- both make the check below \
+             weaker than it looks.",
+            unknown
+        );
+        assert!(
+            missing.is_empty(),
+            "RPC(s) classified LifecycleGated whose handler never opens an SRM \
+             transaction: {:?}. That classification claims the operation is gated by the \
+             FR-9 occurrence state machine; with no prepare()/prepare_teardown() the \
+             classification is decoration and the operation mutates lifecycle state \
+             unmediated.",
+            missing
+        );
     }
 
     /// The behavioural proof of complete mediation: with a policy that denies everything,

--- a/src/agent/src/mediation.rs
+++ b/src/agent/src/mediation.rs
@@ -462,11 +462,54 @@ mod tests {
         attrs.iter().filter_map(cfg_tokens).any(|t| t == "test")
     }
 
+    /// The comma-separated predicates inside `all(..)` / `any(..)`.
+    fn cfg_operands(list: &syn::MetaList) -> Vec<syn::Meta> {
+        list.parse_args_with(
+            syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated,
+        )
+        .map(|operands| operands.into_iter().collect())
+        .unwrap_or_default()
+    }
+
+    /// Does this predicate hold *only* in a build with `strict-policy` enabled?
+    ///
+    /// Not "does the attribute mention the feature". Both guards of a handler name it,
+    /// and the fallback names it under `not(..)`; a containment test would accept the
+    /// fallback as evidence of mediation, so swapping a handler's two guards -- moving
+    /// the transaction out of the confidential build entirely -- would leave this lint
+    /// green. `not(..)` therefore never certifies mediation, whatever it wraps.
+    fn requires_strict_policy(meta: &syn::Meta) -> bool {
+        match meta {
+            syn::Meta::NameValue(nv) => {
+                nv.path.is_ident("feature")
+                    && matches!(
+                        &nv.value,
+                        syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Str(name),
+                            ..
+                        }) if name.value() == STRICT_POLICY
+                    )
+            }
+            // `all(..)` holds only if every operand does, so one is enough.
+            syn::Meta::List(list) if list.path.is_ident("all") => {
+                cfg_operands(list).iter().any(requires_strict_policy)
+            }
+            // `any(..)` can be satisfied by whichever operand is weakest, so all of them
+            // must require the feature. An empty `any(..)` is never satisfied.
+            syn::Meta::List(list) if list.path.is_ident("any") => {
+                let operands = cfg_operands(list);
+                !operands.is_empty() && operands.iter().all(requires_strict_policy)
+            }
+            _ => false,
+        }
+    }
+
     fn is_strict_policy(attrs: &[syn::Attribute]) -> bool {
         attrs
             .iter()
-            .filter_map(cfg_tokens)
-            .any(|t| t.contains(STRICT_POLICY))
+            .filter(|attr| attr.path().is_ident("cfg"))
+            .filter_map(|attr| attr.parse_args::<syn::Meta>().ok())
+            .any(|meta| requires_strict_policy(&meta))
     }
 
     /// Every method the production build compiles, collected from the syntax tree.

--- a/src/agent/src/mediation.rs
+++ b/src/agent/src/mediation.rs
@@ -320,6 +320,14 @@ mod tests {
     /// entry.
     const RPC_SOURCE: &str = include_str!("rpc.rs");
 
+    /// Calls that open an SRM transaction.
+    const TRANSACTION_OPENERS: &[&str] = &["prepare", "prepare_teardown"];
+
+    /// The feature that compiles the mediation in. Mediation is conditional, which is why
+    /// this lint reads the source rather than relying on the type system: a compile-time
+    /// rule can only constrain the configuration actually being built.
+    const STRICT_POLICY: &str = "strict-policy";
+
     /// Extract `(method, request type)` for every `rpc <Name>(<Request>)` declared by the
     /// agent proto service.
     fn proto_rpcs() -> Vec<(String, String)> {
@@ -420,41 +428,112 @@ mod tests {
         }
     }
 
-    /// The body of the handler `async fn <name>(` as written in `rpc.rs`.
-    ///
-    /// Delimited by the *next* method of the same `impl` block rather than by matching
-    /// braces: handler bodies are full of `format!` strings containing `{}`, so a brace
-    /// counter would have to understand Rust string, char and comment syntax before it
-    /// could be trusted. Every handler sits at one indentation level inside its `impl`,
-    /// which makes the next `fn` at that level -- or the end of the block -- an exact and
-    /// far cheaper boundary.
-    ///
-    /// Searching for `fn <name>(` also excludes the inner `do_<name>` helpers for free,
-    /// since `fn do_create_container(` does not contain `fn create_container(`.
-    /// Everything in `rpc.rs` before its unit-test module.
-    ///
-    /// Without this, a test helper could stand in for a production handler that had been
-    /// deleted, and the lint would go on reporting the RPC as mediated. The marker is
-    /// matched at column zero because `#[cfg(test)]` also guards items further up the
-    /// file, so the attribute is not a reliable boundary on its own.
-    const TEST_MODULE: &str = "\nmod tests {";
-
-    fn production_only(src: &str) -> &str {
-        match src.find(TEST_MODULE) {
-            Some(at) => &src[..at],
-            None => src,
+    /// The `#[cfg(...)]` predicate of an attribute, as written.
+    fn cfg_tokens(attr: &syn::Attribute) -> Option<String> {
+        match &attr.meta {
+            syn::Meta::List(list) if list.path.is_ident("cfg") => Some(list.tokens.to_string()),
+            _ => None,
         }
     }
 
-    fn handler_body<'a>(src: &'a str, name: &str) -> Option<&'a str> {
-        let at = src.find(&format!("fn {}(", name))?;
-        let rest = &src[at..];
-        let end = ["\n    async fn ", "\n    fn ", "\n}"]
+    fn is_cfg_test(attrs: &[syn::Attribute]) -> bool {
+        attrs.iter().filter_map(cfg_tokens).any(|t| t == "test")
+    }
+
+    fn is_strict_policy(attrs: &[syn::Attribute]) -> bool {
+        attrs
             .iter()
-            .filter_map(|marker| rest.find(marker))
-            .min()
-            .unwrap_or(rest.len());
-        Some(&rest[..end])
+            .filter_map(cfg_tokens)
+            .any(|t| t.contains(STRICT_POLICY))
+    }
+
+    /// Every method the production build compiles, collected from the syntax tree.
+    ///
+    /// `#[cfg(test)]` modules are skipped structurally, so a test helper can never stand
+    /// in for a production handler that was deleted.
+    #[derive(Default)]
+    struct ProductionMethods<'ast> {
+        methods: Vec<&'ast syn::ImplItemFn>,
+    }
+
+    impl<'ast> syn::visit::Visit<'ast> for ProductionMethods<'ast> {
+        fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+            if is_cfg_test(&node.attrs) {
+                return;
+            }
+            syn::visit::visit_item_mod(self, node);
+        }
+
+        fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+            self.methods.push(node);
+            syn::visit::visit_impl_item_fn(self, node);
+        }
+    }
+
+    /// What a piece of syntax does that this lint cares about.
+    #[derive(Default)]
+    struct CallScan {
+        opens_transaction: bool,
+        self_calls: Vec<String>,
+    }
+
+    impl CallScan {
+        fn of_fn(f: &syn::ImplItemFn) -> Self {
+            let mut scan = CallScan::default();
+            syn::visit::visit_impl_item_fn(&mut scan, f);
+            scan
+        }
+
+        fn of_block(b: &syn::ExprBlock) -> Self {
+            let mut scan = CallScan::default();
+            syn::visit::visit_expr_block(&mut scan, b);
+            scan
+        }
+    }
+
+    impl<'ast> syn::visit::Visit<'ast> for CallScan {
+        fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+            let method = node.method.to_string();
+            if TRANSACTION_OPENERS.contains(&method.as_str()) {
+                self.opens_transaction = true;
+            }
+            // `self.do_create_container(..).await` parses as an await of a method call
+            // whose receiver is `self`, so the receiver test still holds here.
+            if let syn::Expr::Path(path) = &*node.receiver {
+                if path.path.is_ident("self") {
+                    self.self_calls.push(method);
+                }
+            }
+            syn::visit::visit_expr_method_call(self, node);
+        }
+    }
+
+    /// Does this block's *success* path leave the handler?
+    ///
+    /// Deliberately the tail statement rather than "contains a `return` somewhere". Each
+    /// of these blocks returns early on its error paths, so the weaker test is satisfied
+    /// by those alone -- it stays green in exactly the situation it is supposed to catch,
+    /// where the block completes normally and falls into the unmediated call below.
+    fn tail_returns(block: &syn::ExprBlock) -> bool {
+        matches!(
+            block.block.stmts.last(),
+            Some(syn::Stmt::Expr(syn::Expr::Return(_), _))
+        )
+    }
+
+    /// Blocks written as `#[cfg(feature = "strict-policy")] { .. }`.
+    #[derive(Default)]
+    struct StrictPolicyBlocks<'ast> {
+        blocks: Vec<&'ast syn::ExprBlock>,
+    }
+
+    impl<'ast> syn::visit::Visit<'ast> for StrictPolicyBlocks<'ast> {
+        fn visit_expr_block(&mut self, node: &'ast syn::ExprBlock) {
+            if is_strict_policy(&node.attrs) {
+                self.blocks.push(node);
+            }
+            syn::visit::visit_expr_block(self, node);
+        }
     }
 
     /// FR-7/FR-9: classifying an RPC `LifecycleGated` is a claim that its handler runs
@@ -463,38 +542,87 @@ mod tests {
     /// state without opening a transaction at all. Classification and mediation are
     /// separate facts, and only the first one was being enforced.
     ///
-    /// This is deliberately a shallow check: it proves the call is *written in* the
-    /// handler, not that it is reached on every path. What makes it worth having anyway is
-    /// that it is static over the whole handler set, so it holds for every RPC rather than
-    /// for the configurations a model or a test happens to explore.
+    /// The check works on the parsed syntax tree rather than on the source text. That
+    /// buys three things: handler bodies and the unit-test module are exact properties of
+    /// the tree instead of guesses about indentation and column-zero markers; a match can
+    /// no longer come from a comment or a string literal; and delegation through a
+    /// `self.do_*` helper is followed rather than reported as a violation.
+    ///
+    /// Reading the source also makes the check `cfg`-agnostic: it sees the
+    /// `strict-policy` block whichever way the crate is compiled. A type-level rule --
+    /// making the transaction a capability the mutation demands -- would be stronger where
+    /// it applied, but it would only ever constrain the configuration actually being
+    /// built, and mediation here is feature-conditional.
+    ///
+    /// What it still does not prove is reachability: the call must be *written* in the
+    /// handler, not reached on every path. That limit is inherent to a syntactic check.
     #[test]
     fn every_lifecycle_gated_handler_opens_a_transaction() {
+        let file = syn::parse_file(RPC_SOURCE).expect("rpc.rs parses as Rust");
+        let mut production = ProductionMethods::default();
+        syn::visit::Visit::visit_file(&mut production, &file);
+
+        let find = |name: &str| -> Vec<&syn::ImplItemFn> {
+            production
+                .methods
+                .iter()
+                .copied()
+                .filter(|m| m.sig.ident == name)
+                .collect()
+        };
+
         let mut missing = Vec::new();
         let mut unknown = Vec::new();
+        let mut ambiguous = Vec::new();
+        let mut falls_through = Vec::new();
         let mut checked = 0;
-
-        // If this marker ever stops matching, the scan silently widens back over the test
-        // module instead of failing, so it is checked rather than assumed.
-        assert!(
-            RPC_SOURCE.contains(TEST_MODULE),
-            "rpc.rs no longer contains a `{}` module declaration at column zero, so this \
-             lint would scan test code as if it were production code. Update TEST_MODULE.",
-            TEST_MODULE.trim()
-        );
-        let production = production_only(RPC_SOURCE);
 
         for (rpc, handler, _, class) in MEDIATION_MANIFEST {
             if !matches!(class, EnforcementClass::LifecycleGated) {
                 continue;
             }
             checked += 1;
-            match handler_body(production, handler) {
-                None => unknown.push(format!("{} ({})", rpc, handler)),
-                Some(body) => {
-                    if !body.contains(".prepare(") && !body.contains(".prepare_teardown(") {
-                        missing.push(format!("{} ({})", rpc, handler));
-                    }
+            let where_ = format!("{} ({})", rpc, handler);
+
+            let candidates = find(handler);
+            let body = match candidates.len() {
+                0 => {
+                    unknown.push(where_);
+                    continue;
                 }
+                1 => candidates[0],
+                n => {
+                    ambiguous.push(format!("{} x{}", where_, n));
+                    continue;
+                }
+            };
+
+            let scan = CallScan::of_fn(body);
+            // One hop only. It covers the `do_*` delegation this file actually uses, and
+            // stopping there keeps the check from wandering the whole call graph, where a
+            // `prepare` on some unrelated path would start counting as mediation.
+            let delegated = || {
+                scan.self_calls.iter().any(|callee| {
+                    find(callee)
+                        .into_iter()
+                        .any(|f| CallScan::of_fn(f).opens_transaction)
+                })
+            };
+            if !scan.opens_transaction && !delegated() {
+                missing.push(where_.clone());
+            }
+
+            // Mediation is compiled in only under `strict-policy`; the same handler calls
+            // the same mutation unguarded below the block. That is by design, and it is
+            // safe only while the guarded block diverges -- otherwise both run.
+            let mut blocks = StrictPolicyBlocks::default();
+            syn::visit::Visit::visit_impl_item_fn(&mut blocks, body);
+            let guarded_and_diverging = blocks
+                .blocks
+                .iter()
+                .any(|b| CallScan::of_block(b).opens_transaction && tail_returns(b));
+            if !guarded_and_diverging {
+                falls_through.push(where_);
             }
         }
 
@@ -515,6 +643,13 @@ mod tests {
             unknown
         );
         assert!(
+            ambiguous.is_empty(),
+            "more than one method in rpc.rs answers to these handler name(s): {:?}. The \
+             lint cannot tell which one mediates the RPC, so it would be checking an \
+             arbitrary one of them.",
+            ambiguous
+        );
+        assert!(
             missing.is_empty(),
             "RPC(s) classified LifecycleGated whose handler never opens an SRM \
              transaction: {:?}. That classification claims the operation is gated by the \
@@ -522,6 +657,15 @@ mod tests {
              classification is decoration and the operation mutates lifecycle state \
              unmediated.",
             missing
+        );
+        assert!(
+            falls_through.is_empty(),
+            "RPC(s) whose `strict-policy` transaction block does not return: {:?}. Each \
+             of these handlers calls its mutation again, unmediated, below that block -- \
+             the arrangement is only sound because the mediated path returns first. If it \
+             falls through, the confidential build performs the operation twice, the \
+             second time outside the transaction it just committed.",
+            falls_through
         );
     }
 

--- a/src/agent/src/mediation.rs
+++ b/src/agent/src/mediation.rs
@@ -496,16 +496,9 @@ mod tests {
     #[derive(Default)]
     struct CallScan {
         opens_transaction: bool,
-        self_calls: Vec<String>,
     }
 
     impl CallScan {
-        fn of_fn(f: &syn::ImplItemFn) -> Self {
-            let mut scan = CallScan::default();
-            syn::visit::visit_impl_item_fn(&mut scan, f);
-            scan
-        }
-
         fn of_block(b: &syn::ExprBlock) -> Self {
             let mut scan = CallScan::default();
             syn::visit::visit_expr_block(&mut scan, b);
@@ -515,16 +508,8 @@ mod tests {
 
     impl<'ast> syn::visit::Visit<'ast> for CallScan {
         fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
-            let method = node.method.to_string();
-            if TRANSACTION_OPENERS.contains(&method.as_str()) {
+            if TRANSACTION_OPENERS.contains(&node.method.to_string().as_str()) {
                 self.opens_transaction = true;
-            }
-            // `self.do_create_container(..).await` parses as an await of a method call
-            // whose receiver is `self`, so the receiver test still holds here.
-            if let syn::Expr::Path(path) = &*node.receiver {
-                if path.path.is_ident("self") {
-                    self.self_calls.push(method);
-                }
             }
             syn::visit::visit_expr_method_call(self, node);
         }
@@ -534,8 +519,7 @@ mod tests {
     ///
     /// Deliberately the tail statement rather than "contains a `return` somewhere". Each
     /// of these blocks returns early on its error paths, so the weaker test is satisfied
-    /// by those alone -- it stays green in exactly the situation it is supposed to catch,
-    /// where the block completes normally and falls into the unmediated call below.
+    /// by those alone -- it stays green in exactly the situation it is supposed to catch.
     fn tail_returns(block: &syn::ExprBlock) -> bool {
         matches!(
             block.block.stmts.last(),
@@ -565,19 +549,20 @@ mod tests {
     /// separate facts, and only the first one was being enforced.
     ///
     /// The check works on the parsed syntax tree rather than on the source text. That
-    /// buys three things: handler bodies and the unit-test module are exact properties of
-    /// the tree instead of guesses about indentation and column-zero markers; a match can
-    /// no longer come from a comment or a string literal; and delegation through a
-    /// `self.do_*` helper is followed rather than reported as a violation.
+    /// buys two things: handler bodies and the unit-test module are exact properties of
+    /// the tree instead of guesses about indentation and column-zero markers, and a match
+    /// can no longer come from a comment or a string literal.
     ///
-    /// Reading the source also makes the check `cfg`-agnostic: it sees the
-    /// `strict-policy` block whichever way the crate is compiled. A type-level rule --
-    /// making the transaction a capability the mutation demands -- would be stronger where
-    /// it applied, but it would only ever constrain the configuration actually being
-    /// built, and mediation here is feature-conditional.
+    /// It reads source rather than relying on types because mediation is
+    /// feature-conditional: a compile-time rule can only constrain the configuration
+    /// actually being built. Where a type *can* apply it is used instead — `execute`
+    /// takes the `Reserved` value `prepare` returns, so ordering within a transaction is
+    /// the compiler's business and not asserted about here. What is left for this lint is
+    /// the part no type reaches: whether the handler enters the state machine at all.
     ///
     /// What it still does not prove is reachability: the call must be *written* in the
-    /// handler, not reached on every path. That limit is inherent to a syntactic check.
+    /// handler's guarded block, not reached on every path. That limit is inherent to a
+    /// syntactic check.
     #[test]
     fn every_lifecycle_gated_handler_opens_a_transaction() {
         let file = syn::parse_file(RPC_SOURCE).expect("rpc.rs parses as Rust");
@@ -593,10 +578,9 @@ mod tests {
                 .collect()
         };
 
-        let mut missing = Vec::new();
+        let mut unmediated = Vec::new();
         let mut unknown = Vec::new();
         let mut ambiguous = Vec::new();
-        let mut falls_through = Vec::new();
         let mut gated = Vec::new();
 
         for (rpc, handler, _, class) in MEDIATION_MANIFEST {
@@ -619,32 +603,33 @@ mod tests {
                 }
             };
 
-            let scan = CallScan::of_fn(body);
-            // One hop only. It covers the `do_*` delegation this file actually uses, and
-            // stopping there keeps the check from wandering the whole call graph, where a
-            // `prepare` on some unrelated path would start counting as mediation.
-            let delegated = || {
-                scan.self_calls.iter().any(|callee| {
-                    find(callee)
-                        .into_iter()
-                        .any(|f| CallScan::of_fn(f).opens_transaction)
-                })
-            };
-            if !scan.opens_transaction && !delegated() {
-                missing.push(where_.clone());
-            }
-
-            // Mediation is compiled in only under `strict-policy`; the same handler calls
-            // the same mutation unguarded below the block. That is by design, and it is
-            // safe only while the guarded block diverges -- otherwise both run.
+            // Both halves are load-bearing, and neither is sufficient alone.
+            //
+            // The transaction must be opened inside a block guarded by `strict-policy`,
+            // since that is the only configuration where mediation is compiled at all; an
+            // opener elsewhere in the handler would not describe the build the row claims.
+            //
+            // The guarded block must also leave the handler rather than falling into what
+            // follows it. Today the unmediated call below is `cfg(not(strict-policy))` and
+            // so cannot coexist with the guarded one -- but that exclusivity is a
+            // convention of how these handlers are written, not something the compiler
+            // enforces. Drop the `cfg` from the fallback and a strict build runs the
+            // mutation twice, the second time outside the transaction it just committed.
+            // Nothing else would notice; this does.
+            //
+            // The cost is that a guarded block which is itself the handler's tail may
+            // legitimately yield its value instead of returning, and is asked to return
+            // anyway. That is a real false positive, accepted because the alternative --
+            // proving no unguarded path reaches the mutation -- is a reachability
+            // question a syntactic check cannot answer.
             let mut blocks = StrictPolicyBlocks::default();
             syn::visit::Visit::visit_impl_item_fn(&mut blocks, body);
-            let guarded_and_diverging = blocks
+            let mediates = blocks
                 .blocks
                 .iter()
                 .any(|b| CallScan::of_block(b).opens_transaction && tail_returns(b));
-            if !guarded_and_diverging {
-                falls_through.push(where_);
+            if !mediates {
+                unmediated.push(where_);
             }
         }
 
@@ -687,22 +672,18 @@ mod tests {
             ambiguous
         );
         assert!(
-            missing.is_empty(),
-            "RPC(s) classified LifecycleGated whose handler never opens an SRM \
+            unmediated.is_empty(),
+            "RPC(s) classified LifecycleGated whose handler is not mediated by an SRM \
              transaction: {:?}. That classification claims the operation is gated by the \
-             FR-9 occurrence state machine; with no prepare()/prepare_teardown() the \
-             classification is decoration and the operation mutates lifecycle state \
-             unmediated.",
-            missing
-        );
-        assert!(
-            falls_through.is_empty(),
-            "RPC(s) whose `strict-policy` transaction block does not return: {:?}. Each \
-             of these handlers calls its mutation again, unmediated, below that block -- \
-             the arrangement is only sound because the mediated path returns first. If it \
-             falls through, the confidential build performs the operation twice, the \
-             second time outside the transaction it just committed.",
-            falls_through
+             FR-9 occurrence state machine. It fails either way it can: no \
+             prepare()/prepare_teardown() inside the handler's `strict-policy` block, in \
+             which case the classification is decoration and the operation mutates \
+             lifecycle state unmediated; or a block that opens one and does not return, \
+             which is safe only while the unmediated call below it stays behind \
+             `cfg(not(strict-policy))` -- if that guard is ever dropped, a strict build \
+             performs the operation twice, the second time outside the transaction it \
+             just committed.",
+            unmediated
         );
     }
 

--- a/src/agent/src/mediation.rs
+++ b/src/agent/src/mediation.rs
@@ -122,12 +122,31 @@ impl EnforcementClass {
 /// often than it is edited, and rustfmt would expand each row to a five-line tuple.
 #[rustfmt::skip]
 pub const MEDIATION_MANIFEST: &[(&str, &str, &str, EnforcementClass)] = &[
-    // Container lifecycle (policy + occurrence state machine).
+    // Container lifecycle. The occurrence state machine that gates these is compiled in
+    // only under `strict-policy`; every other build runs the same mutation with no
+    // transaction around it and is left with the policy check alone. Declared per
+    // configuration for the same reason `CopyFile` is below: the row describes the binary
+    // that is running, not the one we would like to be running.
+    #[cfg(feature = "strict-policy")]
     ("CreateContainer", "create_container", "CreateContainerRequest", EnforcementClass::LifecycleGated),
+    #[cfg(not(feature = "strict-policy"))]
+    ("CreateContainer", "create_container", "CreateContainerRequest", EnforcementClass::PolicyGated),
+    #[cfg(feature = "strict-policy")]
     ("StartContainer", "start_container", "StartContainerRequest", EnforcementClass::LifecycleGated),
+    #[cfg(not(feature = "strict-policy"))]
+    ("StartContainer", "start_container", "StartContainerRequest", EnforcementClass::PolicyGated),
+    #[cfg(feature = "strict-policy")]
     ("RemoveContainer", "remove_container", "RemoveContainerRequest", EnforcementClass::LifecycleGated),
+    #[cfg(not(feature = "strict-policy"))]
+    ("RemoveContainer", "remove_container", "RemoveContainerRequest", EnforcementClass::PolicyGated),
+    #[cfg(feature = "strict-policy")]
     ("ExecProcess", "exec_process", "ExecProcessRequest", EnforcementClass::LifecycleGated),
+    #[cfg(not(feature = "strict-policy"))]
+    ("ExecProcess", "exec_process", "ExecProcessRequest", EnforcementClass::PolicyGated),
+    #[cfg(feature = "strict-policy")]
     ("SignalProcess", "signal_process", "SignalProcessRequest", EnforcementClass::LifecycleGated),
+    #[cfg(not(feature = "strict-policy"))]
+    ("SignalProcess", "signal_process", "SignalProcessRequest", EnforcementClass::PolicyGated),
     // State-mutating operations (policy gated).
     ("WaitProcess", "wait_process", "WaitProcessRequest", EnforcementClass::PolicyGated),
     ("UpdateContainer", "update_container", "UpdateContainerRequest", EnforcementClass::PolicyGated),
@@ -327,6 +346,9 @@ mod tests {
     /// this lint reads the source rather than relying on the type system: a compile-time
     /// rule can only constrain the configuration actually being built.
     const STRICT_POLICY: &str = "strict-policy";
+
+    /// Whether this build compiles the occurrence state machine in at all.
+    const LIFECYCLE_GATING_COMPILED_IN: bool = cfg!(feature = "strict-policy");
 
     /// Extract `(method, request type)` for every `rpc <Name>(<Request>)` declared by the
     /// agent proto service.
@@ -575,14 +597,14 @@ mod tests {
         let mut unknown = Vec::new();
         let mut ambiguous = Vec::new();
         let mut falls_through = Vec::new();
-        let mut checked = 0;
+        let mut gated = Vec::new();
 
         for (rpc, handler, _, class) in MEDIATION_MANIFEST {
             if !matches!(class, EnforcementClass::LifecycleGated) {
                 continue;
             }
-            checked += 1;
             let where_ = format!("{} ({})", rpc, handler);
+            gated.push(where_.clone());
 
             let candidates = find(handler);
             let body = match candidates.len() {
@@ -626,14 +648,29 @@ mod tests {
             }
         }
 
-        // A lint that silently checks nothing is worse than no lint: renaming or retiring
-        // the variant would leave this test green while enforcing nothing at all.
-        assert!(
-            checked > 0,
-            "no LifecycleGated entries found in MEDIATION_MANIFEST, so this lint verified \
-             nothing. If the class was renamed, update this test to match rather than \
-             leaving it vacuously green."
-        );
+        // The expected count is a property of the configuration, not a constant. Requiring
+        // only "more than zero" would have accepted the very inaccuracy this pairing fixes:
+        // an unconditional LifecycleGated row claims a transaction that a default build
+        // never opens, and the lint would have confirmed the claim by reading strict-only
+        // source. Each configuration is now asked the question that is true of it.
+        if LIFECYCLE_GATING_COMPILED_IN {
+            assert!(
+                !gated.is_empty(),
+                "no LifecycleGated entries found in MEDIATION_MANIFEST, so this lint \
+                 verified nothing. If the class was renamed, update this test to match \
+                 rather than leaving it vacuously green."
+            );
+        } else {
+            assert!(
+                gated.is_empty(),
+                "this build does not compile the occurrence state machine in, yet the \
+                 manifest still classifies {:?} as LifecycleGated. Such a row claims a \
+                 transaction the handler never opens here: the mediation is behind \
+                 `strict-policy`, and below it the same mutation runs unguarded. Declare \
+                 the row per configuration, as CopyFile and SetPolicy are.",
+                gated
+            );
+        }
         assert!(
             unknown.is_empty(),
             "the mediation manifest names handler(s) that do not exist in rpc.rs: {:?}. \

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1214,7 +1214,7 @@ impl agent_ttrpc::AgentService for AgentService {
                 let version = srm.state_version();
                 let prepared = srm.prepare(op_id.clone(), version, digest.clone());
                 let guard = srm.guard(&op_id);
-                match prepared {
+                let reserved = match prepared {
                     // Idempotent replay of an already-committed create: no new effect.
                     Ok(Prepared::AlreadyCommitted(_)) => {
                         drop(srm);
@@ -1225,7 +1225,7 @@ impl agent_ttrpc::AgentService for AgentService {
                         rollback_policy_state(&policy_snapshot, "duplicate create_container").await;
                         return Ok(Empty::new());
                     }
-                    Ok(Prepared::New) => {}
+                    Ok(Prepared::New(reserved)) => reserved,
                     Err(e) => {
                         drop(srm);
                         guard.disarm();
@@ -1236,10 +1236,10 @@ impl agent_ttrpc::AgentService for AgentService {
                         rollback_policy_state(&policy_snapshot, "create_container prepare").await;
                         return Err(ttrpc_error(srm_code(&e), e));
                     }
-                }
+                };
                 // From here on every exit must resolve the transaction; the guard covers
                 // the paths that never run, i.e. this future being dropped mid-flight.
-                if let Err(e) = srm.execute(&op_id, &digest) {
+                if let Err(e) = srm.execute(&reserved, &digest) {
                     abort_or_quarantine(&mut srm, &op_id, "create_container execute");
                     drop(srm);
                     guard.disarm();
@@ -1337,8 +1337,8 @@ impl agent_ttrpc::AgentService for AgentService {
                 let prepared = srm.prepare(op_id.clone(), version, digest.clone());
                 let guard = srm.guard(&op_id);
                 drop(srm);
-                match prepared {
-                    Ok(Prepared::New) => {}
+                let reserved = match prepared {
+                    Ok(Prepared::New(reserved)) => reserved,
                     // A double start is already refused by the occurrence registry above,
                     // so a committed transaction here means the operation id was reused
                     // rather than that this is a legitimate replay. Refuse instead of
@@ -1359,9 +1359,9 @@ impl agent_ttrpc::AgentService for AgentService {
                         rollback_policy_state(&policy_snapshot, "start_container prepare").await;
                         return Err(ttrpc_error(srm_code(&e), e));
                     }
-                }
+                };
                 let mut srm = crate::SRM.lock().await;
-                if let Err(e) = srm.execute(&op_id, &digest) {
+                if let Err(e) = srm.execute(&reserved, &digest) {
                     abort_or_quarantine(&mut srm, &op_id, "start_container execute");
                     drop(srm);
                     guard.disarm();
@@ -1471,8 +1471,8 @@ impl agent_ttrpc::AgentService for AgentService {
                 // host cancels the call, which wedges the operation id forever.
                 let guard = srm.guard(&op_id);
                 drop(srm);
-                match prepared {
-                    Ok(Prepared::New) => {}
+                let reserved = match prepared {
+                    Ok(Prepared::New(reserved)) => reserved,
                     // Removal is already single-shot at the policy layer: a second remove
                     // of the same container is undefined and denied before reaching here.
                     // A committed transaction therefore means the operation id was reused,
@@ -1494,9 +1494,9 @@ impl agent_ttrpc::AgentService for AgentService {
                         rollback_policy_state(&policy_snapshot, "remove_container prepare").await;
                         return Err(ttrpc_error(srm_code(&e), e));
                     }
-                }
+                };
                 let mut srm = crate::SRM.lock().await;
-                if let Err(e) = srm.execute(&op_id, &digest) {
+                if let Err(e) = srm.execute(&reserved, &digest) {
                     abort_or_quarantine(&mut srm, &op_id, "remove_container execute");
                     drop(srm);
                     guard.disarm();
@@ -1638,24 +1638,24 @@ impl agent_ttrpc::AgentService for AgentService {
                 let version = srm.state_version();
                 let prepared = srm.prepare(op_id.clone(), version, digest.clone());
                 let guard = srm.guard(&op_id);
-                match prepared {
+                let reserved = match prepared {
                     Ok(Prepared::AlreadyCommitted(_)) => {
                         drop(srm);
                         guard.disarm();
                         rollback_policy_state(&policy_snapshot, "duplicate exec_process").await;
                         return Ok(Empty::new());
                     }
-                    Ok(Prepared::New) => {}
+                    Ok(Prepared::New(reserved)) => reserved,
                     Err(e) => {
                         drop(srm);
                         guard.disarm();
                         rollback_policy_state(&policy_snapshot, "exec_process prepare").await;
                         return Err(ttrpc_error(srm_code(&e), e));
                     }
-                }
+                };
                 // From here on every exit must resolve the transaction; the guard covers
                 // the paths that never run, i.e. this future being dropped mid-flight.
-                if let Err(e) = srm.execute(&op_id, &digest) {
+                if let Err(e) = srm.execute(&reserved, &digest) {
                     abort_or_quarantine(&mut srm, &op_id, "exec_process execute");
                     drop(srm);
                     guard.disarm();
@@ -1772,15 +1772,15 @@ impl agent_ttrpc::AgentService for AgentService {
                 } else {
                     srm.prepare(op_id.clone(), version, digest.clone())
                 };
-                match prepared {
+                let reserved = match prepared {
                     Ok(Prepared::AlreadyCommitted(_)) => return Ok(Empty::new()),
-                    Ok(Prepared::New) => {}
+                    Ok(Prepared::New(reserved)) => reserved,
                     Err(e) => return Err(ttrpc_error(srm_code(&e), e)),
-                }
+                };
                 // From here on every exit must resolve the transaction; the guard covers
                 // the paths that never run, i.e. this future being dropped mid-flight.
                 let guard = srm.guard(&op_id);
-                if let Err(e) = srm.execute(&op_id, &digest) {
+                if let Err(e) = srm.execute(&reserved, &digest) {
                     abort_or_quarantine(&mut srm, &op_id, "signal_process execute");
                     drop(srm);
                     guard.disarm();
@@ -6951,16 +6951,18 @@ COMMIT
             // `AlreadyCommitted` without running anything.
             let mut m = ReferenceMonitor::new();
             let create = srm_op_id("create", &["a:b"]);
-            m.prepare(create.clone(), 0, "d1").unwrap();
-            m.execute(&create, "d1").unwrap();
+            let r_create = m.prepare(create.clone(), 0, "d1").unwrap().expect_new();
+            m.execute(&r_create, "d1").unwrap();
             m.commit(&create, "container-created").unwrap();
 
             // The exec that a separator-joined encoding would have aliased onto it.
             let exec = srm_op_id("exec", &["a", "b"]);
             assert_ne!(exec, create);
-            assert_eq!(
-                m.prepare(exec, m.state_version(), "d2").unwrap(),
-                Prepared::New,
+            assert!(
+                matches!(
+                    m.prepare(exec, m.state_version(), "d2").unwrap(),
+                    Prepared::New(_)
+                ),
                 "a distinct operation must not be answered from another's result"
             );
         }
@@ -6985,8 +6987,8 @@ COMMIT
             );
 
             let mut m = ReferenceMonitor::new();
-            m.prepare(op.clone(), 0, "authorized").unwrap();
-            m.execute(&op, "authorized").unwrap();
+            let r_op = m.prepare(op.clone(), 0, "authorized").unwrap().expect_new();
+            m.execute(&r_op, "authorized").unwrap();
 
             assert!(
                 m.attach_executed(cid, "executed".to_string()).is_err(),
@@ -7005,8 +7007,8 @@ COMMIT
         fn commit_or_quarantine_records_success_and_leaves_the_monitor_usable() {
             let mut m = ReferenceMonitor::new();
             let op = srm_op_id("create", &["ctr1"]);
-            m.prepare(op.clone(), 0, "d").unwrap();
-            m.execute(&op, "d").unwrap();
+            let r_op = m.prepare(op.clone(), 0, "d").unwrap().expect_new();
+            m.execute(&r_op, "d").unwrap();
 
             commit_or_quarantine(&mut m, &op, "container-created", "create_container");
 
@@ -7042,14 +7044,16 @@ COMMIT
         fn abort_or_quarantine_releases_the_id_for_a_later_attempt() {
             let mut m = ReferenceMonitor::new();
             let op = srm_op_id("remove", &["ctr1"]);
-            m.prepare(op.clone(), 0, "d").unwrap();
-            m.execute(&op, "d").unwrap();
+            let r_op = m.prepare(op.clone(), 0, "d").unwrap().expect_new();
+            m.execute(&r_op, "d").unwrap();
 
             abort_or_quarantine(&mut m, &op, "remove_container");
 
-            assert_eq!(
-                m.prepare(op, m.state_version(), "d").unwrap(),
-                Prepared::New,
+            assert!(
+                matches!(
+                    m.prepare(op, m.state_version(), "d").unwrap(),
+                    Prepared::New(_)
+                ),
                 "a failed removal must stay retryable"
             );
         }
@@ -7072,8 +7076,8 @@ COMMIT
         fn retire_or_warn_frees_the_id_and_tolerates_an_unknown_one() {
             let mut m = ReferenceMonitor::new();
             let op = srm_op_id("signal", &["ctr1", "", "1"]);
-            m.prepare(op.clone(), 0, "d").unwrap();
-            m.execute(&op, "d").unwrap();
+            let r_op = m.prepare(op.clone(), 0, "d").unwrap().expect_new();
+            m.execute(&r_op, "d").unwrap();
             m.commit(&op, "signal-delivered").unwrap();
 
             retire_or_warn(&mut m, &op);
@@ -7081,10 +7085,10 @@ COMMIT
 
             // A repeated signal is a legitimate request, not a replay, and must be
             // admitted rather than answered from the retained result.
-            assert_eq!(
+            assert!(matches!(
                 m.prepare(op, m.state_version(), "d").unwrap(),
-                Prepared::New
-            );
+                Prepared::New(_)
+            ));
 
             // Retiring something unknown must not panic or quarantine: the operation it
             // followed already succeeded.
@@ -7102,12 +7106,15 @@ COMMIT
             let create = srm_op_id("create", &["ctr1"]);
             let remove = srm_op_id("remove", &["ctr1"]);
 
-            m.prepare(create.clone(), 0, "d1").unwrap();
-            m.execute(&create, "d1").unwrap();
+            let r_create = m.prepare(create.clone(), 0, "d1").unwrap().expect_new();
+            m.execute(&r_create, "d1").unwrap();
             m.commit(&create, "container-created").unwrap();
 
-            m.prepare(remove.clone(), m.state_version(), "d2").unwrap();
-            m.execute(&remove, "d2").unwrap();
+            let r_remove = m
+                .prepare(remove.clone(), m.state_version(), "d2")
+                .unwrap()
+                .expect_new();
+            m.execute(&r_remove, "d2").unwrap();
             commit_or_quarantine(&mut m, &remove, "container-removed", "remove_container");
             for id in [&create, &remove] {
                 retire_or_warn(&mut m, id);
@@ -7115,10 +7122,10 @@ COMMIT
 
             // Without retiring the create, this would be an idempotent replay and the new
             // container would never be created.
-            assert_eq!(
+            assert!(matches!(
                 m.prepare(create, m.state_version(), "d3").unwrap(),
-                Prepared::New
-            );
+                Prepared::New(_)
+            ));
         }
 
         /// RM-7: a quarantine must be distinguishable from a bad request. Everything else
@@ -7293,8 +7300,8 @@ COMMIT
         fn a_quarantined_monitor_can_still_be_torn_down() {
             let mut m = ReferenceMonitor::new();
             let create = srm_op_id("create", &["ctr1"]);
-            m.prepare(create.clone(), 0, "d1").unwrap();
-            m.execute(&create, "d1").unwrap();
+            let r_create = m.prepare(create.clone(), 0, "d1").unwrap().expect_new();
+            m.execute(&r_create, "d1").unwrap();
             m.commit(&create, "container-created").unwrap();
 
             m.quarantine("policy state rollback failed after exec_process");
@@ -7328,16 +7335,20 @@ COMMIT
                 "signal",
                 &["ctr1", "e1", &(libc::SIGKILL as u32).to_string()],
             );
-            m.prepare_teardown(kill.clone(), m.state_version(), "d2")
-                .unwrap();
-            m.execute(&kill, "d2").unwrap();
+            let r_kill = m
+                .prepare_teardown(kill.clone(), m.state_version(), "d2")
+                .unwrap()
+                .expect_new();
+            m.execute(&r_kill, "d2").unwrap();
             commit_or_quarantine(&mut m, &kill, "signal-delivered", "signal_process");
             retire_or_warn(&mut m, &kill);
 
             let remove = srm_op_id("remove", &["ctr1"]);
-            m.prepare_teardown(remove.clone(), m.state_version(), "d3")
-                .unwrap();
-            m.execute(&remove, "d3").unwrap();
+            let r_remove = m
+                .prepare_teardown(remove.clone(), m.state_version(), "d3")
+                .unwrap()
+                .expect_new();
+            m.execute(&r_remove, "d3").unwrap();
             commit_or_quarantine(&mut m, &remove, "container-removed", "remove_container");
             assert_eq!(
                 m.transaction(&remove).map(|t| t.state.clone()),
@@ -7356,8 +7367,8 @@ COMMIT
         fn a_quarantined_monitor_refuses_to_start_an_already_created_container() {
             let mut m = ReferenceMonitor::new();
             let create = srm_op_id("create", &["ctr1"]);
-            m.prepare(create.clone(), 0, "d1").unwrap();
-            m.execute(&create, "d1").unwrap();
+            let r_create = m.prepare(create.clone(), 0, "d1").unwrap().expect_new();
+            m.execute(&r_create, "d1").unwrap();
             m.commit(&create, "container-created").unwrap();
 
             // The container exists and is startable at this point.


### PR DESCRIPTION
## What

Closes the gap between what `MEDIATION_MANIFEST` claims about the container lifecycle RPCs and what the agent actually does, in three parts that fit together:

- **the manifest declares lifecycle gating only where it is compiled in**,
- **the compiler enforces the ordering there**, and
- **a lint covers the part the compiler cannot see.**

## Why

`mediation.rs` exists because an earlier proof of mediation read `rpc.rs` as text and asserted a substring appeared in each handler. It was removed for being cfg-blind: it certified `CopyFile` as policy-gated while strict builds denied it without consulting the policy at all. The manifest disagreed with the binary and the test could not tell.

The five `LifecycleGated` rows had the same defect, in the other direction. They claimed unconditionally that create/start/remove/exec/signal open an occurrence transaction. That is true only under `strict-policy`; below it the handler takes the other branch and performs the same mutation with no transaction at all. The table already declares `CopyFile`, `GetDiagnosticData`, `SetPolicy` and `LoadPolicyFragment` once per configuration for exactly this reason.

## Changes

**1. The rows are declared per configuration.** `LifecycleGated` under `strict-policy`, `PolicyGated` below it — which is what the handler does, since the policy check ahead of the branch is unconditional.

**2. The lint asks each configuration the question that is true of it.** Scoping the rows alone would have left the lint asserting nothing in a default build while still reporting success. A strict build must find lifecycle rows to check; a default build must find none, and names any row that reappears unconditionally. The previous "more than zero" form would have accepted precisely the inaccuracy being fixed.

**3. The lint reads the syntax tree rather than the file as text.** `syn` (already in the lock file as a proc-macro dependency; adding it as a dev-dependency changed one line and no crate, licence or source) gives exact handler bodies, a structural `cfg(test)` skip so a test helper cannot stand in for a production handler, and detection of ambiguity rather than a silent guess.

**4. `execute` demands the reservation instead of trusting an id.** `prepare` now returns a `Reserved` with a private field, and `execute` takes that rather than an op id string. "Execute an operation nobody prepared" is no longer a program that compiles, and `AlreadyCommitted` no longer needs to ask callers not to execute a replay — it carries nothing to execute with.

This is deliberately narrow: the monitor already rejects out-of-order phases at runtime and is tested for it, so the type moves an existing rule earlier rather than adding a new one. It is worth doing because the runtime answer to a broken invariant is to quarantine, and a quarantined sandbox is a denied one — the same mistake costs a build instead of availability.

## What is checked, and what is not

The type covers ordering within a transaction. It cannot cover whether a handler enters the state machine at all, and it can only constrain the configuration being built — which is why the lint stays, and why the lint reads source rather than relying on types.

Neither reachability nor "this transaction belongs to this request" is checked by either. Both remain runtime properties.

## Evidence

Every assertion here was run against a deliberately broken tree first, because an assertion that can pass vacuously is worse than none — one of these did, and was fixed:

| Injected defect | Result |
| --- | --- |
| `prepare()` removed from `start_container` | names `StartContainer` |
| an RPC that opens no transaction classified `LifecycleGated` | names `PauseContainer` |
| manifest points at a handler that does not exist | unknown-handler assertion |
| every `LifecycleGated` row reclassified | vacuity guard |
| guarded block completes instead of returning | names `CreateContainer` |
| decoy handler in the `cfg(test)` module | invisible; removing the skip → ambiguity failure |
| a row made unconditionally `LifecycleGated` | default build names it; strict build unaffected |
| a handler's two `cfg` guards swapped | names `CreateContainer`; the earlier predicate passed it |
| `Reserved`'s field made public | the `compile_fail` doctest fails, as it must |
| `Reserved` renamed in code but not in the docs | the positive doctest fails, so the negative one cannot pass vacuously |

The fall-through check originally asked whether the strict block *contained* a `return`. Every one of these blocks returns on its error paths, so it was satisfied by those alone and passed the control designed to fail it. It now examines the tail statement.

Re-running the controls against the finished lint also corrected two of its own claims. The delegation-tolerant bucket could never fire alone — the stricter guarded-block check rejected the same handler first — so it was removed; the `PauseContainer` control above shows the coverage is unchanged. And the tail-return check does not prevent a double execution, because the guarded block and the fallback are `cfg`-exclusive: what it defends is that exclusivity, which is a convention of how these handlers are written rather than anything the compiler enforces. Its comment now says so, and says which false positive is accepted in exchange.

The `compile_fail` doctest is paired with a positive one on purpose: `compile_fail` passes for *any* compilation error, including one caused by renaming what it references, so both are written to share the names they depend on and the forgery is expressed as a struct update that asks for the private field without naming it. Pinning the diagnostic instead would assert nothing — rustdoc parses `compile_fail,E0616` but does not check the code on stable, and a deliberately wrong `E0308` still passes.

Two of the controls above were found by review rather than written up front. The `cfg` predicate originally asked whether an attribute *mentioned* `strict-policy`; both guards of a mediated handler do, one of them under `not(..)`, so the fallback block could certify mediation and swapping a handler's two guards left the lint green. It now parses the predicate and asks whether it can hold only when the feature is on.

Two tests could no longer be written and were rewritten rather than deleted, which improved them — both now exercise use-after-abort, which was not covered before. The fault-injection loop keeps its adversary by retaining reservations after their transactions end.

Validated in both configurations: 382 default, 480 strict, 154 + 4 + 3 + 2 in the monitor crate, `rustfmt --check` clean, no new clippy findings.

## Note

`test_copy_single_file_accepts_empty_unspecified_file` fails when run in isolation under `strict-policy` — it relies on another test having activated a policy first. Pre-existing and unrelated to this change; it passes in a full run. Flagging rather than fixing it here.
