### PR TITLE
tests: restore the copy_file destination paths from upstream

### DIFF
--- a/tests/functional/kata-agent-apis/api-tests/test_copy_file.bats
+++ b/tests/functional/kata-agent-apis/api-tests/test_copy_file.bats
@@ -11,32 +11,32 @@ setup_file() {
     info "setup"
 }
 
-@test "Test CopyFile API: Copy a file to /run/kata-containers" {
-    info "Copy file to /run/kata-containers"
+@test "Test CopyFile API: Copy a file to /run/kata-containers/shared/containers" {
+    info "Copy file to /run/kata-containers/shared/containers"
     src_file=$(mktemp)
     local cmds=()
-    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/foo\"}'")
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/shared/containers/foo\"}'")
     run_agent_ctl "${cmds[@]}"
     rm $src_file
 }
 
-@test "Test CopyFile API: Copy a symlink to /run/kata-containers" {
-    info "Copy symlink to /run/kata-containers"
+@test "Test CopyFile API: Copy a symlink to /run/kata-containers/shared/containers" {
+    info "Copy symlink to /run/kata-containers/shared/containers"
     src_file=$(mktemp)
     link_file="/tmp/link"
     ln -s $src_file $link_file
     local cmds=()
-    cmds+=("-c 'CopyFile json://{\"src\": \"$link_file\", \"dest\":\"/run/kata-containers/link\"}'")
+    cmds+=("-c 'CopyFile json://{\"src\": \"$link_file\", \"dest\":\"/run/kata-containers/shared/containers/link\"}'")
     run_agent_ctl "${cmds[@]}"
     unlink $link_file
     rm $src_file
 }
 
-@test "Test CopyFile API: Copy a directory to /run/kata-containers" {
-    info "Copy directory to /run/kata-containers"
+@test "Test CopyFile API: Copy a directory to /run/kata-containers/shared/containers" {
+    info "Copy directory to /run/kata-containers/shared/containers"
     src_dir=$(mktemp -d)
     local cmds=()
-    cmds+=("-c 'CopyFile json://{\"src\": \"$src_dir\", \"dest\":\"/run/kata-containers/dir\"}'")
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_dir\", \"dest\":\"/run/kata-containers/shared/containers/dir\"}'")
     run_agent_ctl "${cmds[@]}"
     rmdir $src_dir
 }
@@ -51,17 +51,30 @@ setup_file() {
     rm $src_file
 }
 
-@test "Test CopyFile API: Copy a large file to /run/kata-containers" {
-    info "Copy large file to /run/kata-containers"
+@test "Test CopyFile API: Copy a file to an unallowed destination beneath /run/kata-containers" {
+    # This is a regression test, copying files to /run/kata-containers used to be allowed, but the
+    # implementation is more strict now and requires paths to be under
+    # /run/kata-containers/shared/containers.
+    info "Copy file to /run/kata-containers/shared"
+    src_file=$(mktemp)
+    local cmds=()
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/shared/foo\"}'")
+    run run_agent_ctl "${cmds[@]}"
+    [ "$status" -ne 0 ]
+    rm $src_file
+}
+
+@test "Test CopyFile API: Copy a large file to /run/kata-containers/shared/containers" {
+    info "Copy large file to /run/kata-containers/shared/containers"
     src_file="/tmp/large_file_2M.txt"
     truncate -s 2M $src_file
     local cmds=()
-    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/large_file_2M.txt\"}'")
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/shared/containers/large_file_2M.txt\"}'")
     run_agent_ctl "${cmds[@]}"
     rm $src_file
 }
 
 teardown_file() {
     info "teardown"
-    sudo rm -r /run/kata-containers/ || echo "Failed to clean /run/kata-containers"
+    sudo rm -r /run/kata-containers/shared/containers/ || echo "Failed to clean /run/kata-containers/shared/containers"
 }

--- a/tests/functional/kata-agent-apis/api-tests/test_set_policy.bats
+++ b/tests/functional/kata-agent-apis/api-tests/test_set_policy.bats
@@ -30,7 +30,7 @@ setup_file() {
 
     src_file=$(mktemp)
     local cmds=()
-    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/foo\"}'")
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/shared/containers/foo\"}'")
     run run_agent_ctl "${cmds[@]}"
     [ "$status" -ne 0 ]
 


### PR DESCRIPTION
Restores the test-side half of upstream `3dba12cd81` ("agent: constrain copy_file to shared
directory"). No product code changes.

## Why

`run-basic-amd64-tests / run-kata-agent-apis` fails 4 of 12 tests on every PR against this branch
(#553, #542, #534, #531, #527 all show the identical set). It is deterministic, not flaky.

```
1..12
not ok 1 Test CopyFile API: Copy a file to /run/kata-containers
not ok 2 Test CopyFile API: Copy a symlink to /run/kata-containers
not ok 3 Test CopyFile API: Copy a directory to /run/kata-containers
ok     4 Test CopyFile API: Copy a file to an unallowed destination
not ok 5 Test CopyFile API: Copy a large file to /run/kata-containers
```

The first error in the log is a red herring -- `Failed to connect to Unix Domain abstract socket`
is a startup race the `waitForProcess` loop recovers from, and the agent is healthy (tests 6-12
boot real qemu and clh pod VMs and pass). The real error is:

```
RpcStatus INTERNAL: removing "/run/kata-containers/shared/containers/" prefix
                    from /run/kata-containers/foo
  Caused by: prefix not found
    1: kata_agent::rpc::do_copy_file
```

`do_copy_file` confines destinations to `KATA_GUEST_SHARE_DIR`
(`/run/kata-containers/shared/containers/`). The tests copy to `/run/kata-containers/` -- outside
it. The product is correct; the tests assert behaviour that was deliberately removed.

## How the branch got here

Upstream `3dba12cd81` changed `rpc.rs` and these two test files in one commit. On this branch:

| | state |
|---|---|
| `3dba12cd81` in history | yes, merged via `fe5071ccd2` (upstream PR #12971) |
| `rpc.rs` confinement | present (`.strip_prefix(shared_dir)`) |
| `test_copy_file.bats` | byte-identical to the 2024 original `2c774fb207` |

`git log -- test_copy_file.bats` on this branch lists only the 2024 commit, and no revert commit
touches the file, so the test hunks were dropped in a merge resolution that kept the old side. The
code hardening landed; its test update did not.

## The change

- move the four positive destinations under `/run/kata-containers/shared/containers/`
- add upstream's regression test for the now-forbidden region beneath `/run/kata-containers`
- update `teardown_file` to clean the new path
- same one-line destination fix in `test_set_policy.bats`

Verified that `kata-containers/main` has not touched `test_copy_file.bats` since `3dba12cd81`, so
this matches the current upstream content -- with one deliberate exception, below.

## One deliberate difference from upstream

Upstream's new regression test carries an `info "Copy file to /tmp"` line copy-pasted from the
`/tmp` case above it, while the test actually targets `/run/kata-containers/shared/foo`. That makes
the two negative cases indistinguishable in a failing log, so this PR names the destination the
test really exercises. Caught by Copilot's review here. Worth sending back upstream.

## Two tests that passed for the wrong reason

Worth calling out, because it is the reason this went unnoticed:

- "Copy a file to an unallowed destination" (`/tmp/foo`)
- "SetPolicy API: Block CopyFile in policy"

Both assert only `[ "\" -ne 0 ]`. Both were failing on the prefix check rather than on the
denial they are named for -- they would pass just as happily with the agent dead. With the
destinations corrected they test what they claim again.

A follow-up worth considering: have negative tests assert the *reason* for failure, so a broken
agent can never be mistaken for a correctly enforced denial.

## Note for strict builds

In `strict-policy` builds the generic CopyFile RPC is refused outright with `PERMISSION_DENIED`
before any path check (FR-10). These jobs build the non-strict agent, so they exercise the
confinement path above.


