### PR TITLE
agent/srm: refresh the pinned tla2tools.jar hash

### DIFF
--- a/src/agent/security-reference-monitor/formal/run-tlc.sh
+++ b/src/agent/security-reference-monitor/formal/run-tlc.sh
@@ -33,8 +33,16 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# v1.8.0 is upstream's only *prerelease*, and it targets master rather than a
+# fixed commit: the release object is deleted and recreated as master advances,
+# republishing tla2tools.jar under this same URL. The pin below was correct when
+# it landed on 2026-08-21 and stopped matching on 2026-09-01, when the release
+# was recreated (its created_at moved forward, which a stable release's cannot).
+# Expect to refresh this hash again. The durable fix is to pin the latest stable
+# release instead -- v1.7.4, untouched since 2024-08-08 -- once the model has
+# been confirmed to check cleanly, with the coverage gates below intact, there.
 TLA2TOOLS_VERSION=v1.8.0
-TLA2TOOLS_SHA256=eabd140a70f49eb9305a3bd3f3df944eddf87e5a90d329789085f8953a80533a
+TLA2TOOLS_SHA256=dbcc75552f21978a4846688b8e23be1a6b6c0b3fcee35d78fec2df167958ec94
 
 JAR=${TLA2TOOLS_JAR:-tla2tools.jar}
 if [[ ! -f "${JAR}" ]]; then


### PR DESCRIPTION
Third of three branch-wide CI breaks on `manifold-cc`, alongside #554 (kubeadm `v1beta4`) and
#555 (CopyFile test paths). One changed line of configuration, plus a comment.

## Why

The required `Formal model check (SRM) / TLC + mutation + drift` job fails on every PR against this
branch, including PRs that touch nothing under `src/agent/security-reference-monitor`. Both #554
(3 lines in a kubeadm config) and #555 (2 bats files) fail it:

```
ERROR: tla2tools.jar does not match the pinned sha256.
       expected eabd140a70f49eb9305a3bd3f3df944eddf87e5a90d329789085f8953a80533a
```

`run-tlc.sh` pins the `tla2tools.jar` content hash as well as the version, which is the right thing
to do -- the jar is downloaded at check time, and a formal-methods gate that silently accepts
whatever bytes arrive is not a gate. The problem is what it pins *to*.

## Root cause

`v1.8.0` is upstream `tlaplus/tlaplus`'s only **prerelease**, and it targets `master` rather than a
fixed commit. The release object is deleted and recreated as `master` advances, republishing
`tla2tools.jar` at the same URL with different content.

The evidence that it was recreated rather than edited is in the release metadata: our pin landed
2026-08-21 and matched at the time, yet the release's `created_at` now reads 2026-09-01 -- 11 days
later. A release's `created_at` cannot move forward, so the object we pinned against no longer
exists.

## The change

Refresh the hash to the currently published content, and record the above in a comment above the
pin so the next person to hit this does not have to rediscover it.

Verified just now, immediately before pushing:

```
version = v1.8.0
live    = dbcc75552f21978a4846688b8e23be1a6b6c0b3fcee35d78fec2df167958ec94
pin     = dbcc75552f21978a4846688b8e23be1a6b6c0b3fcee35d78fec2df167958ec94
VERIFY: PASS
```

## This will recur

Refreshing the hash is a stopgap, and the comment says so. The durable fix is to pin the latest
**stable** release, `v1.7.4`, whose asset has been untouched since 2024-08-08. I did not do that here
because `SRM.tla` has not yet been confirmed to model-check cleanly under `v1.7.4` with the action
and property coverage gates intact -- that is a change that needs its own validation, not a
drive-by in a CI unblock.

Also worth noting: the TLA+ Toolbox deprecation notice does not affect us. `run-tlc.sh` invokes
`java -cp tla2tools.jar tlc2.TLC` -- the command-line TLC, which is exactly what upstream now
recommends.
