### PR TITLE
tests: switch the kubeadm config to the v1beta4 API

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -493,12 +493,12 @@ function do_deploy_k8s() {
 	local kubeadm_config
 	kubeadm_config="$(mktemp --tmpdir kubeadm-config.XXXXXX.yaml)"
 	cat <<EOF | tee "${kubeadm_config}"
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
-  criSocket: "/run/containerd/containerd.sock"
+  criSocket: "unix:///run/containerd/containerd.sock"
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 networking:
   podSubnet: "10.244.0.0/16"


### PR DESCRIPTION
Cherry-pick of upstream `83dd52702fd737128a5d259b374b5eb2da482d61`.

## Why

Every `run-k8s-tests` job on `manifold-cc` currently fails, on every PR, for every hypervisor
(`qemu`, `qemu-runtime-rs`, `clh`, `clh-runtime-rs`, `dragonball`) and both `latest` and
`minimum`. That is 14 required jobs, which also fails `gatekeeper`. No PR against this branch
can go green until it is fixed.

The visible symptom is misleading -- a wall of `dial tcp [::1]:8080: connect: connection refused`.
The real error is much earlier, in `do_deploy_k8s`:

```
error: your configuration file uses an old API spec: "kubeadm.k8s.io/v1beta3"
       (kind: "ClusterConfiguration"). Please use kubeadm v1.36 instead ...
do_deploy_k8s failed after 5 attempts
```

kubeadm 1.37 removed the `kubeadm.k8s.io/v1beta3` API, and `tests/gha-run-k8s-common.sh` still
generates both its `InitConfiguration` and `ClusterConfiguration` against `v1beta3`. `kubeadm init`
refuses the config, so the cluster never comes up, `/etc/kubernetes/admin.conf` is never written,
and every later `kubectl` falls back to `localhost:8080`. Retrying cannot help -- the config is
rejected identically on all 5 attempts, which is why each job burns ~15 minutes before failing.

## This is a runner-image change, not a repository change

It is purely time-based. Same job, same branch, same day:

| Run | Time (UTC, 2026-09-01) | `run-k8s-tests (qemu, latest)` |
|---|---|---|
| PR #532 | 15:14 | pass |
| PR #553 | 22:05 | fail |

The hosted runner's kubeadm crossed 1.37 between those two runs.

## The change

`v1beta3` -> `v1beta4` in both documents, and the CRI socket spelled as a `unix://` URL, which is
the form the `v1beta4` documentation uses. Per the upstream commit message no other field needs to
change, and this is safe for the versions installed here because `v1beta4` has been supported
since kubeadm 1.31.

3 changed lines in 1 file. `kata-containers/main` has been on `v1beta4` since 2026-08-27; verified
that this commit is not an ancestor of `manifold-cc`.
