### PR TITLE
SR: Phase 3: Handle restore-from annotation and consuming of snapshot artifact

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -34,6 +34,8 @@ pub mod thirdparty;
 // Common section
 /// Prefix for Kata specific annotations
 pub const KATA_ANNO_PREFIX: &str = "io.katacontainers.";
+/// Selects a packaged VM snapshot for annotation-driven sandbox restore.
+pub const KATA_ANNO_RESTORE_FROM: &str = "io.katacontainers.restore-from";
 /// Prefix for Kata configuration annotations
 pub const KATA_ANNO_CFG_PREFIX: &str = "io.katacontainers.config.";
 /// Prefix for Kata container annotations

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -11,7 +11,7 @@ use agent::{Agent, Storage};
 use anyhow::Result;
 use async_trait::async_trait;
 use hypervisor::device::device_manager::DeviceManager;
-use hypervisor::Hypervisor;
+use hypervisor::{Hypervisor, RestoreNetworkConfig};
 use kata_types::config::TomlConfig;
 use kata_types::mount::Mount;
 use oci::{Linux, LinuxResources};
@@ -82,6 +82,23 @@ impl ResourceManager {
     pub async fn handle_network(&self, network_config: NetworkConfig) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.handle_network(network_config).await
+    }
+
+    pub async fn prepare_restore_network(
+        &self,
+        network_config: NetworkConfig,
+        saved_device_id: String,
+        saved_tap_queue_count: usize,
+    ) -> Result<RestoreNetworkConfig> {
+        self.inner
+            .write()
+            .await
+            .prepare_restore_network(network_config, saved_device_id, saved_tap_queue_count)
+            .await
+    }
+
+    pub async fn activate_restore_network(&self) -> Result<()> {
+        self.inner.read().await.activate_restore_network().await
     }
 
     #[instrument]

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -15,8 +15,8 @@ use hypervisor::{
         util::{get_host_path, DEVICE_TYPE_BLOCK, DEVICE_TYPE_CHAR},
         DeviceConfig, DeviceType,
     },
-    utils::uses_native_ccw_bus,
-    BlockConfig, BlockDeviceAio, Hypervisor, VfioConfig,
+    utils::{open_named_tuntap, uses_native_ccw_bus},
+    BlockConfig, BlockDeviceAio, Hypervisor, RestoreNetworkConfig, VfioConfig,
 };
 use kata_types::mount::{kata_guest_sandbox_dir, Mount, KATA_EPHEMERAL_VOLUME_TYPE, SHM_DIR};
 use kata_types::{
@@ -253,6 +253,64 @@ impl ResourceManagerInner {
         .context("failed to set up network")?;
         self.network = Some(network);
         Ok(())
+    }
+
+    pub async fn prepare_restore_network(
+        &mut self,
+        network_config: NetworkConfig,
+        saved_device_id: String,
+        saved_tap_queue_count: usize,
+    ) -> Result<RestoreNetworkConfig> {
+        if saved_device_id.is_empty() || saved_tap_queue_count == 0 {
+            return Err(anyhow!("invalid saved restore network contract"));
+        }
+        let netns_path = match &network_config {
+            NetworkConfig::NetNs(config) if !config.netns_path.is_empty() => {
+                config.netns_path.clone()
+            }
+            NetworkConfig::NetNs(_) => {
+                return Err(anyhow!("target network namespace is required for restore"))
+            }
+            NetworkConfig::Dan(_) => return Err(anyhow!("DAN snapshot restore is not supported")),
+        };
+        let device_manager = self.device_manager.clone();
+        let (network, fds) = thread::spawn(move || -> Result<_> {
+            let runtime = runtime::Builder::new_current_thread().enable_io().build()?;
+            let _netns_guard = kata_sys_util::netns::NetnsGuard::new(&netns_path)
+                .context("enter target restore netns")?;
+            let network = runtime
+                .block_on(network::new(&network_config, device_manager))
+                .context("prepare target restore network")?;
+            let mut configs = runtime
+                .block_on(network.restore_network_configs())
+                .context("get target restore network config")?;
+            if configs.len() != 1 {
+                return Err(anyhow!(
+                    "snapshot restore requires exactly one target network endpoint, found {}",
+                    configs.len()
+                ));
+            }
+            let config = configs.remove(0);
+            let files = open_named_tuntap(&config.host_dev_name, saved_tap_queue_count as u32)
+                .context("open target restore TAP queues")?;
+            let fds = files.into_iter().map(std::os::fd::OwnedFd::from).collect();
+            Ok((network, fds))
+        })
+        .join()
+        .map_err(|error| anyhow!("restore network thread failed: {error:?}"))??;
+        self.network = Some(network);
+        Ok(RestoreNetworkConfig {
+            id: saved_device_id,
+            fds,
+        })
+    }
+
+    pub async fn activate_restore_network(&self) -> Result<()> {
+        self.network
+            .as_ref()
+            .ok_or_else(|| anyhow!("restore network was not prepared"))?
+            .activate_restore()
+            .await
     }
 
     async fn handle_interfaces(&self, network: &dyn Network) -> Result<()> {
@@ -496,7 +554,11 @@ impl ResourceManagerInner {
             sid: &self.sid,
             agent: self.agent.clone(),
             emptydir_mode: &self.toml_config.runtime.emptydir_mode,
-            fs_sharing_supported: self.hypervisor.capabilities().await?.is_fs_sharing_supported(),
+            fs_sharing_supported: self
+                .hypervisor
+                .capabilities()
+                .await?
+                .is_fs_sharing_supported(),
         };
         self.volume_resource.handler_volumes(&ctx, cid, spec).await
     }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
@@ -23,7 +23,7 @@ pub use vhost_user_endpoint::VhostUserEndpoint;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use hypervisor::Hypervisor;
+use hypervisor::{Hypervisor, NetworkConfig};
 
 use super::EndpointState;
 
@@ -34,6 +34,15 @@ pub trait Endpoint: std::fmt::Debug + Send + Sync {
     async fn attach(&self) -> Result<()>;
     async fn detach(&self, hypervisor: &dyn Hypervisor) -> Result<()>;
     async fn save(&self) -> Option<EndpointState>;
+    /// Return the target TAP configuration without attaching a second guest NIC
+    /// or enabling host traffic redirects.
+    async fn restore_network_config(&self) -> Result<Option<NetworkConfig>> {
+        Ok(None)
+    }
+    /// Enable host traffic only after restored guest identity is verified.
+    async fn activate_restore(&self) -> Result<()> {
+        anyhow::bail!("endpoint does not support fenced snapshot restore")
+    }
     /// Returns the guest PCI path for this endpoint if it is a cold-plugged
     /// physical (VFIO) device, e.g. `"05/00"`. Used to populate
     /// `Interface.device_path` in `update_interface` so the agent can do

--- a/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
@@ -112,4 +112,15 @@ impl Endpoint for VethEndpoint {
             ..Default::default()
         })
     }
+
+    async fn restore_network_config(&self) -> Result<Option<NetworkConfig>> {
+        Ok(Some(self.get_network_config()?))
+    }
+
+    async fn activate_restore(&self) -> Result<()> {
+        self.net_pair
+            .add_network_model()
+            .await
+            .context("activate restore network model")
+    }
 }

--- a/src/runtime-rs/crates/resource/src/network/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/mod.rs
@@ -28,6 +28,7 @@ use tokio::sync::RwLock;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use hypervisor::NetworkConfig as HypervisorNetworkConfig;
 use hypervisor::{device::device_manager::DeviceManager, Hypervisor};
 
 #[derive(Debug)]
@@ -44,6 +45,12 @@ pub trait Network: Send + Sync {
     async fn neighs(&self) -> Result<Vec<agent::ARPNeighbor>>;
     async fn save(&self) -> Option<Vec<EndpointState>>;
     async fn remove(&self, h: &dyn Hypervisor) -> Result<()>;
+    async fn restore_network_configs(&self) -> Result<Vec<HypervisorNetworkConfig>> {
+        Ok(Vec::new())
+    }
+    async fn activate_restore(&self) -> Result<()> {
+        anyhow::bail!("network does not support fenced snapshot restore")
+    }
     /// Returns the list of network endpoints. Used to resolve PCI paths
     /// via QMP before sending update_interface to the agent.
     async fn endpoints(&self) -> Vec<std::sync::Arc<dyn endpoint::Endpoint>> {

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -149,6 +149,29 @@ impl Network for NetworkWithNetns {
         Some(endpoint)
     }
 
+    async fn restore_network_configs(&self) -> Result<Vec<hypervisor::NetworkConfig>> {
+        let inner = self.inner.read().await;
+        let mut configs = Vec::with_capacity(inner.entity_list.len());
+        for entity in &inner.entity_list {
+            let config = entity
+                .endpoint
+                .restore_network_config()
+                .await?
+                .ok_or_else(|| anyhow!("network endpoint does not support snapshot restore"))?;
+            configs.push(config);
+        }
+        Ok(configs)
+    }
+
+    async fn activate_restore(&self) -> Result<()> {
+        let inner = self.inner.read().await;
+        let _netns_guard = netns::NetnsGuard::new(&inner.netns_path).context("net netns guard")?;
+        for entity in &inner.entity_list {
+            entity.endpoint.activate_restore().await?;
+        }
+        Ok(())
+    }
+
     async fn remove(&self, h: &dyn Hypervisor) -> Result<()> {
         let inner = self.inner.read().await;
 

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -25,6 +25,7 @@ use kata_types::{
     annotations::Annotation,
     build_path,
     config::{default::DEFAULT_GUEST_DNS_FILE, hypervisor::RootlessUser, Hypervisor, TomlConfig},
+    k8s::container_type,
     mount::SHM_DEVICE,
     rootless::{is_rootless, rootless_dir, set_rootless},
 };
@@ -366,6 +367,19 @@ impl RuntimeHandlerManager {
         // return if runtime instance has init
         if inner.runtime_instance.is_some() {
             return Ok(());
+        }
+
+        if let Some(restore_from) = spec.annotations().as_ref().and_then(|annotations| {
+            annotations.get(kata_types::annotations::KATA_ANNO_RESTORE_FROM)
+        }) {
+            if restore_from.is_empty() {
+                return Err(anyhow!("restore-from annotation is empty"));
+            }
+            if !container_type(spec).is_pod_sandbox() {
+                return Err(anyhow!(
+                    "restore-from is supported only on pod sandbox tasks"
+                ));
+            }
         }
 
         let mut dns: Vec<String> = vec![];

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -55,6 +55,19 @@ pub struct Container {
 }
 
 impl Container {
+    pub(crate) async fn set_state(&self, state: ProcessStatus) {
+        self.inner.write().await.set_state(state).await;
+    }
+
+    pub(crate) async fn complete_locally(&self, exit_code: i32) {
+        self.inner
+            .write()
+            .await
+            .init_process
+            .complete_locally(exit_code)
+            .await;
+    }
+
     pub async fn new(
         pid: u32,
         config: ContainerConfig,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -28,8 +28,10 @@ use tokio::sync::{OnceCell, RwLock};
 use tracing::instrument;
 
 use kata_sys_util::{hooks::HookStates, netns::NetnsGuard};
+use kata_types::k8s::container_type;
 
 use crate::container_manager::is_termination_signal;
+use crate::restore::RestoreCoordinator;
 
 use super::{logger_with_process, Container};
 
@@ -41,6 +43,7 @@ pub struct VirtContainerManager {
     agent: Arc<dyn Agent>,
     hypervisor: Arc<dyn Hypervisor>,
     vmm_master_tid: OnceCell<u32>,
+    restore_coordinator: Arc<RestoreCoordinator>,
 }
 
 impl std::fmt::Debug for VirtContainerManager {
@@ -66,6 +69,7 @@ impl VirtContainerManager {
         agent: Arc<dyn Agent>,
         hypervisor: Arc<dyn Hypervisor>,
         resource_manager: Arc<ResourceManager>,
+        restore_coordinator: Arc<RestoreCoordinator>,
     ) -> Self {
         Self {
             sid: sid.to_string(),
@@ -75,6 +79,7 @@ impl VirtContainerManager {
             agent,
             hypervisor,
             vmm_master_tid: OnceCell::new(),
+            restore_coordinator,
         }
     }
 
@@ -91,6 +96,35 @@ impl ContainerManager for VirtContainerManager {
     #[instrument]
     async fn create_container(&self, config: ContainerConfig, spec: oci::Spec) -> Result<PID> {
         let vmm_master_tid = self.get_vmm_master_tid().await?;
+
+        if self
+            .restore_coordinator
+            .adopt_pause(&config.container_id, container_type(&spec).is_pod_sandbox())
+            .await?
+        {
+            if spec.hooks().is_some() {
+                return Err(anyhow!(
+                    "OCI hooks are not supported for restored pause tasks"
+                ));
+            }
+            let container = Container::new(
+                vmm_master_tid,
+                config.clone(),
+                spec,
+                self.agent.clone(),
+                self.resource_manager.clone(),
+                self.hypervisor.get_passfd_listener_addr().await.ok(),
+            )
+            .await
+            .context("adopt restored pause container")?;
+            self.containers
+                .write()
+                .await
+                .insert(config.container_id, container);
+            return Ok(PID {
+                pid: vmm_master_tid,
+            });
+        }
 
         let mut container = Container::new(
             vmm_master_tid,
@@ -232,6 +266,17 @@ impl ContainerManager for VirtContainerManager {
 
     #[instrument]
     async fn kill_process(&self, req: &KillRequest) -> Result<()> {
+        if is_termination_signal(req.signal)
+            && self
+                .restore_coordinator
+                .is_adopted_pause(req.process.container_id())
+                .await
+        {
+            if let Some(container) = self.containers.read().await.get(req.process.container_id()) {
+                container.complete_locally(0).await;
+            }
+            return Ok(());
+        }
         let containers = self.containers.read().await;
         let container_id = &req.process.container_id.container_id;
 
@@ -328,6 +373,21 @@ impl ContainerManager for VirtContainerManager {
 
     #[instrument]
     async fn start_process(&self, process: &ContainerProcess) -> Result<PID> {
+        if process.process_type == ProcessType::Container
+            && self
+                .restore_coordinator
+                .stage_pause_start(process.container_id())
+                .await?
+        {
+            let containers = self.containers.read().await;
+            let container = containers
+                .get(process.container_id())
+                .ok_or_else(|| Error::ContainerNotFound(process.container_id().to_string()))?;
+            container.set_state(ProcessStatus::Running).await;
+            return Ok(PID {
+                pid: self.get_vmm_master_tid().await?,
+            });
+        }
         let containers = self.containers.read().await;
         let container_id = &process.container_id.container_id;
         let c = containers

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
@@ -437,6 +437,12 @@ impl Process {
         *status = ProcessStatus::Stopped;
     }
 
+    pub async fn complete_locally(&mut self, exit_code: i32) {
+        self.exit_status.write().await.update_exit_code(exit_code);
+        self.set_status(ProcessStatus::Stopped).await;
+        self.exit_watcher_tx.take();
+    }
+
     /// Close the stdin of the process in container.
     pub async fn close_io(&mut self, _agent: Arc<dyn Agent>) {
         // Close the stdin writer keeper so that
@@ -455,5 +461,26 @@ impl Process {
     pub async fn set_status(&self, new_status: ProcessStatus) {
         let mut status = self.status.write().await;
         *status = new_status;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_completion_records_exit_and_releases_waiter() {
+        let process_id = ContainerProcess::new("restored-pause", "").unwrap();
+        let mut process = Process::new(&process_id, 1234, "/bundle", None, None, None, false);
+        let (watcher, exit_status) = process.fetch_exit_watcher().unwrap();
+        let mut watcher = watcher.unwrap();
+
+        process.complete_locally(42).await;
+
+        assert!(watcher.changed().await.is_err());
+        assert_eq!(process.get_status().await, ProcessStatus::Stopped);
+        let exit_status = exit_status.read().await;
+        assert_eq!(exit_status.exit_code, 42);
+        assert!(exit_status.exit_time.is_some());
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm.rs
@@ -287,6 +287,7 @@ impl TemplateVm {
             resource_manager.clone(),
             sandbox_config,
             factory,
+            Arc::new(crate::restore::RestoreCoordinator::new()),
         )
         .await
         .context("build sandbox")?;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -12,6 +12,7 @@ logging::logger_with_subsystem!(sl, "virt-container");
 mod container_manager;
 pub mod factory;
 pub mod health_check;
+mod restore;
 pub mod sandbox;
 pub mod sandbox_persist;
 
@@ -135,6 +136,7 @@ impl RuntimeHandler for VirtContainer {
             .await?,
         );
         let pid = std::process::id();
+        let restore_coordinator = Arc::new(restore::RestoreCoordinator::new());
 
         let sandbox = sandbox::VirtSandbox::new(
             sid,
@@ -144,6 +146,7 @@ impl RuntimeHandler for VirtContainer {
             resource_manager.clone(),
             sandbox_config,
             factory,
+            restore_coordinator.clone(),
         )
         .await
         .context("new virt sandbox")?;
@@ -153,6 +156,7 @@ impl RuntimeHandler for VirtContainer {
             agent,
             hypervisor,
             resource_manager,
+            restore_coordinator,
         );
         Ok(RuntimeInstance {
             sandbox: Arc::new(sandbox),

--- a/src/runtime-rs/crates/runtimes/virt_container/src/restore.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/restore.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RestorePhase {
+    Cold,
+    RestoringPaused,
+    AdoptingPause,
+    PauseAdopted,
+    StartsStaged,
+    Failed,
+}
+
+#[derive(Debug)]
+struct RestoreState {
+    phase: RestorePhase,
+    source_sandbox_id: Option<String>,
+    target_pause_id: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct RestoreCoordinator {
+    state: Mutex<RestoreState>,
+}
+
+impl RestoreCoordinator {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(RestoreState {
+                phase: RestorePhase::Cold,
+                source_sandbox_id: None,
+                target_pause_id: None,
+            }),
+        }
+    }
+
+    pub(crate) async fn begin(&self, source_sandbox_id: &str) -> Result<()> {
+        let mut state = self.state.lock().await;
+        if state.phase != RestorePhase::Cold || source_sandbox_id.is_empty() {
+            return Err(anyhow!("invalid restore begin transition"));
+        }
+        state.phase = RestorePhase::RestoringPaused;
+        state.source_sandbox_id = Some(source_sandbox_id.to_string());
+        Ok(())
+    }
+
+    pub(crate) async fn restored_paused(&self) -> Result<()> {
+        let mut state = self.state.lock().await;
+        if state.phase != RestorePhase::RestoringPaused {
+            return Err(anyhow!("invalid restored-paused transition"));
+        }
+        state.phase = RestorePhase::AdoptingPause;
+        Ok(())
+    }
+
+    pub(crate) async fn adopt_pause(&self, target_id: &str, is_pause: bool) -> Result<bool> {
+        let mut state = self.state.lock().await;
+        match state.phase {
+            RestorePhase::Cold => Ok(false),
+            RestorePhase::AdoptingPause if is_pause && !target_id.is_empty() => {
+                state.target_pause_id = Some(target_id.to_string());
+                state.phase = RestorePhase::PauseAdopted;
+                Ok(true)
+            }
+            RestorePhase::Failed => Err(anyhow!("restore attempt has failed")),
+            _ if !is_pause => {
+                state.phase = RestorePhase::Failed;
+                Err(anyhow!(
+                    "workload adoption requires Phase 4; restored VM remains paused"
+                ))
+            }
+            _ => Err(anyhow!("invalid pause adoption transition")),
+        }
+    }
+
+    pub(crate) async fn stage_pause_start(&self, target_id: &str) -> Result<bool> {
+        let mut state = self.state.lock().await;
+        match state.phase {
+            RestorePhase::Cold => Ok(false),
+            RestorePhase::PauseAdopted if state.target_pause_id.as_deref() == Some(target_id) => {
+                state.phase = RestorePhase::StartsStaged;
+                Ok(true)
+            }
+            RestorePhase::StartsStaged if state.target_pause_id.as_deref() == Some(target_id) => {
+                Ok(true)
+            }
+            RestorePhase::Failed => Err(anyhow!("restore attempt has failed")),
+            _ => Err(anyhow!("invalid restored pause start transition")),
+        }
+    }
+
+    pub(crate) async fn is_adopted_pause(&self, target_id: &str) -> bool {
+        self.state.lock().await.target_pause_id.as_deref() == Some(target_id)
+    }
+
+    pub(crate) async fn fail(&self) {
+        self.state.lock().await.phase = RestorePhase::Failed;
+    }
+
+    #[cfg(test)]
+    async fn phase(&self) -> RestorePhase {
+        self.state.lock().await.phase
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stages_only_the_restored_pause_task() {
+        let coordinator = RestoreCoordinator::new();
+        coordinator.begin("source").await.unwrap();
+        coordinator.restored_paused().await.unwrap();
+        assert!(coordinator.adopt_pause("target", true).await.unwrap());
+        assert!(coordinator.stage_pause_start("target").await.unwrap());
+        assert_eq!(coordinator.phase().await, RestorePhase::StartsStaged);
+    }
+
+    #[tokio::test]
+    async fn rejects_workloads_before_phase_four() {
+        let coordinator = RestoreCoordinator::new();
+        coordinator.begin("source").await.unwrap();
+        coordinator.restored_paused().await.unwrap();
+        assert!(coordinator.adopt_pause("workload", false).await.is_err());
+    }
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -5,6 +5,7 @@
 //
 
 use crate::health_check::HealthCheck;
+use crate::restore::RestoreCoordinator;
 use agent::kata::KataAgent;
 use agent::types::{KernelModule, SetPolicyRequest};
 use agent::{
@@ -61,7 +62,7 @@ use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
     any(target_arch = "x86_64", target_arch = "aarch64")
 ))]
 use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
-use kata_types::config::{hypervisor::Factory, TomlConfig};
+use kata_types::config::{hypervisor::Factory, hypervisor::MemoryRestoreMode, TomlConfig};
 use kata_types::initdata::{calculate_initdata_digest, ProtectedPlatform};
 use oci_spec::runtime as oci;
 use persist::{self, sandbox_persist::Persist};
@@ -75,8 +76,10 @@ use resource::manager::ManagerArgs;
 use resource::network::{dan_config_path, DanNetworkConfig, NetworkConfig, NetworkWithNetNsConfig};
 use resource::{ResourceConfig, ResourceManager};
 use runtime_spec as spec;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
 use std::fs;
 use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
@@ -91,40 +94,369 @@ use tracing::instrument;
 pub(crate) const VIRTCONTAINER: &str = "virt_container";
 const VMM_START_TIMEOUT_SECS: i32 = 10_000;
 const SOURCE_AGENT_LISTEN_GRACE: Duration = Duration::from_secs(2);
+const SNAPSHOT_BASE_DIR: &str = "/run/vc/vm/snapshots";
+const SNAPSHOT_MANIFEST_FILE: &str = "kata-snapshot.json";
 
-#[derive(Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct SnapshotFileManifest {
     path: String,
     size: u64,
     sha256: String,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct SnapshotContainerManifest {
     cri_name: String,
     source_host_id: String,
     snapshot_guest_id: String,
+    readonly_disk_id: String,
     readonly_disk: String,
+    writable_disk_id: Option<String>,
     writable_disk: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct SnapshotAgentTransportManifest {
     contract_version: u32,
-    state: &'static str,
+    state: String,
     server_port: u32,
     log_port: u32,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct SnapshotManifest {
     format_version: u32,
-    producer: &'static str,
-    hypervisor: &'static str,
+    producer: String,
+    hypervisor: String,
     source_sandbox_id: String,
     agent_transport: SnapshotAgentTransportManifest,
     containers: Vec<SnapshotContainerManifest>,
     files: Vec<SnapshotFileManifest>,
+}
+
+struct SavedRestoreNetwork {
+    id: String,
+    tap_queue_count: usize,
+}
+
+fn clean_relative_snapshot_path(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(anyhow!(
+            "snapshot manifest path is not a clean relative path: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn restore_source_from_annotations(
+    annotations: &std::collections::HashMap<String, String>,
+) -> Result<Option<PathBuf>> {
+    let Some(value) = annotations.get(kata_types::annotations::KATA_ANNO_RESTORE_FROM) else {
+        return Ok(None);
+    };
+    if value.is_empty() {
+        return Err(anyhow!("restore-from annotation is empty"));
+    }
+
+    let annotation_path = Path::new(value);
+    let restore_source = if annotation_path.is_absolute() {
+        if annotation_path == Path::new("/")
+            || annotation_path
+                .components()
+                .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+        {
+            return Err(anyhow!("restore-from path is not lexically clean"));
+        }
+        annotation_path.to_path_buf()
+    } else {
+        clean_relative_snapshot_path(annotation_path)?;
+        Path::new(SNAPSHOT_BASE_DIR).join(annotation_path)
+    };
+
+    let metadata = fs::symlink_metadata(&restore_source).with_context(|| {
+        format!(
+            "restore-from snapshot is unavailable: {}",
+            restore_source.display()
+        )
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(anyhow!(
+            "restore-from snapshot is not a directory: {}",
+            restore_source.display()
+        ));
+    }
+    let canonical = restore_source.canonicalize()?;
+    if canonical != restore_source {
+        return Err(anyhow!(
+            "restore-from path contains a symlink or non-canonical component: {}",
+            restore_source.display()
+        ));
+    }
+    Ok(Some(restore_source))
+}
+
+fn load_restore_manifest(snapshot_dir: &Path) -> Result<SnapshotManifest> {
+    let manifest_path = snapshot_dir.join(SNAPSHOT_MANIFEST_FILE);
+    let manifest_metadata = fs::symlink_metadata(&manifest_path).with_context(|| {
+        format!(
+            "snapshot manifest is unavailable: {}",
+            manifest_path.display()
+        )
+    })?;
+    if !manifest_metadata.file_type().is_file() {
+        return Err(anyhow!(
+            "snapshot manifest is not a regular file: {}",
+            manifest_path.display()
+        ));
+    }
+    let manifest: SnapshotManifest = serde_json::from_reader(fs::File::open(&manifest_path)?)
+        .with_context(|| format!("parse snapshot manifest {}", manifest_path.display()))?;
+
+    if manifest.format_version != 1
+        || manifest.producer != "runtime-rs"
+        || manifest.hypervisor != "cloud-hypervisor"
+    {
+        return Err(anyhow!("unsupported snapshot manifest contract"));
+    }
+    if manifest.source_sandbox_id.is_empty() {
+        return Err(anyhow!("snapshot source sandbox ID is empty"));
+    }
+    if manifest.agent_transport.contract_version != 1
+        || manifest.agent_transport.state != "disconnected-listening"
+        || manifest.agent_transport.server_port == 0
+        || manifest.agent_transport.log_port == 0
+    {
+        return Err(anyhow!("unsupported snapshot agent transport contract"));
+    }
+
+    let mut declared_files = HashSet::new();
+    for file in &manifest.files {
+        let relative = Path::new(&file.path);
+        clean_relative_snapshot_path(relative)?;
+        if !declared_files.insert(file.path.as_str()) {
+            return Err(anyhow!("duplicate snapshot file {}", file.path));
+        }
+        let path = snapshot_dir.join(relative);
+        let metadata = fs::symlink_metadata(&path)
+            .with_context(|| format!("snapshot file is unavailable: {}", path.display()))?;
+        if !metadata.file_type().is_file() {
+            return Err(anyhow!(
+                "snapshot artifact is not a regular file: {}",
+                path.display()
+            ));
+        }
+        if metadata.len() != file.size {
+            return Err(anyhow!(
+                "snapshot artifact size mismatch for {}: manifest {}, actual {}",
+                file.path,
+                file.size,
+                metadata.len()
+            ));
+        }
+    }
+
+    for required in ["clh/config.json", "clh/state.json", "runtime-state.json"] {
+        if !declared_files.contains(required) {
+            return Err(anyhow!("snapshot manifest does not declare {required}"));
+        }
+    }
+    for container in &manifest.containers {
+        if container.cri_name.is_empty()
+            || container.source_host_id.is_empty()
+            || container.snapshot_guest_id.is_empty()
+            || container.readonly_disk_id.is_empty()
+            || container.writable_disk_id.is_some() != container.writable_disk.is_some()
+            || container
+                .writable_disk_id
+                .as_ref()
+                .is_some_and(String::is_empty)
+        {
+            return Err(anyhow!("snapshot container identity is incomplete"));
+        }
+        for disk in std::iter::once(container.readonly_disk.as_str())
+            .chain(container.writable_disk.as_deref())
+        {
+            clean_relative_snapshot_path(Path::new(disk))?;
+            if !declared_files.contains(disk) {
+                return Err(anyhow!("snapshot manifest does not declare disk {disk}"));
+            }
+        }
+    }
+
+    Ok(manifest)
+}
+
+fn snapshot_disk_id(config: &serde_json::Value, path: &Path) -> Result<String> {
+    let matches = config
+        .get("disks")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow!("snapshot config missing disks"))?
+        .iter()
+        .filter(|disk| disk.get("path").and_then(serde_json::Value::as_str) == path.to_str())
+        .collect::<Vec<_>>();
+    if matches.len() != 1 {
+        return Err(anyhow!(
+            "snapshot config has {} entries for disk {}",
+            matches.len(),
+            path.display()
+        ));
+    }
+    matches[0]
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("snapshot disk {} has no ID", path.display()))
+}
+
+fn prepare_restore_source(
+    snapshot_dir: &Path,
+    private_dir: &Path,
+    manifest: &SnapshotManifest,
+) -> Result<PathBuf> {
+    fs::create_dir(private_dir)
+        .with_context(|| format!("create private restore directory {}", private_dir.display()))?;
+    fs::set_permissions(private_dir, fs::Permissions::from_mode(0o700))?;
+
+    let restore_source = private_dir.join("clh");
+    fs::create_dir(&restore_source)?;
+    fs::set_permissions(&restore_source, fs::Permissions::from_mode(0o700))?;
+    let snapshot_clh = snapshot_dir.join("clh");
+    let private_config_path = restore_source.join("config.json");
+    reflink_copy(&snapshot_clh.join("config.json"), &private_config_path)
+        .context("copy private restore config")?;
+    fs::set_permissions(&private_config_path, fs::Permissions::from_mode(0o600))?;
+    std::os::unix::fs::symlink(
+        snapshot_clh.join("state.json"),
+        restore_source.join("state.json"),
+    )
+    .context("link immutable restore state")?;
+    let memory_ranges = snapshot_clh.join("memory-ranges");
+    if memory_ranges.is_file() {
+        std::os::unix::fs::symlink(&memory_ranges, restore_source.join("memory-ranges"))
+            .context("link immutable restore memory")?;
+    }
+
+    let mut replacements = HashMap::<String, PathBuf>::new();
+    for container in &manifest.containers {
+        let readonly = snapshot_dir.join(&container.readonly_disk);
+        if replacements
+            .insert(container.readonly_disk_id.clone(), readonly)
+            .is_some()
+        {
+            return Err(anyhow!(
+                "duplicate snapshot disk ID {}",
+                container.readonly_disk_id
+            ));
+        }
+        if let (Some(writable_id), Some(writable)) = (
+            container.writable_disk_id.as_ref(),
+            container.writable_disk.as_ref(),
+        ) {
+            clean_relative_snapshot_path(Path::new(&container.source_host_id))?;
+            let private_container = private_dir
+                .join("containers")
+                .join(&container.source_host_id);
+            fs::create_dir_all(&private_container)?;
+            fs::set_permissions(&private_container, fs::Permissions::from_mode(0o700))?;
+            let private_writable = private_container.join("rwlayer.img");
+            reflink_copy(&snapshot_dir.join(writable), &private_writable)
+                .with_context(|| format!("clone private writable disk {writable}"))?;
+            fs::set_permissions(&private_writable, fs::Permissions::from_mode(0o600))?;
+            if replacements
+                .insert(writable_id.clone(), private_writable)
+                .is_some()
+            {
+                return Err(anyhow!("duplicate snapshot disk ID {writable_id}"));
+            }
+        }
+    }
+
+    let mut config: serde_json::Value = serde_json::from_slice(&fs::read(&private_config_path)?)
+        .context("parse private restore config")?;
+    let disks = config
+        .get_mut("disks")
+        .and_then(serde_json::Value::as_array_mut)
+        .ok_or_else(|| anyhow!("snapshot config missing disks"))?;
+    let mut rewritten = HashSet::new();
+    for disk in disks {
+        let Some(id) = disk
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let Some(path) = replacements.get(&id) else {
+            continue;
+        };
+        if !rewritten.insert(id.clone()) {
+            return Err(anyhow!("snapshot config contains duplicate disk ID {id}"));
+        }
+        disk.as_object_mut()
+            .ok_or_else(|| anyhow!("snapshot config has invalid disk"))?
+            .insert(
+                "path".to_string(),
+                serde_json::Value::String(path.display().to_string()),
+            );
+    }
+    let expected = replacements.keys().cloned().collect::<HashSet<_>>();
+    if rewritten != expected {
+        return Err(anyhow!(
+            "snapshot config did not reference manifest disk IDs: {:?}",
+            expected.difference(&rewritten).collect::<Vec<_>>()
+        ));
+    }
+    fs::write(&private_config_path, serde_json::to_vec(&config)?)?;
+    Ok(restore_source)
+}
+
+fn saved_restore_network(snapshot_dir: &Path) -> Result<SavedRestoreNetwork> {
+    let config: serde_json::Value =
+        serde_json::from_slice(&fs::read(snapshot_dir.join("clh/config.json"))?)
+            .context("parse saved CLH network config")?;
+    let networks = config
+        .get("net")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow!("snapshot config missing network devices"))?;
+    if networks.len() != 1 {
+        return Err(anyhow!(
+            "snapshot restore requires exactly one saved network device, found {}",
+            networks.len()
+        ));
+    }
+    let network = &networks[0];
+    if network
+        .get("vhost_user")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(anyhow!("vhost-user snapshot restore is not supported"));
+    }
+    let id = network
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| anyhow!("saved restore network has no device ID"))?;
+    let virtio_queue_count = network
+        .get("num_queues")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|queues| usize::try_from(queues).ok())
+        .filter(|queues| *queues > 0 && *queues % 2 == 0)
+        .ok_or_else(|| anyhow!("saved restore network has invalid virtio queue count"))?;
+    Ok(SavedRestoreNetwork {
+        id: id.to_string(),
+        tap_queue_count: virtio_queue_count / 2,
+    })
 }
 
 fn relative_snapshot_path(root: &Path, path: &Path) -> Result<String> {
@@ -175,17 +507,72 @@ fn snapshot_file_manifest(root: &Path, path: &Path) -> Result<SnapshotFileManife
 #[cfg(test)]
 mod snapshot_manifest_tests {
     use super::*;
+    use tempfile::TempDir;
+
+    fn write_artifact(root: &Path, relative: &str, data: &[u8]) -> SnapshotFileManifest {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, data).unwrap();
+        SnapshotFileManifest {
+            path: relative.to_string(),
+            size: data.len() as u64,
+            sha256: format!("sha256:{}", "0".repeat(64)),
+        }
+    }
+
+    fn valid_manifest(root: &Path) -> SnapshotManifest {
+        let readonly = root.join("containers/source/rootfs.vmdk");
+        let writable = root.join("containers/source/rwlayer.img");
+        let config = serde_json::to_vec(&serde_json::json!({
+            "disks": [
+                {"id": "readonly-source", "path": readonly},
+                {"id": "writable-source", "path": writable},
+            ],
+            "memory": {"zones": []},
+            "net": [{"id": "net0", "num_queues": 2}],
+        }))
+        .unwrap();
+        let files = vec![
+            write_artifact(root, "clh/config.json", &config),
+            write_artifact(root, "clh/state.json", b"{}"),
+            write_artifact(root, "runtime-state.json", b"{}"),
+            write_artifact(root, "containers/source/rootfs.vmdk", b"descriptor"),
+            write_artifact(root, "containers/source/rwlayer.img", b"writable"),
+        ];
+        SnapshotManifest {
+            format_version: 1,
+            producer: "runtime-rs".to_string(),
+            hypervisor: "cloud-hypervisor".to_string(),
+            source_sandbox_id: "source-sandbox".to_string(),
+            agent_transport: SnapshotAgentTransportManifest {
+                contract_version: 1,
+                state: "disconnected-listening".to_string(),
+                server_port: 1024,
+                log_port: 1025,
+            },
+            containers: vec![SnapshotContainerManifest {
+                cri_name: "workload".to_string(),
+                source_host_id: "source".to_string(),
+                snapshot_guest_id: "source".to_string(),
+                readonly_disk_id: "readonly-source".to_string(),
+                readonly_disk: "containers/source/rootfs.vmdk".to_string(),
+                writable_disk_id: Some("writable-source".to_string()),
+                writable_disk: Some("containers/source/rwlayer.img".to_string()),
+            }],
+            files,
+        }
+    }
 
     #[test]
     fn agent_transport_contract_is_required_in_manifest() {
         let manifest = SnapshotManifest {
             format_version: 1,
-            producer: "runtime-rs",
-            hypervisor: "cloud-hypervisor",
+            producer: "runtime-rs".to_string(),
+            hypervisor: "cloud-hypervisor".to_string(),
             source_sandbox_id: "sandbox".to_string(),
             agent_transport: SnapshotAgentTransportManifest {
                 contract_version: 1,
-                state: "disconnected-listening",
+                state: "disconnected-listening".to_string(),
                 server_port: 1024,
                 log_port: 1025,
             },
@@ -198,6 +585,87 @@ mod snapshot_manifest_tests {
         assert_eq!(value["agent_transport"]["state"], "disconnected-listening");
         assert_eq!(value["agent_transport"]["server_port"], 1024);
         assert_eq!(value["agent_transport"]["log_port"], 1025);
+    }
+
+    #[test]
+    fn restore_manifest_validation_does_not_hash_payloads() {
+        let snapshot = TempDir::new().unwrap();
+        let manifest = valid_manifest(snapshot.path());
+        fs::write(
+            snapshot.path().join(SNAPSHOT_MANIFEST_FILE),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let loaded = load_restore_manifest(snapshot.path()).unwrap();
+        assert_eq!(loaded.source_sandbox_id, "source-sandbox");
+    }
+
+    #[test]
+    fn restore_manifest_rejects_symlinks_and_size_mismatches() {
+        let snapshot = TempDir::new().unwrap();
+        let mut manifest = valid_manifest(snapshot.path());
+        manifest.files[0].size += 1;
+        fs::write(
+            snapshot.path().join(SNAPSHOT_MANIFEST_FILE),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        assert!(load_restore_manifest(snapshot.path())
+            .unwrap_err()
+            .to_string()
+            .contains("size mismatch"));
+    }
+
+    #[test]
+    fn restore_annotation_resolves_absolute_snapshot_directory() {
+        let snapshot = TempDir::new().unwrap();
+        let annotations = std::collections::HashMap::from([(
+            kata_types::annotations::KATA_ANNO_RESTORE_FROM.to_string(),
+            snapshot.path().to_string_lossy().to_string(),
+        )]);
+        assert_eq!(
+            restore_source_from_annotations(&annotations).unwrap(),
+            Some(snapshot.path().to_path_buf())
+        );
+    }
+
+    #[test]
+    fn restore_source_clones_writable_and_rewrites_disks_by_id() {
+        let snapshot = TempDir::new().unwrap();
+        let manifest = valid_manifest(snapshot.path());
+        let private_parent = TempDir::new().unwrap();
+        let private = private_parent.path().join("restore");
+
+        let restore_source = prepare_restore_source(snapshot.path(), &private, &manifest).unwrap();
+        let config: serde_json::Value =
+            serde_json::from_slice(&fs::read(restore_source.join("config.json")).unwrap()).unwrap();
+        let disks = config["disks"].as_array().unwrap();
+        assert_eq!(
+            disks[0]["path"],
+            snapshot
+                .path()
+                .join("containers/source/rootfs.vmdk")
+                .display()
+                .to_string()
+        );
+        let private_writable = private.join("containers/source/rwlayer.img");
+        assert_eq!(disks[1]["path"], private_writable.display().to_string());
+        assert_eq!(fs::read(private_writable).unwrap(), b"writable");
+        assert_eq!(
+            fs::read(snapshot.path().join("containers/source/rwlayer.img")).unwrap(),
+            b"writable"
+        );
+    }
+
+    #[test]
+    fn saved_restore_network_requires_one_id_and_queue_count() {
+        let snapshot = TempDir::new().unwrap();
+        let _manifest = valid_manifest(snapshot.path());
+
+        let network = saved_restore_network(snapshot.path()).unwrap();
+        assert_eq!(network.id, "net0");
+        assert_eq!(network.tap_queue_count, 1);
     }
 }
 
@@ -253,6 +721,7 @@ pub struct VirtSandbox {
     shm_size: u64,
     factory: Option<Factory>,
     cancel_token: CancellationToken,
+    restore_coordinator: Arc<RestoreCoordinator>,
 }
 
 impl std::fmt::Debug for VirtSandbox {
@@ -273,7 +742,7 @@ impl std::fmt::Debug for VirtSandbox {
 }
 
 impl VirtSandbox {
-    pub async fn new(
+    pub(crate) async fn new(
         sid: &str,
         msg_sender: Sender<Message>,
         agent: Arc<dyn Agent>,
@@ -281,6 +750,7 @@ impl VirtSandbox {
         resource_manager: Arc<ResourceManager>,
         sandbox_config: SandboxConfig,
         factory: Factory,
+        restore_coordinator: Arc<RestoreCoordinator>,
     ) -> Result<Self> {
         let config = resource_manager.config().await;
         let keep_abnormal = config.runtime.keep_abnormal;
@@ -299,6 +769,7 @@ impl VirtSandbox {
             sandbox_config: Some(sandbox_config),
             factory: Some(factory),
             cancel_token,
+            restore_coordinator,
         })
     }
 
@@ -312,6 +783,134 @@ impl VirtSandbox {
 
     pub fn get_hypervisor(&self) -> Arc<dyn Hypervisor> {
         self.hypervisor.clone()
+    }
+
+    fn restore_private_dir(&self) -> PathBuf {
+        PathBuf::from(kata_types::build_path(kata_types::config::KATA_PATH))
+            .join(&self.sid)
+            .join("restore")
+    }
+
+    async fn start_restore_if_requested(
+        &self,
+        sandbox_config: &SandboxConfig,
+        inner: &mut SandboxInner,
+    ) -> Result<bool> {
+        let Some(snapshot_dir) = restore_source_from_annotations(&sandbox_config.annotations)?
+        else {
+            return Ok(false);
+        };
+        if sandbox_config.hooks.is_some() {
+            return Err(anyhow!(
+                "sandbox OCI hooks are not supported for snapshot restore"
+            ));
+        }
+        let runtime_config = self.resource_manager.config().await;
+        if runtime_config.runtime.hypervisor_name != HYPERVISOR_NAME_CH {
+            return Err(anyhow!(
+                "snapshot restore requires cloud-hypervisor, configured {}",
+                runtime_config.runtime.hypervisor_name
+            ));
+        }
+
+        let manifest = load_restore_manifest(&snapshot_dir)?;
+        let saved_network = saved_restore_network(&snapshot_dir)?;
+        self.restore_coordinator
+            .begin(&manifest.source_sandbox_id)
+            .await?;
+        let private_dir = self.restore_private_dir();
+        let result: Result<()> = async {
+            fs::create_dir_all(private_dir.parent().unwrap())?;
+            let restore_source = prepare_restore_source(&snapshot_dir, &private_dir, &manifest)?;
+            let selinux_label = load_oci_spec().ok().and_then(|spec| {
+                spec.process()
+                    .as_ref()
+                    .and_then(|process| process.selinux_label().clone())
+            });
+            self.hypervisor
+                .prepare_vm(
+                    &self.sid,
+                    sandbox_config.network_env.netns.clone(),
+                    &sandbox_config.annotations,
+                    selinux_label,
+                )
+                .await
+                .context("prepare restored VM")?;
+            let target_network = self
+                .prepare_network_resource(&sandbox_config.network_env)
+                .await
+                .ok_or_else(|| anyhow!("target network is required for snapshot restore"))?;
+            let target_network = match target_network {
+                ResourceConfig::Network(network) => network,
+                _ => unreachable!(),
+            };
+            let restore_network = self
+                .resource_manager
+                .prepare_restore_network(
+                    target_network,
+                    saved_network.id,
+                    saved_network.tap_queue_count,
+                )
+                .await
+                .context("prepare fenced restore network")?;
+            let hypervisor_config = self.hypervisor.hypervisor_config().await;
+            if hypervisor_config.memory_info.enable_virtio_mem
+                && hypervisor_config.memory_info.memory_restore_mode
+                    == MemoryRestoreMode::CopyOnWrite
+            {
+                return Err(anyhow!(
+                    "copy-on-write snapshot restore is incompatible with virtio-mem"
+                ));
+            }
+            self.hypervisor
+                .restore_vm(RestoreVmRequest {
+                    snapshot_dir: restore_source,
+                    memory_restore_mode: hypervisor_config.memory_info.memory_restore_mode,
+                    network: vec![restore_network],
+                    timeout_secs: VMM_START_TIMEOUT_SECS,
+                })
+                .await
+                .context("restore workload VM paused")?;
+            self.restore_coordinator.restored_paused().await?;
+            inner.state = SandboxState::Running;
+            inner.created_at = Some(SystemTime::now());
+            self.save()
+                .await
+                .context("persist paused restored sandbox")?;
+            Ok(())
+        }
+        .await;
+        if let Err(error) = result {
+            self.restore_coordinator.fail().await;
+            if let Err(stop_error) = self.hypervisor.stop_vm().await {
+                return Err(error.context(format!(
+                    "failed to stop restored VMM; preserving private restore storage: {stop_error:#}"
+                )));
+            }
+            let _ = self.resource_manager.cleanup().await;
+            let _ = fs::remove_dir_all(&private_dir);
+            return Err(error);
+        }
+
+        let sandbox = self.clone();
+        tokio::spawn(async move {
+            match sandbox.hypervisor.wait_vm().await {
+                Ok(exit_code) => {
+                    sandbox
+                        .record_stop(exit_code as u32, SystemTime::now())
+                        .await
+                }
+                Err(error) => {
+                    warn!(sl!(), "failed waiting for restored VM exit: {:?}", error);
+                    sandbox.record_stop(255, SystemTime::now()).await;
+                }
+            }
+        });
+        info!(
+            sl!(),
+            "restored workload VM is paused and awaiting task adoption"
+        );
+        Ok(true)
     }
 
     async fn record_stop(&self, exit_status: u32, exited_at: std::time::SystemTime) {
@@ -1102,6 +1701,8 @@ impl VirtSandbox {
                 .iter()
                 .map(|path| snapshot_file_manifest(&staging, path))
                 .collect::<Result<Vec<_>>>()?;
+            let clh_config: serde_json::Value =
+                serde_json::from_slice(&fs::read(clh_staging.join("config.json"))?)?;
             let containers = artifacts
                 .iter()
                 .map(|artifact| {
@@ -1109,10 +1710,19 @@ impl VirtSandbox {
                         cri_name: artifact.cri_name.clone(),
                         source_host_id: artifact.source_host_id.clone(),
                         snapshot_guest_id: artifact.snapshot_guest_id.clone(),
+                        readonly_disk_id: snapshot_disk_id(
+                            &clh_config,
+                            &artifact.readonly_disk.snapshot_path,
+                        )?,
                         readonly_disk: relative_snapshot_path(
                             destination,
                             &artifact.readonly_disk.snapshot_path,
                         )?,
+                        writable_disk_id: artifact
+                            .writable_disk
+                            .as_ref()
+                            .map(|disk| snapshot_disk_id(&clh_config, &disk.snapshot_path))
+                            .transpose()?,
                         writable_disk: artifact
                             .writable_disk
                             .as_ref()
@@ -1123,12 +1733,12 @@ impl VirtSandbox {
                 .collect::<Result<Vec<_>>>()?;
             let manifest = SnapshotManifest {
                 format_version: 1,
-                producer: "runtime-rs",
-                hypervisor: "cloud-hypervisor",
+                producer: "runtime-rs".to_string(),
+                hypervisor: "cloud-hypervisor".to_string(),
                 source_sandbox_id: self.sid.clone(),
                 agent_transport: SnapshotAgentTransportManifest {
                     contract_version: 1,
-                    state: "disconnected-listening",
+                    state: "disconnected-listening".to_string(),
                     server_port: agent_config.server_port,
                     log_port: agent_config.log_port,
                 },
@@ -1171,6 +1781,12 @@ impl Sandbox for VirtSandbox {
         let mut inner = self.inner.write().await;
         if inner.state != SandboxState::Init {
             warn!(sl!(), "sandbox is started");
+            return Ok(());
+        }
+        if self
+            .start_restore_if_requested(sandbox_config, &mut inner)
+            .await?
+        {
             return Ok(());
         }
         let selinux_label = load_oci_spec().ok().and_then(|spec| {
@@ -1576,6 +2192,16 @@ impl Sandbox for VirtSandbox {
             .await
             .context("resource clean up")?;
 
+        let private_restore = self.restore_private_dir();
+        if private_restore.exists() {
+            fs::remove_dir_all(&private_restore).with_context(|| {
+                format!(
+                    "remove private restore directory {}",
+                    private_restore.display()
+                )
+            })?;
+        }
+
         // TODO: cleanup other sandbox resource
         Ok(())
     }
@@ -1822,6 +2448,7 @@ impl Persist for VirtSandbox {
             shm_size: DEFAULT_SHM_SIZE,
             factory: None,
             cancel_token: CancellationToken::default(),
+            restore_coordinator: Arc::new(RestoreCoordinator::new()),
         })
     }
 }


### PR DESCRIPTION
Register and parse new annotation io.katacontainers.restore-from.

When present, it triggers the snapshot restore path. It:
1. Parses and validates the snapshot payload
2. Prepares private copies of restore artifacts: 
     i. Writable rwlayer.img 
     ii. Private mutable copy of clh config.json
4. Fenced CNI veth handling: update the target TAP device with the new fds. Network remains fenced until the full restore operation completes, with all CreateContainers for workload contianers registered.
5. RestoreVM is called. memory_restore_mode controls the restore mode used, default is copyonwrite with no virtio-mem hotplug.
6. Handles CreateContainer for the POD/pause sandbox id. 
7. The next PR in the chain will finish the setup of workloads.

This change only represents the partial restore process for the pause workload and VM-based sandbox.
