### PR TITLE
tests: switch the kubeadm config to the v1beta4 API

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -505,12 +505,12 @@ function do_deploy_k8s() {
 	local kubeadm_config
 	kubeadm_config="$(mktemp --tmpdir kubeadm-config.XXXXXX.yaml)"
 	cat <<EOF | tee "${kubeadm_config}"
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
-  criSocket: "/run/containerd/containerd.sock"
+  criSocket: "unix:///run/containerd/containerd.sock"
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 networking:
   podSubnet: "10.244.0.0/16"


### PR DESCRIPTION
kubeadm 1.37 dropped the kubeadm.k8s.io/v1beta3 API, so `kubeadm init` now refuses the config we hand it, with:

```
  error: your configuration file uses an old API spec:
  "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use
  kubeadm v1.36 instead and run 'kubeadm config migrate ...'
```

That takes down the whole vanilla k8s deployment: without a cluster there is no /etc/kubernetes/admin.conf to copy, so every kubectl call that follows falls back to localhost:8080 and fails as well. Retrying does not help either, as the config is rejected the same way on each attempt.

Move both documents to v1beta4, which needs no other change as the fields we set are untouched. This is safe for the versions we install, which are the latest minor and the one before it, as v1beta4 has been supported since kubeadm 1.31.

While here, spell the CRI socket as a unix:// URL, which is the form the v1beta4 documentation uses. A bare absolute path is still accepted, but only through a deprecation path we have no reason to rely on.

Assisted-by: Cursor <cursoragent@cursor.com>

(cherry picked from commit 83dd52702fd737128a5d259b374b5eb2da482d61)