### PR TITLE
genpolicy: add versioned Kubernetes compatibility appliance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,14 @@ on:
         required: false
         type: string
         default: small
+      nested-policy-compat:
+        required: false
+        type: boolean
+        default: false
+      nested-policy-compat-runner:
+        required: false
+        type: string
+        default: ubuntu-24.04
     secrets:
       AUTHENTICATED_IMAGE_PASSWORD:
         required: true
@@ -64,6 +72,16 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
     secrets:
       KBUILD_SIGN_PIN: ${{ secrets.KBUILD_SIGN_PIN }}
+
+  nested-policy-compat:
+    if: ${{ inputs.skip-test != 'yes' && inputs.nested-policy-compat }}
+    needs: build-kata-static-tarball-amd64
+    uses: ./.github/workflows/run-nested-policy-compat.yaml
+    with:
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
+      tarball-suffix: -${{ inputs.tag }}
+      runner: ${{ inputs.nested-policy-compat-runner }}
 
   publish-kata-deploy-image-amd64:
     needs: build-kata-static-tarball-amd64

--- a/.github/workflows/run-nested-policy-compat.yaml
+++ b/.github/workflows/run-nested-policy-compat.yaml
@@ -1,0 +1,191 @@
+name: CI | Nested policy compatibility
+on:
+  workflow_call:
+    inputs:
+      commit-hash:
+        required: true
+        type: string
+      target-branch:
+        required: false
+        type: string
+        default: ""
+      tarball-suffix:
+        required: true
+        type: string
+      runner:
+        required: false
+        type: string
+        default: ubuntu-24.04
+
+permissions: {}
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ inputs.commit-hash }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Validate compatibility harness
+        run: make -C src/tools/genpolicy/nested-policy-compat validate
+
+  prepare:
+    name: prepare compatibility bundle
+    runs-on: ${{ inputs.runner }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ inputs.commit-hash }}
+      cancel-in-progress: true
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Install host build dependencies
+        run: |
+          ./tests/install_rust.sh
+          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+          sudo apt-get update
+          sudo apt-get install -y \
+            bison build-essential flex kmod lvm2 m4 musl-tools pkg-config \
+            qemu-utils uuid-dev zstd
+
+      - name: Download Cloud Hypervisor
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-artifacts-amd64-cloud-hypervisor${{ inputs.tarball-suffix }}
+          path: ${{ runner.temp }}/kata-artifacts
+
+      - name: Download guest kernel
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-artifacts-amd64-kernel${{ inputs.tarball-suffix }}
+          path: ${{ runner.temp }}/kata-artifacts
+
+      - name: Download runtime-rs shim
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-artifacts-amd64-shim-v2-rust${{ inputs.tarball-suffix }}
+          path: ${{ runner.temp }}/kata-artifacts
+
+      - name: Download confidential guest image
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-artifacts-amd64-rootfs-image-confidential${{ inputs.tarball-suffix }}
+          path: ${{ runner.temp }}/kata-artifacts
+
+      - name: Install PR-built boot artifacts
+        run: |
+          make -C src/tools/genpolicy/nested-policy-compat ensure-host-environment \
+            PROFILE=k8s-1.36-containerd-2.3-erofs-dmverity \
+            APPROVE_KATA_INSTALL=yes \
+            KATA_ARTIFACT_DIR="${RUNNER_TEMP}/kata-artifacts" \
+            KATA_ROOT="${RUNNER_TEMP}/kata" \
+            KATA_CONFIG="${RUNNER_TEMP}/kata/share/defaults/kata-containers/runtime-rs/configuration-nested-policy-compat.toml"
+
+      - name: Build strict compatibility artifacts
+        timeout-minutes: 60
+        run: |
+          make -C src/tools/genpolicy/nested-policy-compat prepare-kata-stack \
+            KATA_ROOT="${RUNNER_TEMP}/kata" \
+            KATA_CONFIG="${RUNNER_TEMP}/kata/share/defaults/kata-containers/runtime-rs/configuration-nested-policy-compat.toml"
+
+      - name: Package compatibility bundle
+        run: tar --zstd -cf "${RUNNER_TEMP}/nested-policy-kata.tar.zst" -C "${RUNNER_TEMP}" kata
+
+      - name: Upload compatibility bundle
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: nested-policy-kata${{ inputs.tarball-suffix }}
+          path: ${{ runner.temp }}/nested-policy-kata.tar.zst
+          retention-days: 7
+          if-no-files-found: error
+
+  profile:
+    name: profile (${{ matrix.profile }})
+    needs: [validate, prepare]
+    runs-on: ${{ inputs.runner }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ inputs.commit-hash }}-${{ matrix.profile }}
+      cancel-in-progress: true
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - k8s-1.33-containerd-1.7-guest-pull
+          - k8s-1.36-containerd-2.3-guest-pull
+          - k8s-1.33-containerd-2.3-erofs-dmverity
+          - k8s-1.36-containerd-2.3-erofs-dmverity
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Install host test dependencies
+        run: |
+          ./tests/install_rust.sh
+          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
+          sudo apt-get update
+          sudo apt-get install -y kmod lvm2 zstd
+
+      - name: Download compatibility bundle
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: nested-policy-kata${{ inputs.tarball-suffix }}
+          path: ${{ runner.temp }}
+
+      - name: Extract compatibility bundle
+        run: tar --zstd -xf "${RUNNER_TEMP}/nested-policy-kata.tar.zst" -C "${RUNNER_TEMP}"
+
+      - name: Run compatibility profile
+        run: |
+          make -C src/tools/genpolicy/nested-policy-compat ci-fixture-e2e \
+            PROFILE="${PROFILE}" \
+            IMAGE="nested-policy-compat:${PROFILE}" \
+            KATA_ROOT="${RUNNER_TEMP}/kata" \
+            KATA_CONFIG="${RUNNER_TEMP}/kata/share/defaults/kata-containers/runtime-rs/configuration-nested-policy-compat.toml" \
+            OUTPUT_ROOT="${RUNNER_TEMP}/results"
+        env:
+          PROFILE: ${{ matrix.profile }}
+
+      - name: Upload compatibility results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: nested-policy-results-${{ matrix.profile }}${{ inputs.tarball-suffix }}
+          path: ${{ runner.temp }}/results
+          retention-days: 15
+          if-no-files-found: warn

--- a/src/tools/genpolicy/nested-policy-compat/.gitignore
+++ b/src/tools/genpolicy/nested-policy-compat/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+/bin/
+/build/

--- a/src/tools/genpolicy/nested-policy-compat/DESIGN.md
+++ b/src/tools/genpolicy/nested-policy-compat/DESIGN.md
@@ -49,15 +49,15 @@ An unmodified Kata installation is mounted at `/opt/kata`. This separates the
 Kubernetes/containerd profile from the Kata build being tested and avoids
 rebuilding Kata inside every version-matrix image.
 
-Before a matrix starts, the host-side harness extracts the commits embedded in
-the installed runtime-rs shim and the Agent inside the configured guest image.
-Each installed commit must exist in the checkout, and the corresponding
-`src/runtime-rs` or `src/agent` tree must match the current working tree.
-Tracked differences and untracked component files both stop the run, while
-harness-only commits do not require rebuilding unrelated Kata binaries. A
-mismatch invokes the repository's local-build pipeline with its artifact cache
-disabled, atomically replaces the installed shim and measured guest image, and
-writes a marker binding their hashes to fingerprints of both source trees.
+Before a matrix starts, the host-side harness requires the provenance marker
+written by its rebuild path. The marker binds the VMM, guest kernel, runtime
+configuration, runtime-rs shim, monolithic confidential image, and
+confidential-image root hash to fingerprints of the runtime-rs and strict-Agent
+build inputs. Requiring this marker prevents a same-commit Agent built without
+strict-policy enforcement, an unrelated confidential image, or stale boot
+components from being accepted. A mismatch invokes the repository's local-build
+pipeline with its artifact cache disabled, atomically replaces the installed
+artifacts, and writes a new marker.
 For CI, `prepare-kata-stack` is the artifact-production phase,
 `verify-kata-provenance` is the artifact-consumption gate, and
 `ci-fixture-e2e` deliberately verifies without rebuilding so a stale artifact

--- a/src/tools/genpolicy/nested-policy-compat/DESIGN.md
+++ b/src/tools/genpolicy/nested-policy-compat/DESIGN.md
@@ -1,0 +1,269 @@
+# Nested Policy Compatibility Appliance
+
+## Goal
+
+Test whether an externally generated Kata Agent policy remains compatible with
+the shim requests produced by a specific Kubernetes and containerd version.
+Policy generation is a separate phase from nested execution, but both phases
+run in the same self-contained profile image.
+
+The image builds GenPolicy from the checked-out source tree and vendors the
+versioned appliance profiles, API server, kubelet, containerd, etcd, CNI
+plugins, image preparation, and workload normalization needed by the test. It
+uses an unmodified Kata shim to boot a real guest through nested virtualization
+exposed by the disposable L1 VM.
+
+```text
+externally annotated workload
+             |
+             v
+pinned API server -> pinned kubelet -> pinned containerd
+                                           |
+                                           v
+                                 unmodified Kata shim
+                                           |
+                                  hybrid-vsock relay
+                                           |
+                                           v
+                              policy-enabled Kata Agent
+```
+
+The Agent's allow or deny response is authoritative for compatibility. The
+captured byte streams and component logs explain the result.
+
+## Appliance boundary
+
+The harness carries its appliance profile beneath `appliance/`. The Docker
+build downloads the exact component versions declared by the selected profile
+and embeds OCI fixtures, the workload submitter, kubelet and CNI configuration,
+and startup orchestration. It has no dependency on another Git branch, source
+worktree, or prebuilt appliance image.
+
+The compatibility matrix invokes the embedded GenPolicy binary in a dedicated
+generation mode before annotating the workload. Consequently the generated
+policy, rules, and settings all come from the same `manifold-cc`-based commit
+as the harness. Policy generation is separate from the nested runtime path and
+remains independent of the Kubernetes/containerd version under test.
+
+An unmodified Kata installation is mounted at `/opt/kata`. This separates the
+Kubernetes/containerd profile from the Kata build being tested and avoids
+rebuilding Kata inside every version-matrix image.
+
+Before a matrix starts, the host-side harness extracts the commits embedded in
+the installed runtime-rs shim and the Agent inside the configured guest image.
+Each installed commit must exist in the checkout, and the corresponding
+`src/runtime-rs` or `src/agent` tree must match the current working tree.
+Tracked differences and untracked component files both stop the run, while
+harness-only commits do not require rebuilding unrelated Kata binaries. A
+mismatch invokes the repository's local-build pipeline with its artifact cache
+disabled, atomically replaces the installed shim and measured guest image, and
+writes a marker binding their hashes to fingerprints of both source trees.
+For CI, `prepare-kata-stack` is the artifact-production phase,
+`verify-kata-provenance` is the artifact-consumption gate, and
+`ci-fixture-e2e` deliberately verifies without rebuilding so a stale artifact
+cannot be hidden by work performed inside the test job.
+
+## Test-only policy reasons
+
+Strict-policy Agent builds intentionally avoid exposing request contents or a
+full policy trace to the host. A bare GenPolicy denial can therefore
+identify the rejected endpoint without identifying which comparison failed.
+The compatibility appliance adds test-only `reason` rules so a failed matrix
+case can attribute the denial without weakening enforcement.
+
+The reason rules are Rego source, not a GenPolicy settings option and not a
+runtime-rs or Agent configuration flag. During the appliance image build,
+`tests/policy/create-sandbox-reasons.rego.inc` is appended to the repository-tip
+`rules.rego`. During policy generation, that combined module is supplied to
+GenPolicy through:
+
+```text
+--rego-rules-path /opt/genpolicy/policy/rules.rego
+```
+
+GenPolicy embeds the resulting rules module in each generated workload policy.
+The same reason rules are therefore used by every appliance profile; profile
+environment files and profile JSON settings patches do not enable or alter
+them.
+
+The rules add only explanatory entries to the policy's existing `errors`
+collection. They do not define an allow result, bypass a check, mutate policy
+data, or change the request. Current attribution covers:
+
+- non-empty guest hook paths;
+- unexpected kernel modules;
+- sandbox PID namespace mode;
+- unmatched or duplicate sandbox storage entries;
+- the field category of a sandbox-storage mismatch; and
+- failure to match a container's root path, mounts, or storages.
+
+Reason text crosses the guest boundary in the denied RPC status. The rules keep
+it concise by reporting rule categories, field names, counts, or indexes.
+Detailed request values remain available in the raw hybrid-vsock captures when
+deeper debugging is required.
+
+## Capture
+
+Cloud Hypervisor, Firecracker, and OpenVMM expose the host side of the Agent
+channel as a Unix socket. The capture supervisor watches the Kata runtime
+directories, renames a newly created backend socket, and binds a relay at the
+original pathname before the shim connects. It forwards both directions
+without decoding or modifying bytes.
+
+Each connection produces:
+
+- `shim-to-agent.bin`;
+- `agent-to-shim.bin`;
+- connection timing and socket metadata.
+
+The raw streams include the hybrid-vsock `CONNECT` handshake followed by ttRPC
+frames. They may also contain the synthetic Secret or ConfigMap fixture
+payloads sent through `CopyFile`. The `agent-rpcs` directory is mode `0700` to
+keep each run's diagnostic artifacts isolated.
+
+The initial implementation supports hybrid-vsock configurations only. Native
+QEMU AF_VSOCK does not expose a Unix pathname that this relay can interpose.
+Failure to capture at least one connection is an infrastructure failure.
+
+## Verdict
+
+The harness accepts an already annotated `/input/workload.yaml`. It rejects a
+workload without the `io.katacontainers.config.hypervisor.cc_init_data`
+annotation so a successful boot cannot accidentally test the guest's baked-in
+default policy. It also rejects a Kata configuration whose selected hypervisor
+does not enable the `cc_init_data` annotation; accepting such a configuration
+would cause the runtime to discard the supplied policy before VM creation.
+
+The result is:
+
+- `compatible` when every expected Pod reaches `Ready` and every operation
+  declared by the fixture completes, including any exec, graceful stop,
+  finalizer removal, and Pod deletion checks;
+- `policy-incompatible` when the workload fails and the collected logs contain
+  a policy denial;
+- `infrastructure-failure` for all other failures.
+
+All retries remain in the raw stream. The primary evidence is never
+deduplicated.
+
+## Isolation
+
+Run the harness container only inside a disposable L1 VM with nested KVM. The
+image is a normal OCI image; privilege is granted when the container is
+started. The container requires `--privileged`, `--cgroupns=host`, cgroup v2,
+mount propagation, and access to `/dev/kvm` because it acts as a complete
+nested Kubernetes node rather than as an ordinary workload container. These
+permissions allow it to:
+
+- start containerd, kubelet, etcd, and the Kubernetes API server;
+- create and manage cgroups and mount namespaces;
+- configure CNI networking, network namespaces, routes, and iptables rules;
+- start udev and manage block and device-mapper nodes for EROFS dm-verity;
+- launch nested Kata virtual machines through the host KVM device.
+
+Depending on the selected VMM, `/dev/net/tun` and `/dev/vhost-vsock` must also
+be passed through. The privileged container can modify kernel-visible state in
+its L1 host, so this is a test-only deployment model. It must not run directly
+on a developer workstation, shared host, or production node.
+
+The appliance supports EROFS dm-verity and digest-pinned guest pull. Both paths
+boot the same monolithic dm-verity-protected guest image containing the strict
+Agent, Confidential Data Hub, and pause bundle. Profile behavior comes from
+containerd, GenPolicy, and a temporary derived Kata configuration; the
+caller-supplied configuration and runtime-rs source are not modified.
+
+The EROFS profiles use containerd's EROFS snapshotter with dm-verity enabled.
+Container image content is converted to verified block-backed root filesystems
+before the nested shim starts the guest. The selected Kata configuration must
+set `shared_fs = "none"`; this matches confidential-runtime configurations and
+prevents host filesystem sharing from becoming either a policy artifact or a
+content channel. The EROFS snapshotter's writable layer size is zero, leaving
+the Agent to create an ephemeral upper under `/run` instead of presenting an
+additional, unverified host-backed ext4 storage.
+
+The guest-pull profiles use the native snapshotter for host-side CRI metadata,
+then enable runtime-rs `force_guest_pull` in the derived test configuration.
+Runtime-rs sends an `image_guest_pull` storage source to the Agent. The policy
+requires its digest to equal the digest recorded by GenPolicy in
+`io.kubernetes.cri.image-name`. The Agent delegates the approved reference to
+CDH, whose image-rs/rust-oci-client path verifies the downloaded manifest bytes
+against that digest before unpacking.
+
+The local TLS registry binds the CNI gateway `10.188.0.1:5000`, which is
+reachable from the nested guest without external DNS. The appliance image
+contains a dedicated registry certificate with that IP address as a subject
+alternative name, and the harness embeds its CA certificate in the workload's
+CDH init-data configuration. Policy generation rewrites only the synthetic
+fixture registry authority to that address. Runtime publication pushes the
+matching deterministic OCI manifests, then the appliance drops forwarded IPv4
+and IPv6 traffic so guest workloads cannot use the node as an external-network
+gateway. The `10.188.0.0/16` subnet deliberately avoids Podman's default
+`10.88.0.0/16` network, which would otherwise make registry routing ambiguous
+inside the privileged appliance container.
+
+### EROFS profile settings override and encrypted-emptyDir coverage gap
+
+The Kata configuration used for the current results sets `shared_fs = "none"`
+but omits the runtime-rs `emptydir_mode` setting. Its default is `shared-fs`;
+because filesystem sharing is unavailable, runtime-rs falls back to
+representing a disk-backed Kubernetes `emptyDir` as guest-local Agent storage
+with `driver`, `source`, `fstype`, and mount type set to `local`. GenPolicy's
+default `block-encrypted` emptyDir template instead describes an encrypted ext4
+block device. Without an adjustment, the generated policy rejects the
+runtime-rs `CreateContainerRequest` because those declarations differ.
+
+Both EROFS profiles therefore select a shared JSON Patch settings drop-in.
+During policy generation, `generate_policy.sh` copies the repository-tip
+GenPolicy settings to an output-local directory and installs the patch as
+`genpolicy-settings.d/20-profile.json`. GenPolicy applies that drop-in through
+`--json-settings-path` and emits a policy whose disk-backed emptyDir declaration
+matches runtime-rs's existing guest-local request:
+
+```text
+driver = local
+source = local
+fstype = local
+mount type = local
+options = mode=0777
+shared = false
+```
+
+This is exclusively a policy-generation override. It does not rebuild or
+reconfigure runtime-rs, change Cargo features or build flags, enable an
+experimental feature, alter `force_guest_pull`, or modify the runtime binary.
+The runtime-rs request remains unchanged; only GenPolicy's declaration of the
+expected request is adjusted. No GenPolicy source change or new emptyDir mode
+is required.
+
+This workaround means the current eight-fixture positive matrix validates policy
+compatibility for the guest-local fallback; it does not establish compatibility
+for runtime-rs's `block-encrypted` path. That path creates and hot-plugs a
+host-backed sparse disk, then requests Agent-side LUKS2/dm-crypt setup through
+Confidential Data Hub. The harness accepts a caller-supplied Kata installation
+and does not currently verify the required Agent build features, guest tools,
+CDH availability, or effective dm-crypt mapping. It must not claim encrypted
+disk-backed `emptyDir` coverage until those prerequisites and the resulting
+Agent request are validated end to end.
+
+The positive matrix also excludes Kubernetes termination-message files.
+GenPolicy can authorize the `/dev/termination-log` mount and can set
+`request_defaults.GetDiagnosticDataRequest` to `true`. With `shared_fs =
+"none"`, however, runtime-rs must retrieve the guest file through
+`GetDiagnosticData`, and strict Agent builds reject that RPC before policy
+evaluation. The separate `termination-log-e2e` target reproduces this gap while
+still completing container stop and Pod deletion. Other runtime operations are
+covered by the positive `runtime-operations-workload.yaml` fixture.
+
+The positive service-account fixture uses `serviceAccountName: default`.
+GenPolicy currently reads the value used for
+`fieldRef: spec.serviceAccountName` from its container representation instead
+of the Pod spec, where the field is defined. A production Pod using a custom
+service account therefore gets `SERVICE_ACCOUNT_NAME=default` in policy while
+Kubernetes injects the custom name at runtime. The separate
+`custom-service-account-e2e` target preserves that policy-denial reproducer
+without making it part of the positive matrix.
+
+The runtime-rs multi-layer EROFS implementation consolidates image layers into
+a GPT-partitioned VMDK. Cloud Hypervisor configurations therefore require a
+binary with flat VMDK support from cloud-hypervisor/cloud-hypervisor#8599; the
+repository-pinned v51.1 binary is rejected during harness preflight.

--- a/src/tools/genpolicy/nested-policy-compat/Dockerfile
+++ b/src/tools/genpolicy/nested-policy-compat/Dockerfile
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG KUBERNETES_VERSION=v1.36.3
+ARG CONTAINERD_VERSION=v2.3.5
+ARG RUNC_VERSION=v1.2.8
+ARG ETCD_VERSION=v3.5.21
+ARG CNI_PLUGINS_VERSION=v1.7.1
+
+FROM registry.k8s.io/pause:3.10 AS pause
+FROM busybox:1.36.1 AS busybox
+FROM docker.io/library/registry:2.8.3 AS registry
+
+FROM debian:bookworm-slim AS component-downloader
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM component-downloader AS kubernetes-binaries
+ARG TARGETARCH=amd64
+ARG KUBERNETES_VERSION
+RUN set -eux; \
+    mkdir -p /out; \
+    for binary in kube-apiserver kubelet kubectl; do \
+        curl -fsSLo "/out/${binary}" \
+            "https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/${TARGETARCH}/${binary}"; \
+        chmod 0755 "/out/${binary}"; \
+    done
+
+FROM component-downloader AS runtime-binaries
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG TARGETARCH=amd64
+ARG CONTAINERD_VERSION
+ARG RUNC_VERSION
+ARG ETCD_VERSION
+RUN set -eux; \
+    mkdir -p /out /tmp/containerd; \
+    curl -fsSL \
+        "https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-${TARGETARCH}.tar.gz" \
+        | tar -xz --strip-components=1 -C /out \
+            "etcd-${ETCD_VERSION}-linux-${TARGETARCH}/etcd" \
+            "etcd-${ETCD_VERSION}-linux-${TARGETARCH}/etcdctl"; \
+    curl -fsSL \
+        "https://github.com/containerd/containerd/releases/download/${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION#v}-linux-${TARGETARCH}.tar.gz" \
+        | tar -xz -C /tmp/containerd; \
+    install -m 0755 \
+        /tmp/containerd/bin/containerd \
+        /tmp/containerd/bin/containerd-shim-runc-v2 \
+        /tmp/containerd/bin/ctr \
+        /out/; \
+    curl -fsSLo /out/runc.real \
+        "https://github.com/opencontainers/runc/releases/download/${RUNC_VERSION}/runc.${TARGETARCH}"; \
+    chmod 0755 /out/runc.real
+
+FROM component-downloader AS cni-binaries
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG TARGETARCH=amd64
+ARG CNI_PLUGINS_VERSION
+RUN set -eux; \
+    mkdir -p /out /tmp/cni; \
+    curl -fsSL \
+        "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${TARGETARCH}-${CNI_PLUGINS_VERSION}.tgz" \
+        | tar -xz -C /tmp/cni; \
+    install -m 0755 \
+        /tmp/cni/bridge \
+        /tmp/cni/host-local \
+        /tmp/cni/loopback \
+        /tmp/cni/portmap \
+        /out/
+
+FROM debian:bookworm-slim AS erofs-utils-builder
+ARG EROFS_UTILS_VERSION=1.8.4
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        autoconf automake build-essential ca-certificates curl liblz4-dev \
+        libtool pkg-config uuid-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    curl -fsSLo /tmp/erofs-utils.tar.gz \
+        "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-${EROFS_UTILS_VERSION}.tar.gz"; \
+    tar -xzf /tmp/erofs-utils.tar.gz -C /tmp; \
+    cd "/tmp/erofs-utils-${EROFS_UTILS_VERSION}"; \
+    ./autogen.sh; \
+    ./configure --enable-lz4; \
+    make -j"$(nproc)"; \
+    make install
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates conntrack cryptsetup-bin curl dmsetup iproute2 iptables \
+        kmod liblz4-1 libuuid1 openssl python3 python3-yaml tar udev \
+        util-linux zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=kubernetes-binaries /out/ /usr/local/bin/
+COPY --from=runtime-binaries /out/ /usr/local/bin/
+COPY --from=cni-binaries /out/ /opt/cni/bin/
+COPY --from=registry /bin/registry /usr/local/bin/registry
+COPY --from=erofs-utils-builder /usr/local/bin/mkfs.erofs /usr/local/bin/mkfs.erofs
+COPY src/tools/genpolicy/nested-policy-compat/build/genpolicy /usr/local/bin/genpolicy
+COPY --from=pause /pause /opt/genpolicy/rootfs/pause/pause
+COPY --from=busybox / /opt/genpolicy/rootfs/busybox
+RUN mkdir -p /opt/genpolicy/rootfs/busybox/work
+
+COPY src/tools/genpolicy/nested-policy-compat/appliance /opt/genpolicy/appliance
+COPY src/tools/genpolicy/rules.rego /opt/genpolicy/policy/rules.rego
+COPY src/tools/genpolicy/nested-policy-compat/tests/policy/create-sandbox-reasons.rego.inc \
+    /opt/genpolicy/policy/create-sandbox-reasons.rego.inc
+COPY src/tools/genpolicy/genpolicy-settings.json \
+    /opt/genpolicy/policy/settings/genpolicy-settings.json
+COPY src/tools/genpolicy/nested-policy-compat/appliance/policy-settings.d \
+    /opt/genpolicy/policy/settings/genpolicy-settings.d
+COPY src/tools/genpolicy/nested-policy-compat/config \
+    /opt/nested-policy-compat/config
+COPY src/tools/genpolicy/nested-policy-compat/scripts \
+    /opt/nested-policy-compat/scripts
+
+RUN set -eux; \
+    mkdir -p /opt/genpolicy/registry-tls; \
+    openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+        -subj "/CN=nested-policy-compat-registry" \
+        -addext "basicConstraints=critical,CA:FALSE" \
+        -addext "keyUsage=critical,digitalSignature,keyEncipherment" \
+        -addext "extendedKeyUsage=serverAuth" \
+        -addext "subjectAltName=IP:10.188.0.1" \
+        -keyout /opt/genpolicy/registry-tls/registry.key \
+        -out /opt/genpolicy/registry-tls/registry.crt; \
+    printf '\n' >>/opt/genpolicy/policy/rules.rego; \
+    cat /opt/genpolicy/policy/create-sandbox-reasons.rego.inc \
+        >>/opt/genpolicy/policy/rules.rego; \
+    chmod 0755 /opt/genpolicy/appliance/scripts/*.sh \
+        /opt/nested-policy-compat/scripts/*.sh \
+        /opt/nested-policy-compat/scripts/*.py; \
+    mkdir -p /opt/genpolicy/images; \
+    python3 /opt/genpolicy/appliance/scripts/make_oci_image.py \
+        --rootfs /opt/genpolicy/rootfs/pause \
+        --reference genpolicy.local:5000/pause:3.10 \
+        --entrypoint '["/pause"]' \
+        --user 65535:65535 \
+        --output /opt/genpolicy/images/pause.tar; \
+    python3 /opt/genpolicy/appliance/scripts/make_oci_image.py \
+        --rootfs /opt/genpolicy/rootfs/busybox \
+        --reference genpolicy.local:5000/busybox:1.36.1 \
+        --entrypoint '["/bin/busybox","sleep","3600"]' \
+        --output /opt/genpolicy/images/busybox.tar; \
+    rm -rf /opt/genpolicy/rootfs
+
+ARG PROFILE_NAME=k8s-1.36-containerd-2.3-erofs-dmverity
+ARG INPUT_FINGERPRINT=unknown
+LABEL io.katacontainers.nested-policy-compat.input-fingerprint="${INPUT_FINGERPRINT}"
+ENV PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV GENPOLICY_APPLIANCE_ROOT=/opt/genpolicy/appliance
+ENV GENPOLICY_PROFILE_NAME=${PROFILE_NAME}
+ENV NESTED_POLICY_COMPAT_ROOT=/opt/nested-policy-compat
+
+ENTRYPOINT ["/opt/nested-policy-compat/scripts/entrypoint.sh"]

--- a/src/tools/genpolicy/nested-policy-compat/Makefile
+++ b/src/tools/genpolicy/nested-policy-compat/Makefile
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SHELL := /bin/bash
+
+REPO_ROOT := $(abspath ../../../..)
+PROFILE ?= k8s-1.36-containerd-2.3-erofs-dmverity
+IMAGE ?= nested-policy-compat:$(PROFILE)
+CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+GENPOLICY_TARGET ?= x86_64-unknown-linux-musl
+GENPOLICY_BIN ?= $(REPO_ROOT)/target/$(GENPOLICY_TARGET)/release/genpolicy
+GENPOLICY_STAGE := $(CURDIR)/build/genpolicy
+
+PROFILE_FILE := $(CURDIR)/appliance/profiles/$(PROFILE).env
+ifeq ($(wildcard $(PROFILE_FILE)),)
+$(error unknown PROFILE "$(PROFILE)")
+endif
+include $(PROFILE_FILE)
+
+.PHONY: image ensure-image prepare-kata-stack verify-kata-provenance ensure-kata-provenance validate genpolicy-bin fixture-e2e ci-fixture-e2e runtime-operations-e2e termination-log-e2e custom-service-account-e2e clean
+
+image: $(GENPOLICY_STAGE)
+	@test -n "$(CONTAINER_ENGINE)" || { echo "docker or podman is required"; exit 1; }
+	@input_fingerprint="$$(./scripts/image_input_fingerprint.sh \
+		"$(REPO_ROOT)" "$(PROFILE_FILE)" "$(KATA_ROOT)" "$(KATA_CONFIG)")"; \
+	$(CONTAINER_ENGINE) build \
+		--file $(CURDIR)/Dockerfile \
+		--build-arg PROFILE_NAME=$(PROFILE_NAME) \
+		--build-arg KUBERNETES_VERSION=$(KUBERNETES_VERSION) \
+		--build-arg CONTAINERD_VERSION=$(CONTAINERD_VERSION) \
+		--build-arg RUNC_VERSION=$(RUNC_VERSION) \
+		--build-arg ETCD_VERSION=$(ETCD_VERSION) \
+		--build-arg CNI_PLUGINS_VERSION=$(CNI_PLUGINS_VERSION) \
+		--build-arg INPUT_FINGERPRINT="$${input_fingerprint}" \
+		--tag $(IMAGE) \
+		$(REPO_ROOT)
+
+ensure-image:
+	@test -n "$(CONTAINER_ENGINE)" || { echo "docker or podman is required"; exit 1; }
+	@expected="$$(./scripts/image_input_fingerprint.sh \
+		"$(REPO_ROOT)" "$(PROFILE_FILE)" "$(KATA_ROOT)" "$(KATA_CONFIG)")"; \
+	actual="$$( \
+		$(CONTAINER_ENGINE) image inspect \
+			--format '{{ index .Config.Labels "io.katacontainers.nested-policy-compat.input-fingerprint" }}' \
+			"$(IMAGE)" 2>/dev/null || true \
+	)"; \
+	if [[ "$${actual}" == "$${expected}" ]]; then \
+		echo "reusing current appliance image: $(IMAGE)"; \
+	else \
+		if [[ -n "$${actual}" ]]; then \
+			echo "appliance inputs changed; rebuilding $(IMAGE)"; \
+		else \
+			echo "appliance image missing or unlabelled; building $(IMAGE)"; \
+		fi; \
+		$(MAKE) image; \
+	fi
+
+prepare-kata-stack:
+	./scripts/rebuild_kata_stack.sh \
+		"$(REPO_ROOT)" "$(KATA_ROOT)" "$(KATA_CONFIG)" "$(CONTAINER_ENGINE)"
+	$(MAKE) verify-kata-provenance
+
+verify-kata-provenance:
+	./scripts/verify_kata_source_provenance.sh \
+		"$(REPO_ROOT)" "$(KATA_ROOT)" "$(KATA_CONFIG)"
+
+ensure-kata-provenance:
+	./scripts/ensure_kata_source_provenance.sh \
+		"$(REPO_ROOT)" "$(KATA_ROOT)" "$(KATA_CONFIG)" "$(CONTAINER_ENGINE)"
+
+validate:
+	./tests/validate.sh
+
+genpolicy-bin:
+	$(MAKE) --always-make \
+		--directory $(REPO_ROOT)/src/tools/genpolicy \
+		src/version.rs
+	cargo build --locked --release --package genpolicy \
+		--target $(GENPOLICY_TARGET) \
+		--manifest-path $(REPO_ROOT)/Cargo.toml
+
+$(GENPOLICY_STAGE): genpolicy-bin
+	mkdir -p $(dir $@)
+	cp $(GENPOLICY_BIN) $@
+
+define run_fixture_e2e
+	CONTAINER_ENGINE="$(CONTAINER_ENGINE)" \
+		NESTED_IMAGE="$(IMAGE)" \
+		KATA_ROOT="$(KATA_ROOT)" \
+		KATA_CONFIG="$(KATA_CONFIG)" \
+		FIXTURES="$(FIXTURES)" \
+		POD_READY_TIMEOUT="$(POD_READY_TIMEOUT)" \
+		OUTPUT_ROOT="$(OUTPUT_ROOT)" \
+		./tests/fixture-matrix-e2e.sh
+endef
+
+fixture-e2e: ensure-kata-provenance ensure-image
+	$(run_fixture_e2e)
+
+ci-fixture-e2e: verify-kata-provenance ensure-image
+	$(run_fixture_e2e)
+
+runtime-operations-e2e: FIXTURES := runtime-operations-workload.yaml
+runtime-operations-e2e: fixture-e2e
+
+termination-log-e2e: FIXTURES := termination-log-workload.yaml
+termination-log-e2e: fixture-e2e
+
+custom-service-account-e2e: FIXTURES := custom-service-account-workload.yaml
+custom-service-account-e2e: fixture-e2e
+
+clean:
+	rm -rf bin build

--- a/src/tools/genpolicy/nested-policy-compat/Makefile
+++ b/src/tools/genpolicy/nested-policy-compat/Makefile
@@ -8,6 +8,13 @@ REPO_ROOT := $(abspath ../../../..)
 PROFILE ?= k8s-1.36-containerd-2.3-erofs-dmverity
 IMAGE ?= nested-policy-compat:$(PROFILE)
 CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+KATA_ROOT ?= /opt/kata
+KATA_CONFIG ?= $(KATA_ROOT)/share/defaults/kata-containers/runtime-rs/configuration-nested-policy-compat.toml
+KATA_ARTIFACT_IMAGE ?= quay.io/kata-containers/kata-deploy-ci:kata-containers-latest
+KATA_ARTIFACT_DIR ?=
+FLAT_VMDK_CLOUD_HYPERVISOR_REPO ?= https://github.com/cloud-hypervisor/cloud-hypervisor.git
+FLAT_VMDK_CLOUD_HYPERVISOR_COMMIT ?= f50661fffd0fef38ddfec88c5fafa93f9779149a
+APPROVE_KATA_INSTALL ?= no
 GENPOLICY_TARGET ?= x86_64-unknown-linux-musl
 GENPOLICY_BIN ?= $(REPO_ROOT)/target/$(GENPOLICY_TARGET)/release/genpolicy
 GENPOLICY_STAGE := $(CURDIR)/build/genpolicy
@@ -18,7 +25,7 @@ $(error unknown PROFILE "$(PROFILE)")
 endif
 include $(PROFILE_FILE)
 
-.PHONY: image ensure-image prepare-kata-stack verify-kata-provenance ensure-kata-provenance validate genpolicy-bin fixture-e2e ci-fixture-e2e runtime-operations-e2e termination-log-e2e custom-service-account-e2e clean
+.PHONY: image ensure-image ensure-host-environment prepare-kata-stack verify-kata-provenance ensure-kata-provenance validate genpolicy-bin fixture-e2e ci-fixture-e2e runtime-operations-e2e termination-log-e2e custom-service-account-e2e clean
 
 image: $(GENPOLICY_STAGE)
 	@test -n "$(CONTAINER_ENGINE)" || { echo "docker or podman is required"; exit 1; }
@@ -55,6 +62,16 @@ ensure-image:
 		fi; \
 		$(MAKE) image; \
 	fi
+
+ensure-host-environment:
+	APPROVE_KATA_INSTALL="$(APPROVE_KATA_INSTALL)" \
+		KATA_ARTIFACT_DIR="$(KATA_ARTIFACT_DIR)" \
+		KATA_ARTIFACT_IMAGE="$(KATA_ARTIFACT_IMAGE)" \
+		FLAT_VMDK_CLOUD_HYPERVISOR_REPO="$(FLAT_VMDK_CLOUD_HYPERVISOR_REPO)" \
+		FLAT_VMDK_CLOUD_HYPERVISOR_COMMIT="$(FLAT_VMDK_CLOUD_HYPERVISOR_COMMIT)" \
+		ROOTFS_MODE="$(ROOTFS_MODE)" \
+		./scripts/ensure_host_environment.sh \
+		"$(KATA_ROOT)" "$(KATA_CONFIG)" "$(CONTAINER_ENGINE)"
 
 prepare-kata-stack:
 	./scripts/rebuild_kata_stack.sh \
@@ -95,10 +112,11 @@ define run_fixture_e2e
 		./tests/fixture-matrix-e2e.sh
 endef
 
-fixture-e2e: ensure-kata-provenance ensure-image
+fixture-e2e: ensure-host-environment ensure-kata-provenance ensure-image
 	$(run_fixture_e2e)
 
-ci-fixture-e2e: verify-kata-provenance ensure-image
+ci-fixture-e2e: APPROVE_KATA_INSTALL := no
+ci-fixture-e2e: ensure-host-environment verify-kata-provenance ensure-image
 	$(run_fixture_e2e)
 
 runtime-operations-e2e: FIXTURES := runtime-operations-workload.yaml

--- a/src/tools/genpolicy/nested-policy-compat/README.md
+++ b/src/tools/genpolicy/nested-policy-compat/README.md
@@ -15,20 +15,74 @@ Run the harness on a disposable Linux x86-64 L1 VM with:
   cgroup namespace;
 - GNU Make, Bash, Python 3, and a Rust/Cargo toolchain capable of building the
   repository's `x86_64-unknown-linux-musl` GenPolicy target;
-- a Kata installation supplied through `KATA_ROOT` or mounted at `/opt/kata`.
+- a Kata installation supplied through `KATA_ROOT` or approval to install one.
 
-The supplied installation provides the VMM, guest kernel, and initial runtime
+`fixture-e2e` and `ci-fixture-e2e` check these prerequisites before building or
+running a fixture.
+If the Kata installation is missing, it stops and prints the missing paths and
+the exact opt-in command. It does not pull images or write host files without
+approval. Set `APPROVE_KATA_INSTALL=yes` to authorize pulling
+`quay.io/kata-containers/kata-deploy-ci:kata-containers-latest` and installing
+the packaged Cloud Hypervisor, guest kernel, runtime-rs shim, confidential
+image, root hash, and a dedicated compatibility configuration under
+`KATA_ROOT`. Override the source with `KATA_ARTIFACT_IMAGE`.
+CI always forces `APPROVE_KATA_INSTALL=no`; artifact installation must be a
+separate, explicit preparation step.
+
+CI should set `KATA_ARTIFACT_DIR` to a directory of tarballs built from the
+exact pull-request merge commit instead of pulling the default image. Required
+filenames are `kata-static-cloud-hypervisor.tar.zst`,
+`kata-static-kernel.tar.zst`, `kata-static-shim-v2-rust.tar.zst`, and
+`kata-static-rootfs-image-confidential.tar.zst`.
+
+The default locations are:
+
+```text
+KATA_ROOT=/opt/kata
+KATA_CONFIG=/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-nested-policy-compat.toml
+```
+
+Writing `/opt/kata` commonly requires running the command as root. To avoid
+elevation, select a writable directory and pass both `KATA_ROOT` and
+`KATA_CONFIG`; the Kata paths inside the generated configuration remain
+`/opt/kata` because the harness mounts the selected host directory there.
+
+For example, after reviewing the image and destination:
+
+```bash
+make -C src/tools/genpolicy/nested-policy-compat fixture-e2e \
+  PROFILE=k8s-1.36-containerd-2.3-guest-pull \
+  APPROVE_KATA_INSTALL=yes \
+  KATA_ROOT="$HOME/.local/lib/kata-nested-policy-compat" \
+  KATA_CONFIG="$HOME/.local/lib/kata-nested-policy-compat/share/defaults/kata-containers/runtime-rs/configuration-nested-policy-compat.toml" \
+  OUTPUT_ROOT="$PWD/target/nested-policy-compat-fixtures"
+```
+
+The EROFS dm-verity profiles additionally require a Cloud Hypervisor build
+containing flat-VMDK support. If the packaged VMM lacks it, approved bootstrap
+builds Cloud Hypervisor PR 8599 from the pinned commit
+`f50661fffd0fef38ddfec88c5fafa93f9779149a` and installs the resulting binary.
+Override `FLAT_VMDK_CLOUD_HYPERVISOR_REPO` and
+`FLAT_VMDK_CLOUD_HYPERVISOR_COMMIT` together to select another audited source.
+The build requires `build-essential`, `m4`, `bison`, `flex`, `uuid-dev`,
+`qemu-utils`, `musl-tools`, `pkg-config`, `kmod`, Git, and Rust/Cargo. The
+running host kernel must also provide EROFS filesystem support; approved
+bootstrap loads the `erofs` module and fails clearly if the kernel does not
+provide it. Guest-pull profiles do not require flat-VMDK or host EROFS support.
+
+The supplied or approved installation provides the VMM, guest kernel, and initial runtime
 configuration. The harness builds GenPolicy from the checkout. Before running
-fixtures, it also reads the commits embedded in the installed runtime-rs shim
-and guest Agent and compares their component source trees with the checkout,
-including local tracked and untracked changes. If they differ, it reuses the repository's Kata local-build pipeline with
-component caching disabled, builds a runtime-rs shim, a base image, and a
-monolithic confidential image containing the strict policy-enabled Agent,
-Confidential Data Hub, and pause bundle, installs them under `KATA_ROOT`,
-records source-and-artifact fingerprints, and verifies them again. All
-compatibility profiles boot that same monolithic image so profile comparisons
-do not also compare different guest environments. `KATA_ROOT` must therefore
-be writable when a rebuild is needed.
+fixtures, it verifies a rebuild-generated marker that binds the installed
+runtime-rs shim and monolithic confidential image to the current runtime-rs and
+strict-Agent build inputs, including local tracked and untracked changes. If
+they differ, it reuses the repository's Kata local-build pipeline with
+component caching disabled, builds the shim and monolithic confidential image
+containing the strict policy-enabled Agent, Confidential Data Hub, and pause
+bundle, installs them under `KATA_ROOT`, records source-and-artifact
+fingerprints, and verifies them again. All compatibility profiles boot that
+same monolithic image so profile comparisons do not also compare different
+guest environments. `KATA_ROOT` must therefore be writable when a rebuild is
+needed.
 
 These Cloud Hypervisor profiles are intentionally non-confidential development
 VMs. Their rebuilt Agent enables `allow-unattested-initdata` so the host can
@@ -38,9 +92,10 @@ unattested init-data still makes this a development-only configuration. Do not
 use this appliance build mode for a confidential production guest.
 
 The Kata installation must contain the runtime-rs
-`containerd-shim-kata-v2`, the selected VMM, guest kernel and image, and a
-strict policy-enabled Agent in that guest image. For the retained Cloud
-Hypervisor profiles, the VMM must include flat-VMDK support from
+`containerd-shim-kata-v2`, the selected VMM and guest kernel, the monolithic
+confidential image, and its dm-verity root hash. The runtime configuration's
+image setting is replaced with that confidential image for the test. For the
+retained Cloud Hypervisor profiles, the VMM must include flat-VMDK support from
 [cloud-hypervisor/cloud-hypervisor#8599](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8599).
 The selected runtime configuration must enable the `cc_init_data` annotation
 and use `shared_fs = "none"`.
@@ -108,15 +163,29 @@ separate cache/artifact locations: Kata build artifacts can be reused after
 `verify-kata-provenance`, while test results should always be uploaded from a
 fresh output directory.
 
+The reusable `.github/workflows/run-nested-policy-compat.yaml` implements this
+producer/consumer split. It starts from the exact PR-built Cloud Hypervisor,
+kernel, runtime-rs, and confidential-image tarballs. If that Cloud Hypervisor
+lacks flat-VMDK support, the approved preparation step replaces it with the
+pinned PR 8599 build described above. It then prepares one strict compatibility
+bundle and runs all retained profiles as verify-only matrix jobs. Results are
+uploaded even when a profile fails.
+
+The workflow is available as an opt-in CI pilot through the
+`nested-policy-compat` input to `.github/workflows/ci.yaml`; its default is
+`false`. Enable it on a trusted ephemeral nested-KVM runner before adding its
+profile jobs to `tools/testing/gatekeeper/required-tests.yaml`. Do not execute
+untrusted pull-request code on a persistent privileged runner.
+
 ## Inputs
 
 - `/input/workload.yaml`: digest-pinned workload carrying an externally
   generated `io.katacontainers.config.hypervisor.cc_init_data` annotation.
-- `/input/images/*.tar`: optional OCI or Docker archives, using the same format
-  as the base appliance.
+- `/input/images/*.tar`: optional OCI image-layout archives, using the same
+  format as the base appliance.
 - `/opt/kata`: an unmodified Kata installation containing
-  `containerd-shim-kata-v2`, the selected VMM, guest kernel/image, Agent, and
-  runtime-rs configuration.
+  `containerd-shim-kata-v2`, the selected VMM and guest kernel, the monolithic
+  confidential image and root hash, and the runtime-rs configuration.
 
 The default Kata configuration path is:
 

--- a/src/tools/genpolicy/nested-policy-compat/README.md
+++ b/src/tools/genpolicy/nested-policy-compat/README.md
@@ -1,0 +1,357 @@
+# Nested policy compatibility harness
+
+This harness tests an externally generated Kata policy against the real Agent
+requests produced by a pinned Kubernetes/containerd profile. It runs an
+unmodified Kata shim and policy-enabled Agent through nested virtualization.
+
+## Host prerequisites
+
+Run the harness on a disposable Linux x86-64 L1 VM with:
+
+- nested virtualization enabled and `/dev/kvm` available;
+- `/dev/net/tun`, plus `/dev/vhost-vsock` only when the selected VMM
+  configuration uses native vhost-vsock;
+- Podman or Docker, with permission to run a privileged container in the host
+  cgroup namespace;
+- GNU Make, Bash, Python 3, and a Rust/Cargo toolchain capable of building the
+  repository's `x86_64-unknown-linux-musl` GenPolicy target;
+- a Kata installation supplied through `KATA_ROOT` or mounted at `/opt/kata`.
+
+The supplied installation provides the VMM, guest kernel, and initial runtime
+configuration. The harness builds GenPolicy from the checkout. Before running
+fixtures, it also reads the commits embedded in the installed runtime-rs shim
+and guest Agent and compares their component source trees with the checkout,
+including local tracked and untracked changes. If they differ, it reuses the repository's Kata local-build pipeline with
+component caching disabled, builds a runtime-rs shim, a base image, and a
+monolithic confidential image containing the strict policy-enabled Agent,
+Confidential Data Hub, and pause bundle, installs them under `KATA_ROOT`,
+records source-and-artifact fingerprints, and verifies them again. All
+compatibility profiles boot that same monolithic image so profile comparisons
+do not also compare different guest environments. `KATA_ROOT` must therefore
+be writable when a rebuild is needed.
+
+These Cloud Hypervisor profiles are intentionally non-confidential development
+VMs. Their rebuilt Agent enables `allow-unattested-initdata` so the host can
+deliver the generated test policy through init-data without a TEE launch
+measurement. The monolithic image is dm-verity protected, but accepting
+unattested init-data still makes this a development-only configuration. Do not
+use this appliance build mode for a confidential production guest.
+
+The Kata installation must contain the runtime-rs
+`containerd-shim-kata-v2`, the selected VMM, guest kernel and image, and a
+strict policy-enabled Agent in that guest image. For the retained Cloud
+Hypervisor profiles, the VMM must include flat-VMDK support from
+[cloud-hypervisor/cloud-hypervisor#8599](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8599).
+The selected runtime configuration must enable the `cc_init_data` annotation
+and use `shared_fs = "none"`.
+
+Kubernetes, containerd, etcd, runc, CNI plugins, EROFS tooling, and the fixture
+images do not need to be installed on the host; the appliance image downloads
+or embeds them. The host also does not need an existing Kubernetes cluster.
+
+## Build
+
+Build the selected profile directly from this branch:
+
+```bash
+make -C src/tools/genpolicy/nested-policy-compat \
+  PROFILE=k8s-1.36-containerd-2.3-erofs-dmverity image
+```
+
+The image downloads the Kubernetes, containerd, etcd, runc, and CNI versions
+declared by the selected profile. The build also compiles GenPolicy from the
+checked-out source tree and embeds that binary together with this tree's
+`rules.rego` and `genpolicy-settings.json`. No appliance branch or prebuilt
+appliance image is an input. The other Kata components come from the separately
+prepared `KATA_ROOT`; they are not compiled by this target.
+
+All profiles use the shared `Dockerfile`; the Makefile passes the selected
+profile's version pins as Docker build arguments and stores the resulting tag
+in the local Podman or Docker image store. See `appliance/README.md` for the
+directory layout, build flow, image tags, and storage details.
+
+For compatibility tests, the image appends
+`tests/policy/create-sandbox-reasons.rego.inc` to the selected `rules.rego`.
+These test-only rules add denial attribution for sandbox guest hooks, kernel
+modules, PID namespace mode, and storage matching. This is a GenPolicy
+rules-file input (`--rego-rules-path`/`-p`), not a settings option.
+
+## CI/CD execution contract
+
+The build, provenance, and test phases are separate so a Kata CI workflow can
+cache or transfer artifacts without weakening the source check:
+
+```bash
+# Build and install checkout-derived shim and strict-Agent guest image.
+make -C src/tools/genpolicy/nested-policy-compat prepare-kata-stack \
+  KATA_ROOT=/path/to/writable/opt/kata \
+  KATA_CONFIG=/path/to/configuration.toml
+
+# A later job may verify downloaded artifacts without rebuilding them.
+make -C src/tools/genpolicy/nested-policy-compat verify-kata-provenance \
+  KATA_ROOT=/path/to/opt/kata \
+  KATA_CONFIG=/path/to/configuration.toml
+
+# CI uses verify-only behavior, so stale artifacts fail rather than trigger a
+# hidden rebuild inside the test job.
+make -C src/tools/genpolicy/nested-policy-compat ci-fixture-e2e \
+  PROFILE=k8s-1.36-containerd-2.3-erofs-dmverity \
+  KATA_ROOT=/path/to/opt/kata \
+  KATA_CONFIG=/path/to/configuration.toml \
+  OUTPUT_ROOT=/path/to/test-results
+```
+
+Run `ci-fixture-e2e` once per retained profile as a CI matrix. The job requires
+an x86-64 runner with nested KVM and the same privileged-container devices
+listed above. Keep `KATA_ROOT`, the appliance image store, and result output in
+separate cache/artifact locations: Kata build artifacts can be reused after
+`verify-kata-provenance`, while test results should always be uploaded from a
+fresh output directory.
+
+## Inputs
+
+- `/input/workload.yaml`: digest-pinned workload carrying an externally
+  generated `io.katacontainers.config.hypervisor.cc_init_data` annotation.
+- `/input/images/*.tar`: optional OCI or Docker archives, using the same format
+  as the base appliance.
+- `/opt/kata`: an unmodified Kata installation containing
+  `containerd-shim-kata-v2`, the selected VMM, guest kernel/image, Agent, and
+  runtime-rs configuration.
+
+The default Kata configuration path is:
+
+```text
+/opt/kata/share/defaults/kata-containers/runtime-rs/configuration.toml
+```
+
+The selected hypervisor configuration must include `cc_init_data` in
+`enable_annotations`; otherwise the runtime drops the policy annotation and
+the Agent silently uses its baked-in default policy. The harness rejects that
+configuration instead of reporting a false compatibility result. Override the
+configuration path with `NESTED_KATA_CONFIG`.
+
+All profiles require `shared_fs = "none"` in the selected hypervisor
+configuration. The EROFS profiles use containerd 2.x's EROFS snapshotter to create
+verified block-backed root filesystems, so neither virtio-fs nor runtime-rs
+`force_guest_pull` is used. The harness rejects a mismatched Kata
+configuration rather than recording an unrelated sandbox-storage denial.
+The snapshotter uses `default_size = "0"` so the Agent creates the writable
+overlay upper under `/run`; only the read-only, dm-verity-bound image layers
+cross the policy boundary as block storage.
+
+The compatibility profiles are:
+
+| Profile | Kubernetes | containerd | Image path |
+|---|---:|---:|---|
+| `k8s-1.33-containerd-2.3-erofs-dmverity` | 1.33.13 | 2.3.5 | host EROFS/dm-verity |
+| `k8s-1.36-containerd-2.3-erofs-dmverity` | 1.36.3 | 2.3.5 | host EROFS/dm-verity |
+| `k8s-1.33-containerd-1.7-guest-pull` | 1.33.13 | 1.7.34 | guest pull |
+| `k8s-1.36-containerd-2.3-guest-pull` | 1.36.3 | 2.3.5 | guest pull |
+
+The older guest-pull profile exercises containerd's version-2 CRI
+configuration and OCI 1.1.0 requests. The current profile exercises
+containerd's split CRI plugins and OCI 1.3.0 requests. Guest-pull policy
+generation requires digest-qualified image references, enables
+`allow_guest_pull_images`, and retains `require_pinned_image_digests`.
+Runtime-rs receives `force_guest_pull` only in the derived guest-pull
+configuration; the caller's configuration and runtime-rs source are unchanged.
+
+At runtime, the appliance publishes only its deterministic fixture images on
+the TLS-protected, non-overlapping CNI gateway registry at
+`10.188.0.1:5000`, embeds its CA certificate in the workload's CDH init-data
+configuration, and blocks forwarded traffic.
+The integrity chain is:
+
+```text
+GenPolicy image annotation contains the expected manifest digest
+    -> Agent policy requires the image_guest_pull source digest to match
+    -> CDH/image-rs downloads the manifest
+    -> rust-oci-client hashes the downloaded manifest bytes and rejects mismatch
+```
+
+This verifies manifest identity, while EROFS dm-verity verifies the host-built
+read-only layer block devices. They are distinct integrity mechanisms.
+The profile maps the existing disk-backed emptyDir policy template to the
+runtime-rs guest-local storage request without changing GenPolicy itself.
+Cloud Hypervisor must include flat VMDK support from
+[cloud-hypervisor/cloud-hypervisor#8599](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8599);
+the v51.1 binary pinned by this repository does not support the GPT+VMDK disk
+format emitted by runtime-rs. The harness checks this capability before
+starting the control plane.
+
+## Run
+
+Run inside a disposable L1 VM that exposes nested virtualization:
+
+```bash
+docker run --rm --privileged --cgroupns=host \
+  --device /dev/kvm \
+  --device /dev/net/tun \
+  -e NESTED_KATA_CONFIG=/opt/kata/share/defaults/kata-containers/runtime-rs/configuration.toml \
+  -v /opt/kata:/opt/kata:ro \
+  -v "$PWD/input:/input:ro" \
+  -v "$PWD/output:/output" \
+  nested-policy-compat:k8s-1.36-containerd-2.3-erofs-dmverity
+```
+
+For a VMM using native vhost-vsock, also expose `/dev/vhost-vsock`. The first
+implementation requires a hybrid-vsock configuration using `ch-vm.sock`,
+`kata.hvsock`, or `vsock.sock`. The image itself is not intrinsically
+privileged; the container is granted these privileges at launch because it
+operates a nested Kubernetes node and manages KVM, cgroups, networking, mounts,
+udev, and device-mapper state. See `DESIGN.md` for the complete
+privilege rationale.
+
+## Outputs
+
+- `compatibility.json`: `compatible`, `policy-incompatible`, or
+  `infrastructure-failure`;
+- `agent-rpcs/`: byte-exact bidirectional hybrid-vsock captures;
+- `submitted-objects.json`, `pods.json`, and `pod-status.json`;
+- `component-versions.txt` and `kata-artifacts.sha256`;
+- control-plane, shim, relay, and Agent-related logs available through
+  containerd.
+
+The raw Agent channel intentionally retains complete test request traffic,
+including the synthetic Secret and ConfigMap fixture values, for diagnostics.
+
+## Failure diagnostics
+
+The fixture-matrix console prints one summary line per fixture:
+
+```text
+<fixture> <container-exit-status> <result>
+```
+
+It does not print the complete Agent denial. When the Agent rejects a request,
+the policy `reason` returned in the RPC status propagates into a runtime log,
+normally `nested-output/logs/containerd.log`.
+`compat_report.py` finds the first policy denial and records its source file and
+text in:
+
+```text
+cases/<fixture>/nested-output/compatibility.json
+```
+
+For example:
+
+```json
+{
+  "result": "policy-incompatible",
+  "denial": {
+    "file": "/output/logs/containerd.log",
+    "text": "...CreateContainerRequest is blocked by policy: <reason>..."
+  }
+}
+```
+
+The complete logs remain under `cases/<fixture>/nested-output/logs/`. If policy
+generation fails, the VM cannot start, or another infrastructure error occurs
+before the request reaches Agent policy evaluation, there is no returned policy
+reason and `denial` is `null`.
+
+All Kubernetes objects, Secret values, ConfigMap values, images, and cluster
+configuration used by the supplied fixtures are synthetic test data. Complete
+logs and raw `agent-rpcs/` captures may therefore include those values by
+design.
+
+## Validation
+
+```bash
+make -C src/tools/genpolicy/nested-policy-compat validate
+```
+
+Run the positive GenPolicy compatibility fixture matrix with a Kata
+configuration that enables `cc_init_data`:
+
+```bash
+make -C src/tools/genpolicy/nested-policy-compat fixture-e2e \
+  PROFILE=k8s-1.36-containerd-2.3-erofs-dmverity \
+  IMAGE=nested-policy-compat:k8s-1.36-containerd-2.3-erofs-dmverity \
+  KATA_ROOT=/opt/kata \
+  KATA_CONFIG=/path/to/configuration.toml \
+  GENPOLICY_TARGET=x86_64-unknown-linux-musl \
+  OUTPUT_ROOT="$PWD/target/nested-policy-compat-fixtures"
+```
+
+The matrix covers the basic Pod, environment mutation, process/TTY,
+two-container Deployment, service-account mutation, guest-local disk-backed
+emptyDir, and memory/projected-volume workloads. Every case must generate a
+policy with the repository's GenPolicy implementation and reach `compatible`
+in the nested guest.
+The disk-backed emptyDir fixture deliberately has no Pod `fsGroup`; the
+separate storage fixture retains nonzero `fsGroup` coverage for memory-backed
+emptyDir without conflating it with runtime-rs's local-storage encoding.
+Boundary fixtures that intentionally require unsupported hostPath
+authorization are excluded. The generator embeds the repository-tip
+`rules.rego` and settings, and the image contains the GenPolicy binary built
+from the same source tree. This keeps policy generation pinned to the
+checked-out `manifold-cc`-based branch while adding the current attributable
+`reason` rules.
+
+Set `FIXTURES` to a space-separated subset for a focused run, for example
+`FIXTURES=pod.yaml`.
+
+The positive matrix includes a runtime-operations fixture that exercises
+generated names, allowed sysctls, readiness, `kubectl exec`, the configured
+`SIGHUP` stop signal on containerd 2.x, containerd 1.7's default graceful-stop
+path, finalizer removal, and Pod deletion. Containerd 1.7 predates CRI custom
+stop-signal support, so Kubernetes cannot deliver the fixture's requested
+`SIGHUP` through that runtime; the containerd 1.7 generation path removes that
+unsupported field before generating and applying the workload so the policy
+authorizes the runtime's default stop signal. The old runtime does not retain
+the trap output after teardown, so that profile verifies the zero exit status
+rather than a log marker. Guest-pull teardown can likewise remove current
+containerd's log source before collection; its generated policy only authorizes
+the configured `SIGHUP`, so a zero exit status still verifies graceful
+delivery.
+
+Termination-message files are covered by a separate fixture because strict
+Agent builds currently reject the `GetDiagnosticData` request runtime-rs uses
+to recover `/dev/termination-log` when `shared_fs = "none"`. Run that known-gap
+case separately:
+
+```bash
+make -C src/tools/genpolicy/nested-policy-compat termination-log-e2e \
+  PROFILE=k8s-1.36-containerd-2.3-erofs-dmverity \
+  IMAGE=nested-policy-compat:k8s-1.36-containerd-2.3-erofs-dmverity \
+  KATA_ROOT=/opt/kata \
+  KATA_CONFIG=/path/to/configuration.toml \
+  OUTPUT_ROOT="$PWD/target/nested-policy-compat-runtime-operations"
+```
+
+The focused case writes `runtime-operations.json` with `"complete": false` and
+the missing init-container and signal-handler termination messages under
+`gaps`, then fails to keep the known limitation visible. GenPolicy has a
+`request_defaults.GetDiagnosticDataRequest` setting, but enabling it cannot
+override the strict Agent build's unconditional RPC rejection.
+
+Custom service-account field references are also a known GenPolicy gap.
+GenPolicy currently resolves `fieldRef: spec.serviceAccountName` from the
+container representation rather than the Pod spec, so a custom value falls
+back to `default` in the generated policy. The positive
+`service-account-workload.yaml` fixture uses the default service account; run
+the production-style custom-name reproducer separately:
+
+```bash
+make -C src/tools/genpolicy/nested-policy-compat custom-service-account-e2e \
+  PROFILE=k8s-1.36-containerd-2.3-erofs-dmverity \
+  IMAGE=nested-policy-compat:k8s-1.36-containerd-2.3-erofs-dmverity \
+  KATA_ROOT=/opt/kata \
+  KATA_CONFIG=/path/to/configuration.toml \
+  OUTPUT_ROOT="$PWD/target/nested-policy-compat-custom-service-account"
+```
+
+`fixture-e2e` automatically reuses a current local appliance image. Each image
+stores a content fingerprint covering the selected profile; appliance,
+harness, fixture, and test scripts; GenPolicy source and configuration;
+runtime-rs shim and Agent source; the selected Kata configuration; and
+installed shim or Agent binaries found under `KATA_ROOT`. The target rebuilds
+the image when it is missing, unlabelled, or has a different fingerprint.
+Fingerprinting checkout sources detects a potentially stale appliance, but
+does not build those sources or prove that the artifacts under `KATA_ROOT`
+were produced from them. The separate mandatory provenance preflight performs
+that source-equivalence check for the runtime-rs shim and guest Agent.
+Changing `FIXTURES` or `OUTPUT_ROOT` alone does not rebuild the image because
+those values select a run rather than change image contents. Use `make image`
+when an unconditional rebuild is required.

--- a/src/tools/genpolicy/nested-policy-compat/README.md
+++ b/src/tools/genpolicy/nested-policy-compat/README.md
@@ -69,6 +69,8 @@ The build requires `build-essential`, `m4`, `bison`, `flex`, `uuid-dev`,
 running host kernel must also provide EROFS filesystem support; approved
 bootstrap loads the `erofs` module and fails clearly if the kernel does not
 provide it. Guest-pull profiles do not require flat-VMDK or host EROFS support.
+The Kata build scripts also require mikefarah `yq`; install the repository-pinned
+version with `./ci/install_yq.sh` and add `${HOME}/go/bin` to `PATH`.
 
 The supplied or approved installation provides the VMM, guest kernel, and initial runtime
 configuration. The harness builds GenPolicy from the checkout. Before running

--- a/src/tools/genpolicy/nested-policy-compat/appliance/README.md
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/README.md
@@ -1,0 +1,102 @@
+# Self-contained appliance
+
+This directory contains the control-plane configuration and scripts required by
+`nested-policy-compat`. Building and running the harness uses only files from
+the current checkout; it does not require another branch, repository checkout,
+or prebuilt appliance image.
+
+The entrypoint starts the pinned Kubernetes/containerd control plane, imports
+fixture images, submits the workload, and remains alive while the parent
+harness collects the authoritative nested-Agent verdict.
+
+## Directory layout
+
+- `profiles/*.env` defines a build profile. A profile is a text file containing
+  Kubernetes, containerd, etcd, runc, and CNI version pins plus runtime
+  metadata; it is not a container image.
+- `profiles/erofs-dmverity.settings.json` is shared by the EROFS profiles.
+- `profiles/guest-pull.settings.json` enables strict digest-pinned guest pull
+  for current containerd.
+- `profiles/guest-pull-containerd-1.7.settings.json` also selects OCI 1.1.0 for
+  the older containerd request format.
+- `config/` contains the kubelet and CNI configuration copied into every
+  appliance image.
+- `policy-settings.d/` contains settings applied to every policy-generation
+  run.
+- `scripts/` contains the control-plane entrypoint and helpers embedded in the
+  appliance image.
+
+The repository has one shared Dockerfile:
+
+```text
+src/tools/genpolicy/nested-policy-compat/Dockerfile
+```
+
+There is no Dockerfile per Kubernetes version. The defaults written in that
+Dockerfile support a direct build, but `make image` overrides them with values
+from the selected profile.
+
+## Building a profile image
+
+For example:
+
+```bash
+make -C src/tools/genpolicy/nested-policy-compat \
+  PROFILE=k8s-1.33-containerd-2.3-erofs-dmverity image
+```
+
+The Makefile performs these steps:
+
+1. Includes
+   `appliance/profiles/k8s-1.33-containerd-2.3-erofs-dmverity.env`.
+2. Builds GenPolicy from the current checkout and stages it at
+   `nested-policy-compat/build/genpolicy`.
+3. Invokes the shared Dockerfile with explicit build arguments. For this
+   profile, `KUBERNETES_VERSION=v1.33.13` overrides the Dockerfile's
+   `v1.36.3` default.
+4. Tags the image as
+   `nested-policy-compat:k8s-1.33-containerd-2.3-erofs-dmverity`.
+
+The Kubernetes 1.36 EROFS profile follows the same flow. Guest-pull profiles
+use the same Dockerfile and produce:
+
+```text
+nested-policy-compat:k8s-1.33-containerd-1.7-guest-pull
+nested-policy-compat:k8s-1.36-containerd-2.3-guest-pull
+```
+
+The Dockerfile downloads Kubernetes, containerd/etcd/runc, and CNI binaries in
+independent build stages. Switching between profiles therefore reuses
+unmodified component stages where version pins match. The CNI stage copies only the
+`bridge`, `host-local`, `loopback`, and `portmap` plugins used by the appliance
+configuration rather than storing the complete plugin archive.
+
+Set `IMAGE` to choose another tag:
+
+```bash
+make -C src/tools/genpolicy/nested-policy-compat \
+  PROFILE=k8s-1.33-containerd-2.3-erofs-dmverity \
+  IMAGE=example.com/testing/nested-policy-compat:k8s-1.33 image
+```
+
+## Where images are stored
+
+The build does not write a container-image archive under `appliance/` or
+commit an image to the repository. It stores the tagged image in the local
+image store of the selected container engine:
+
+- Podman is preferred when both Podman and Docker are installed;
+- otherwise Docker is used;
+- set `CONTAINER_ENGINE` to select one explicitly.
+
+List the result with:
+
+```bash
+podman image ls nested-policy-compat
+# or
+docker image ls nested-policy-compat
+```
+
+Podman may display an unqualified local tag with a `localhost/` prefix. The
+harness does not push profile images to a registry; pushing or saving an image
+is an explicit external step.

--- a/src/tools/genpolicy/nested-policy-compat/appliance/config/10-genpolicy.conflist
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/config/10-genpolicy.conflist
@@ -1,0 +1,33 @@
+{
+  "cniVersion": "1.0.0",
+  "name": "genpolicy",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "genpolicy0",
+      "isGateway": true,
+      "ipMasq": false,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [
+            {
+              "subnet": "10.188.0.0/16"
+            }
+          ]
+        ],
+        "routes": [
+          {
+            "dst": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
+    }
+  ]
+}

--- a/src/tools/genpolicy/nested-policy-compat/appliance/config/kubelet.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/config/kubelet.yaml
@@ -1,0 +1,26 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+address: 0.0.0.0
+port: 10250
+readOnlyPort: 0
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+allowedUnsafeSysctls:
+  - net.ipv4.ip_forward
+cgroupDriver: cgroupfs
+cgroupsPerQOS: false
+containerRuntimeEndpoint: unix:///run/containerd/containerd.sock
+enforceNodeAllocatable: []
+failSwapOn: false
+featureGates:
+  ContainerStopSignals: true
+clusterDNS:
+  - 10.96.0.10
+clusterDomain: cluster.local
+serializeImagePulls: false
+streamingConnectionIdleTimeout: 5m

--- a/src/tools/genpolicy/nested-policy-compat/appliance/policy-settings.d/10-appliance.json
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/policy-settings.d/10-appliance.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/cluster_config/pause_container_image",
+    "value": "genpolicy.local:5000/pause:3.10"
+  }
+]

--- a/src/tools/genpolicy/nested-policy-compat/appliance/profiles/erofs-dmverity.settings.json
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/profiles/erofs-dmverity.settings.json
@@ -1,0 +1,54 @@
+[
+  {
+    "op": "replace",
+    "path": "/cluster_config/emptydir_type",
+    "value": "block-encrypted"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_source",
+    "value": "^$(cpath)/$(sandbox-id)/rootfs/local/"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_type",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/driver",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/driver_options",
+    "value": []
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/source",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_point",
+    "value": "^$(cpath)/$(sandbox-id)/rootfs/local/"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/fstype",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/options",
+    "value": [
+      "mode=0777"
+    ]
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/shared",
+    "value": false
+  }
+]

--- a/src/tools/genpolicy/nested-policy-compat/appliance/profiles/guest-pull-containerd-1.7.settings.json
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/profiles/guest-pull-containerd-1.7.settings.json
@@ -1,0 +1,79 @@
+[
+  {
+    "op": "replace",
+    "path": "/common/image_layer_verification",
+    "value": "none"
+  },
+  {
+    "op": "replace",
+    "path": "/common/allow_guest_pull_images",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/common/require_pinned_image_digests",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/cluster_config/guest_pull",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/kata_config/oci_version",
+    "value": "1.1.0"
+  },
+  {
+    "op": "replace",
+    "path": "/cluster_config/emptydir_type",
+    "value": "block-encrypted"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_source",
+    "value": "^$(cpath)/$(sandbox-id)/rootfs/local/"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_type",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/driver",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/driver_options",
+    "value": []
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/source",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_point",
+    "value": "^$(cpath)/$(sandbox-id)/rootfs/local/"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/fstype",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/options",
+    "value": [
+      "mode=0777"
+    ]
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/shared",
+    "value": false
+  }
+]

--- a/src/tools/genpolicy/nested-policy-compat/appliance/profiles/guest-pull.settings.json
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/profiles/guest-pull.settings.json
@@ -1,0 +1,74 @@
+[
+  {
+    "op": "replace",
+    "path": "/common/image_layer_verification",
+    "value": "none"
+  },
+  {
+    "op": "replace",
+    "path": "/common/allow_guest_pull_images",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/common/require_pinned_image_digests",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/cluster_config/guest_pull",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/cluster_config/emptydir_type",
+    "value": "block-encrypted"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_source",
+    "value": "^$(cpath)/$(sandbox-id)/rootfs/local/"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_type",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/driver",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/driver_options",
+    "value": []
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/source",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/mount_point",
+    "value": "^$(cpath)/$(sandbox-id)/rootfs/local/"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/fstype",
+    "value": "local"
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/options",
+    "value": [
+      "mode=0777"
+    ]
+  },
+  {
+    "op": "replace",
+    "path": "/volumes/emptyDir_encrypted/shared",
+    "value": false
+  }
+]

--- a/src/tools/genpolicy/nested-policy-compat/appliance/profiles/k8s-1.33-containerd-1.7-guest-pull.env
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/profiles/k8s-1.33-containerd-1.7-guest-pull.env
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+PROFILE_NAME=k8s-1.33-containerd-1.7-guest-pull
+ROOTFS_MODE=guest-pull
+KUBERNETES_VERSION=v1.33.13
+CONTAINERD_VERSION=v1.7.34
+RUNC_VERSION=v1.2.8
+ETCD_VERSION=v3.5.21
+CNI_PLUGINS_VERSION=v1.7.1
+PAUSE_IMAGE=10.188.0.1:5000/pause:3.10
+NODE_NAME=genpolicy-node
+LOCAL_REGISTRY=10.188.0.1:5000
+GENPOLICY_SETTINGS=guest-pull-containerd-1.7.settings.json
+GENPOLICY_CONTAINERD_CONFIG=containerd-generation-v2.toml
+RUNTIME_CONTAINERD_CONFIG=containerd-guest-pull-v2.toml.in

--- a/src/tools/genpolicy/nested-policy-compat/appliance/profiles/k8s-1.33-containerd-2.3-erofs-dmverity.env
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/profiles/k8s-1.33-containerd-2.3-erofs-dmverity.env
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+PROFILE_NAME=k8s-1.33-containerd-2.3-erofs-dmverity
+ROOTFS_MODE=erofs-dmverity
+KUBERNETES_VERSION=v1.33.13
+CONTAINERD_VERSION=v2.3.5
+RUNC_VERSION=v1.2.8
+ETCD_VERSION=v3.5.21
+CNI_PLUGINS_VERSION=v1.7.1
+PAUSE_IMAGE=genpolicy.local:5000/pause:3.10
+NODE_NAME=genpolicy-node
+LOCAL_REGISTRY=genpolicy.local:5000
+GENPOLICY_SETTINGS=erofs-dmverity.settings.json
+GENPOLICY_CONTAINERD_CONFIG=containerd-generation.toml
+RUNTIME_CONTAINERD_CONFIG=containerd-erofs.toml.in

--- a/src/tools/genpolicy/nested-policy-compat/appliance/profiles/k8s-1.36-containerd-2.3-erofs-dmverity.env
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/profiles/k8s-1.36-containerd-2.3-erofs-dmverity.env
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+PROFILE_NAME=k8s-1.36-containerd-2.3-erofs-dmverity
+ROOTFS_MODE=erofs-dmverity
+KUBERNETES_VERSION=v1.36.3
+CONTAINERD_VERSION=v2.3.5
+RUNC_VERSION=v1.2.8
+ETCD_VERSION=v3.5.21
+CNI_PLUGINS_VERSION=v1.7.1
+PAUSE_IMAGE=genpolicy.local:5000/pause:3.10
+NODE_NAME=genpolicy-node
+LOCAL_REGISTRY=genpolicy.local:5000
+GENPOLICY_SETTINGS=erofs-dmverity.settings.json
+GENPOLICY_CONTAINERD_CONFIG=containerd-generation.toml
+RUNTIME_CONTAINERD_CONFIG=containerd-erofs.toml.in

--- a/src/tools/genpolicy/nested-policy-compat/appliance/profiles/k8s-1.36-containerd-2.3-guest-pull.env
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/profiles/k8s-1.36-containerd-2.3-guest-pull.env
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+PROFILE_NAME=k8s-1.36-containerd-2.3-guest-pull
+ROOTFS_MODE=guest-pull
+KUBERNETES_VERSION=v1.36.3
+CONTAINERD_VERSION=v2.3.5
+RUNC_VERSION=v1.2.8
+ETCD_VERSION=v3.5.21
+CNI_PLUGINS_VERSION=v1.7.1
+PAUSE_IMAGE=10.188.0.1:5000/pause:3.10
+NODE_NAME=genpolicy-node
+LOCAL_REGISTRY=10.188.0.1:5000
+GENPOLICY_SETTINGS=guest-pull.settings.json
+GENPOLICY_CONTAINERD_CONFIG=containerd-generation.toml
+RUNTIME_CONTAINERD_CONFIG=containerd-guest-pull-v4.toml.in

--- a/src/tools/genpolicy/nested-policy-compat/appliance/scripts/entrypoint.sh
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/scripts/entrypoint.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+readonly appliance_root="${GENPOLICY_APPLIANCE_ROOT:-/opt/genpolicy/appliance}"
+readonly input_dir="${GENPOLICY_INPUT_DIR:-/input}"
+readonly output_dir="${GENPOLICY_OUTPUT_DIR:-/output}"
+readonly workload="${input_dir}/workload.yaml"
+
+profile_name="${GENPOLICY_PROFILE_NAME:-k8s-1.36-containerd-2.3-erofs-dmverity}"
+profile_path="${appliance_root}/profiles/${profile_name}.env"
+[[ -f "${profile_path}" ]] || {
+	echo "ERROR: unknown compatibility profile: ${profile_name}" >&2
+	exit 1
+}
+# shellcheck source=/dev/null
+source "${profile_path}"
+
+pids=()
+cleanup() {
+	local pid
+	for pid in "${pids[@]}"; do
+		kill "${pid}" 2>/dev/null || true
+	done
+}
+trap cleanup EXIT
+
+fail() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+
+wait_for() {
+	local description=$1
+	shift
+	local _
+	for _ in $(seq 1 120); do
+		if "$@" >/dev/null 2>&1; then
+			return
+		fi
+		sleep 1
+	done
+	fail "timed out waiting for ${description}"
+}
+
+[[ "$(id -u)" == "0" ]] || fail "the appliance must run as root"
+[[ -f "${workload}" ]] || fail "${workload} is required"
+[[ "$(stat -fc %T /sys/fs/cgroup)" == "cgroup2fs" ]] ||
+	fail "cgroup v2 is required"
+# ROOTFS_MODE is loaded from the selected profile.
+# shellcheck disable=SC2154
+case "${ROOTFS_MODE}" in
+erofs-dmverity | guest-pull) ;;
+*) fail "unsupported rootfs mode: ${ROOTFS_MODE}" ;;
+esac
+[[ "${GENPOLICY_NESTED_RUNTIME_ONLY:-0}" == "1" ]] ||
+	fail "the appliance entrypoint is only supported through the nested harness"
+[[ -n "${CONTAINERD_CONFIG:-}" ]] ||
+	fail "CONTAINERD_CONFIG is required"
+
+mkdir -p "${output_dir}/logs"
+
+python3 "${appliance_root}/scripts/submit_workload.py" \
+	--input "${workload}" \
+	--images-output "${output_dir}/requested-images.txt" \
+	--allow-unsafe-identity-delivery \
+	--validate-only
+
+install -D -m 0644 \
+	"${appliance_root}/config/${CONTAINERD_CONFIG}" \
+	/etc/containerd/config.toml
+install -D -m 0644 \
+	"${appliance_root}/config/kubelet.yaml" \
+	/etc/kubernetes/kubelet.yaml
+install -D -m 0644 \
+	"${appliance_root}/config/10-genpolicy.conflist" \
+	/etc/cni/net.d/10-genpolicy.conflist
+
+# LOCAL_REGISTRY is loaded from the selected profile.
+# shellcheck disable=SC2154
+if [[ "${ROOTFS_MODE}" == "guest-pull" ]]; then
+	registry_host=${LOCAL_REGISTRY%:*}
+	ip link add genpolicy0 type bridge
+	ip address add "${registry_host}/16" dev genpolicy0
+	ip link set genpolicy0 up
+
+	mkdir -p /etc/docker/registry /var/lib/registry
+	cat >/etc/docker/registry/config.yml <<EOF
+version: 0.1
+storage:
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: ${LOCAL_REGISTRY}
+  tls:
+    certificate: /opt/genpolicy/registry-tls/registry.crt
+    key: /opt/genpolicy/registry-tls/registry.key
+EOF
+	registry serve /etc/docker/registry/config.yml \
+		>"${output_dir}/logs/registry.log" 2>&1 &
+	pids+=("$!")
+	wait_for registry curl -fsS \
+		--cacert /opt/genpolicy/registry-tls/registry.crt \
+		"https://${LOCAL_REGISTRY}/v2/"
+fi
+
+/lib/systemd/systemd-udevd --daemon
+wait_for udev udevadm control --ping
+python3 "${appliance_root}/scripts/watch_device_mapper_nodes.py" \
+	>"${output_dir}/logs/device-mapper-nodes.log" 2>&1 &
+pids+=("$!")
+
+# LOCAL_REGISTRY is loaded from the selected profile.
+# shellcheck disable=SC2154
+mkdir -p "/etc/containerd/certs.d/${LOCAL_REGISTRY}"
+cat >"/etc/containerd/certs.d/${LOCAL_REGISTRY}/hosts.toml" <<EOF
+server = "https://${LOCAL_REGISTRY}"
+
+[host."https://${LOCAL_REGISTRY}"]
+  capabilities = ["pull", "resolve", "push"]
+  ca = "/opt/genpolicy/registry-tls/registry.crt"
+EOF
+
+mkdir -p \
+	/etc/kubernetes/pki \
+	/var/lib/etcd \
+	/var/lib/kubelet \
+	/var/lib/containerd \
+	/run/containerd
+printf '127.0.0.1 genpolicy.local\n' >>/etc/hosts
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+	-subj "/CN=kube-apiserver" \
+	-addext "subjectAltName=IP:127.0.0.1,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc" \
+	-keyout /etc/kubernetes/pki/apiserver.key \
+	-out /etc/kubernetes/pki/apiserver.crt \
+	>"${output_dir}/logs/openssl.log" 2>&1
+openssl genrsa -out /etc/kubernetes/pki/sa.key 2048 \
+	>>"${output_dir}/logs/openssl.log" 2>&1
+openssl rsa -in /etc/kubernetes/pki/sa.key -pubout \
+	-out /etc/kubernetes/pki/sa.pub \
+	>>"${output_dir}/logs/openssl.log" 2>&1
+printf '%s\n' \
+	'genpolicy-clean-room-token,genpolicy,1000,"system:masters"' \
+	>/etc/kubernetes/token.csv
+
+etcd \
+	--data-dir=/var/lib/etcd \
+	--listen-client-urls=http://127.0.0.1:2379 \
+	--advertise-client-urls=http://127.0.0.1:2379 \
+	>"${output_dir}/logs/etcd.log" 2>&1 &
+pids+=("$!")
+wait_for etcd etcdctl --endpoints=http://127.0.0.1:2379 endpoint health
+
+kube-apiserver \
+	--advertise-address="$(hostname -i | awk '{print $1}')" \
+	--allow-privileged=true \
+	--anonymous-auth=true \
+	--authorization-mode=AlwaysAllow \
+	--disable-admission-plugins=DefaultStorageClass,DefaultTolerationSeconds,ServiceAccount \
+	--etcd-servers=http://127.0.0.1:2379 \
+	--feature-gates=ContainerStopSignals=true \
+	--kubelet-preferred-address-types=InternalIP,Hostname \
+	--secure-port=6443 \
+	--service-account-issuer=https://kubernetes.default.svc \
+	--service-account-key-file=/etc/kubernetes/pki/sa.pub \
+	--service-account-signing-key-file=/etc/kubernetes/pki/sa.key \
+	--service-cluster-ip-range=10.96.0.0/12 \
+	--tls-cert-file=/etc/kubernetes/pki/apiserver.crt \
+	--tls-private-key-file=/etc/kubernetes/pki/apiserver.key \
+	--token-auth-file=/etc/kubernetes/token.csv \
+	>"${output_dir}/logs/kube-apiserver.log" 2>&1 &
+pids+=("$!")
+wait_for kube-apiserver curl -kfsS \
+	-H 'Authorization: Bearer genpolicy-clean-room-token' \
+	https://127.0.0.1:6443/livez
+
+cat >/etc/kubernetes/kubeconfig <<'EOF'
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+users:
+- name: genpolicy
+  user:
+    token: genpolicy-clean-room-token
+contexts:
+- name: local
+  context:
+    cluster: local
+    user: genpolicy
+current-context: local
+EOF
+export KUBECONFIG=/etc/kubernetes/kubeconfig
+
+kubectl get namespace default >/dev/null 2>&1 ||
+	kubectl create namespace default >/dev/null
+kubectl get namespace kube-system >/dev/null 2>&1 ||
+	kubectl create namespace kube-system >/dev/null
+cat <<'EOF' | kubectl apply -f - >/dev/null
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata
+handler: kata
+EOF
+
+containerd --config /etc/containerd/config.toml \
+	>"${output_dir}/logs/containerd.log" 2>&1 &
+pids+=("$!")
+wait_for containerd ctr --address /run/containerd/containerd.sock version
+
+ctr --address /run/containerd/containerd.sock --namespace k8s.io images import \
+	--digests /opt/genpolicy/images/pause.tar >/dev/null
+# PAUSE_IMAGE is loaded from the selected profile.
+# shellcheck disable=SC2154
+if [[ "${PAUSE_IMAGE}" != "genpolicy.local:5000/pause:3.10" ]]; then
+	ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+		images tag "genpolicy.local:5000/pause:3.10" "${PAUSE_IMAGE}" >/dev/null
+fi
+image_archives=(/opt/genpolicy/images/busybox.tar)
+if [[ -d "${input_dir}/images" ]]; then
+	while IFS= read -r -d '' image; do
+		image_archives+=("${image}")
+	done < <(find "${input_dir}/images" -type f -name '*.tar' -print0)
+fi
+
+referenced_image_dir=/run/genpolicy-requested-images
+mkdir -p "${referenced_image_dir}"
+image_number=0
+while IFS= read -r image_ref; do
+	referenced_archive="${referenced_image_dir}/requested-image-${image_number}.tar"
+	if python3 "${appliance_root}/scripts/reference_oci_image.py" \
+		--reference "${image_ref}" \
+		--output "${referenced_archive}" \
+		"${image_archives[@]}"; then
+		ctr --address /run/containerd/containerd.sock --namespace k8s.io images import \
+			"${referenced_archive}" >/dev/null
+	else
+		[[ "${image_ref}" != "${LOCAL_REGISTRY}/"* ]] ||
+			fail "no imported image has requested manifest digest ${image_ref##*@}"
+		ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+			images pull --hosts-dir /etc/containerd/certs.d "${image_ref}" >/dev/null
+	fi
+	image_number=$((image_number + 1))
+done <"${output_dir}/requested-images.txt"
+
+if [[ "${ROOTFS_MODE}" == "guest-pull" ]]; then
+	while IFS= read -r image_ref; do
+		[[ "${image_ref}" == "${LOCAL_REGISTRY}/"* ]] || continue
+		ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+			images push --hosts-dir /etc/containerd/certs.d "${image_ref}" >/dev/null
+	done < <(ctr --address /run/containerd/containerd.sock --namespace k8s.io images list -q)
+fi
+
+iptables --flush OUTPUT
+iptables --append OUTPUT --out-interface lo --jump ACCEPT
+if [[ "${ROOTFS_MODE}" == "guest-pull" ]]; then
+	iptables --append OUTPUT --out-interface genpolicy0 \
+		--protocol tcp --source-port 5000 --destination 10.188.0.0/16 \
+		--match conntrack --ctstate ESTABLISHED --jump ACCEPT
+fi
+iptables --policy OUTPUT DROP
+iptables --flush FORWARD
+iptables --policy FORWARD DROP
+ip6tables --flush OUTPUT
+ip6tables --append OUTPUT --out-interface lo --jump ACCEPT
+ip6tables --policy OUTPUT DROP
+ip6tables --flush FORWARD
+ip6tables --policy FORWARD DROP
+[[ "$(iptables --list-rules OUTPUT | head -n 1)" == "-P OUTPUT DROP" ]] ||
+	fail "failed to seal IPv4 outbound traffic"
+iptables --check OUTPUT --out-interface lo --jump ACCEPT
+if [[ "${ROOTFS_MODE}" == "guest-pull" ]]; then
+	iptables --check OUTPUT --out-interface genpolicy0 \
+		--protocol tcp --source-port 5000 --destination 10.188.0.0/16 \
+		--match conntrack --ctstate ESTABLISHED --jump ACCEPT
+fi
+[[ "$(iptables --list-rules FORWARD | head -n 1)" == "-P FORWARD DROP" ]] ||
+	fail "failed to seal IPv4 forwarded traffic"
+[[ "$(ip6tables --list-rules OUTPUT | head -n 1)" == "-P OUTPUT DROP" ]] ||
+	fail "failed to seal IPv6 outbound traffic"
+ip6tables --check OUTPUT --out-interface lo --jump ACCEPT
+[[ "$(ip6tables --list-rules FORWARD | head -n 1)" == "-P FORWARD DROP" ]] ||
+	fail "failed to seal IPv6 forwarded traffic"
+
+# NODE_NAME is loaded from the selected profile.
+# shellcheck disable=SC2154
+kubelet \
+	--config=/etc/kubernetes/kubelet.yaml \
+	--hostname-override="${NODE_NAME}" \
+	--kubeconfig=/etc/kubernetes/kubeconfig \
+	--node-ip="$(hostname -i | awk '{print $1}')" \
+	--root-dir=/var/lib/kubelet \
+	>"${output_dir}/logs/kubelet.log" 2>&1 &
+pids+=("$!")
+wait_for kubelet-node kubectl get "node/${NODE_NAME}"
+
+python3 "${appliance_root}/scripts/submit_workload.py" \
+	--input "${workload}" \
+	--allow-unsafe-identity-delivery \
+	--node-name "${NODE_NAME}" \
+	--objects-output "${output_dir}/submitted-objects.json" \
+	--pods-output "${output_dir}/pods.json" \
+	--dynamic-output "${output_dir}/dynamic-values.json"
+
+while IFS=$'\t' read -r namespace pod_name; do
+	kubectl wait \
+		--namespace "${namespace}" \
+		--for=condition=Ready \
+		--timeout="${GENPOLICY_POD_READY_TIMEOUT:-180s}" \
+		"pod/${pod_name}"
+done < <(python3 - "${output_dir}/pods.json" <<'PY'
+import json
+import sys
+
+for pod in json.load(open(sys.argv[1], encoding="utf-8")):
+    metadata = pod["metadata"]
+    print(metadata.get("namespace", "default"), metadata["name"], sep="\t")
+PY
+)
+
+kubectl get pods --all-namespaces -o json \
+	>"${output_dir}/pod-status-ready.json"
+python3 "${appliance_root}/scripts/exercise_runtime_operations.py" \
+	--pods "${output_dir}/pods.json" \
+	--containerd-version "$(containerd --version)" \
+	--output "${output_dir}/runtime-operations.json"
+
+while sleep 3600; do
+	:
+done

--- a/src/tools/genpolicy/nested-policy-compat/appliance/scripts/exercise_runtime_operations.py
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/scripts/exercise_runtime_operations.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+
+
+RUNTIME_ANNOTATION = "test.katacontainers.io/runtime-operations"
+TERMINATION_LOG_ANNOTATION = "test.katacontainers.io/termination-log"
+FINALIZER = "test.katacontainers.io/observe-termination"
+INIT_MESSAGE = "runtime-init-complete"
+STOP_MESSAGE = "runtime-stop-sighup"
+FALLBACK_STOP_MESSAGE = "runtime-stop-sigterm"
+
+
+def kubectl(*args: str, capture: bool = True) -> str:
+    result = subprocess.run(
+        ["kubectl", *args],
+        text=True,
+        capture_output=capture,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip() if capture else ""
+        command = " ".join(("kubectl", *args))
+        raise RuntimeError(f"{command} failed: {stderr or f'exit {result.returncode}'}")
+    return result.stdout if capture else ""
+
+
+def pod_json(namespace: str, name: str) -> dict:
+    return json.loads(kubectl("get", "pod", name, "--namespace", namespace, "-o", "json"))
+
+
+def status_by_name(pod: dict, field: str) -> dict:
+    return {
+        status["name"]: status
+        for status in pod.get("status", {}).get(field, [])
+    }
+
+
+def terminated_status(pod: dict, container_name: str) -> dict | None:
+    status = status_by_name(pod, "containerStatuses").get(container_name, {})
+    return status.get("state", {}).get("terminated")
+
+
+def wait_for_termination(namespace: str, name: str, container_name: str) -> tuple[dict, dict]:
+    deadline = time.monotonic() + 120
+    while time.monotonic() < deadline:
+        pod = pod_json(namespace, name)
+        terminated = terminated_status(pod, container_name)
+        if terminated is not None:
+            return pod, terminated
+        time.sleep(1)
+    raise RuntimeError(f"timed out waiting for {namespace}/{name} to terminate")
+
+
+def validate_runtime_fixture(pod: dict) -> tuple[str, str, str, dict]:
+    metadata = pod["metadata"]
+    namespace = metadata.get("namespace", "default")
+    name = metadata["name"]
+    generated_prefix = metadata.get("generateName", "")
+    if not generated_prefix or not name.startswith(generated_prefix):
+        raise RuntimeError(f"{namespace}/{name} does not match generateName prefix")
+
+    sysctls = {
+        item["name"]: str(item["value"])
+        for item in pod.get("spec", {}).get("securityContext", {}).get("sysctls", [])
+    }
+    if sysctls.get("net.ipv4.ip_forward") != "1":
+        raise RuntimeError(f"{namespace}/{name} is missing the expected sysctl")
+
+    workload_status = status_by_name(pod, "containerStatuses").get("workload", {})
+    if not workload_status.get("ready"):
+        raise RuntimeError(f"{namespace}/{name} readiness probe did not succeed")
+
+    return namespace, name, generated_prefix, sysctls
+
+
+def stop_and_observe(namespace: str, name: str) -> tuple[dict, str]:
+    kubectl(
+        "exec",
+        "--namespace",
+        namespace,
+        name,
+        "--container",
+        "workload",
+        "--",
+        "/bin/busybox",
+        "test",
+        "-f",
+        "/tmp/ready",
+    )
+    kubectl(
+        "delete",
+        "pod",
+        name,
+        "--namespace",
+        namespace,
+        "--grace-period=10",
+        "--wait=false",
+    )
+
+    terminated_pod, terminated = wait_for_termination(namespace, name, "workload")
+    log = kubectl(
+        "logs",
+        "--namespace",
+        namespace,
+        name,
+        "--container",
+        "workload",
+    )
+
+    finalizers = terminated_pod.get("metadata", {}).get("finalizers", [])
+    if FINALIZER not in finalizers:
+        raise RuntimeError(f"{namespace}/{name} observation finalizer is missing")
+    kubectl(
+        "patch",
+        "pod",
+        name,
+        "--namespace",
+        namespace,
+        "--type=merge",
+        "-p",
+        '{"metadata":{"finalizers":[]}}',
+    )
+    kubectl(
+        "wait",
+        "--namespace",
+        namespace,
+        "--for=delete",
+        "--timeout=120s",
+        f"pod/{name}",
+    )
+    return terminated, log
+
+
+def exercise_runtime_fixture(pod: dict, custom_stop_signal: bool) -> dict:
+    namespace, name, generated_prefix, sysctls = validate_runtime_fixture(pod)
+    workload = next(
+        container
+        for container in pod.get("spec", {}).get("containers", [])
+        if container.get("name") == "workload"
+    )
+    declared_stop_signal = workload.get("lifecycle", {}).get("stopSignal")
+    if custom_stop_signal and declared_stop_signal != "SIGHUP":
+        raise RuntimeError(f"{namespace}/{name} is missing the configured SIGHUP")
+    if not custom_stop_signal and declared_stop_signal is not None:
+        raise RuntimeError(
+            f"{namespace}/{name} retains a stop signal unsupported by containerd 1.7"
+        )
+
+    terminated, log = stop_and_observe(namespace, name)
+    if terminated.get("exitCode") != 0:
+        raise RuntimeError(f"{namespace}/{name} did not stop gracefully")
+    if STOP_MESSAGE in log:
+        observed_stop_signal = "SIGHUP"
+    elif FALLBACK_STOP_MESSAGE in log:
+        observed_stop_signal = "SIGTERM fallback"
+    elif custom_stop_signal:
+        observed_stop_signal = "SIGHUP"
+    elif not custom_stop_signal:
+        observed_stop_signal = "containerd 1.7 default"
+    if custom_stop_signal and observed_stop_signal != "SIGHUP":
+        raise RuntimeError(f"{namespace}/{name} did not receive the configured SIGHUP")
+    if not custom_stop_signal and observed_stop_signal == "SIGHUP":
+        raise RuntimeError(f"{namespace}/{name} unexpectedly received SIGHUP")
+
+    return {
+        "exec_process": "passed",
+        "generate_name": generated_prefix,
+        "pod": f"{namespace}/{name}",
+        "readiness_probe": "passed",
+        "stop_signal": observed_stop_signal,
+        "sysctls": sysctls,
+        "container_log": log.strip(),
+        "termination_exit_code": terminated["exitCode"],
+    }
+
+
+def exercise_termination_log_fixture(pod: dict) -> dict:
+    gaps = []
+    metadata = pod["metadata"]
+    namespace = metadata.get("namespace", "default")
+    name = metadata["name"]
+
+    init_status = status_by_name(pod, "initContainerStatuses").get(
+        "termination-message", {}
+    )
+    init_terminated = init_status.get("state", {}).get("terminated", {})
+    if init_terminated.get("message") != INIT_MESSAGE:
+        gaps.append("init termination message was not recorded")
+
+    workload_status = status_by_name(pod, "containerStatuses").get("workload", {})
+    if not workload_status.get("ready"):
+        raise RuntimeError(f"{namespace}/{name} readiness probe did not succeed")
+
+    terminated, log = stop_and_observe(namespace, name)
+    if terminated.get("message") != STOP_MESSAGE:
+        gaps.append("SIGHUP termination message was not recorded")
+
+    return {
+        "gaps": gaps,
+        "init_termination_message": init_terminated.get("message", ""),
+        "pod": f"{namespace}/{name}",
+        "stop_signal": "SIGHUP",
+        "termination_log": log.strip(),
+        "termination_message": terminated.get("message", ""),
+    }
+
+
+def delete_pod(pod: dict) -> dict:
+    metadata = pod["metadata"]
+    namespace = metadata.get("namespace", "default")
+    name = metadata["name"]
+    kubectl(
+        "delete",
+        "pod",
+        name,
+        "--namespace",
+        namespace,
+        "--grace-period=10",
+        "--wait=true",
+        "--timeout=120s",
+    )
+    return {"pod": f"{namespace}/{name}", "graceful_deletion": "passed"}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pods", required=True, type=Path)
+    parser.add_argument("--containerd-version", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    custom_stop_signal = " v1." not in args.containerd_version
+
+    declared_pods = json.loads(args.pods.read_text(encoding="utf-8"))
+    results = []
+    for declared in declared_pods:
+        metadata = declared["metadata"]
+        namespace = metadata.get("namespace", "default")
+        name = metadata["name"]
+        live = pod_json(namespace, name)
+        annotations = live.get("metadata", {}).get("annotations", {})
+        if annotations.get(TERMINATION_LOG_ANNOTATION) == "true":
+            results.append(exercise_termination_log_fixture(live))
+        elif annotations.get(RUNTIME_ANNOTATION) == "true":
+            results.append(exercise_runtime_fixture(live, custom_stop_signal))
+        else:
+            results.append(delete_pod(live))
+
+    gaps = [
+        f"{result['pod']}: {gap}"
+        for result in results
+        for gap in result.get("gaps", [])
+    ]
+    args.output.write_text(
+        json.dumps(
+            {"complete": not gaps, "gaps": gaps, "pods": results},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if gaps:
+        raise RuntimeError("; ".join(gaps))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/genpolicy/nested-policy-compat/appliance/scripts/make_oci_image.py
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/scripts/make_oci_image.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import platform
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def canonical_json(value: object) -> bytes:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+
+
+def add_tree(archive: tarfile.TarFile, rootfs: Path) -> None:
+    for path in sorted(rootfs.rglob("*")):
+        relative = path.relative_to(rootfs)
+        info = archive.gettarinfo(str(path), arcname=str(relative))
+        info.mtime = 0
+        info.uid = 0
+        info.gid = 0
+        info.uname = ""
+        info.gname = ""
+        if info.isfile():
+            with path.open("rb") as source:
+                archive.addfile(info, source)
+        else:
+            archive.addfile(info)
+
+
+def write_blob(layout: Path, data: bytes) -> tuple[str, int]:
+    value_digest = digest(data)
+    destination = layout / "blobs" / "sha256" / value_digest
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(data)
+    return value_digest, len(data)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rootfs", required=True, type=Path)
+    parser.add_argument("--reference", required=True)
+    parser.add_argument("--entrypoint", required=True)
+    parser.add_argument("--user")
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    entrypoint = json.loads(args.entrypoint)
+    architecture = {
+        "x86_64": "amd64",
+        "aarch64": "arm64",
+    }.get(platform.machine(), platform.machine())
+
+    with tempfile.TemporaryDirectory() as temporary:
+        temporary_path = Path(temporary)
+        layer_path = temporary_path / "layer.tar"
+        with tarfile.open(layer_path, "w", format=tarfile.PAX_FORMAT) as layer:
+            add_tree(layer, args.rootfs)
+        layer_data = layer_path.read_bytes()
+        compressed_layer = gzip.compress(layer_data, mtime=0)
+        layer_digest, layer_size = write_blob(temporary_path, compressed_layer)
+        diff_id = digest(layer_data)
+
+        image_config = {
+            "Entrypoint": entrypoint,
+            "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ],
+            "WorkingDir": "/",
+        }
+        if args.user is not None:
+            image_config["User"] = args.user
+
+        config = canonical_json(
+            {
+                "architecture": architecture,
+                "config": image_config,
+                "created": "1970-01-01T00:00:00Z",
+                "history": [{"created": "1970-01-01T00:00:00Z"}],
+                "os": "linux",
+                "rootfs": {
+                    "diff_ids": [f"sha256:{diff_id}"],
+                    "type": "layers",
+                },
+            }
+        )
+        config_digest, config_size = write_blob(temporary_path, config)
+
+        manifest = canonical_json(
+            {
+                "config": {
+                    "digest": f"sha256:{config_digest}",
+                    "mediaType": "application/vnd.oci.image.config.v1+json",
+                    "size": config_size,
+                },
+                "layers": [
+                    {
+                        "digest": f"sha256:{layer_digest}",
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                        "size": layer_size,
+                    }
+                ],
+                "schemaVersion": 2,
+            }
+        )
+        manifest_digest, manifest_size = write_blob(temporary_path, manifest)
+
+        (temporary_path / "oci-layout").write_text(
+            '{"imageLayoutVersion":"1.0.0"}\n', encoding="utf-8"
+        )
+        index = canonical_json(
+            {
+                "manifests": [
+                    {
+                        "annotations": {
+                            "org.opencontainers.image.ref.name": args.reference
+                        },
+                        "digest": f"sha256:{manifest_digest}",
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "platform": {"architecture": architecture, "os": "linux"},
+                        "size": manifest_size,
+                    }
+                ],
+                "schemaVersion": 2,
+            }
+        )
+        (temporary_path / "index.json").write_bytes(index)
+
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(args.output, "w") as output:
+            for name in ("oci-layout", "index.json", "blobs"):
+                output.add(
+                    temporary_path / name,
+                    arcname=name,
+                    recursive=True,
+                    filter=lambda info: _normalize_tar_info(info),
+                )
+
+
+def _normalize_tar_info(info: tarfile.TarInfo) -> tarfile.TarInfo:
+    info.mtime = 0
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    return info
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/genpolicy/nested-policy-compat/appliance/scripts/reference_oci_image.py
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/scripts/reference_oci_image.py
@@ -18,12 +18,22 @@ REFERENCE_ANNOTATION = "org.opencontainers.image.ref.name"
 
 
 def find_archive(archives: list[Path], digest: str) -> tuple[Path, dict]:
+    indexes = []
     for archive in archives:
         with tarfile.open(archive) as layout:
-            index_file = layout.extractfile("index.json")
+            try:
+                index_file = layout.extractfile("index.json")
+            except KeyError as error:
+                raise ValueError(
+                    f"{archive} is not an OCI image-layout archive: index.json not found"
+                ) from error
             if index_file is None:
-                continue
-            index = json.load(index_file)
+                raise ValueError(
+                    f"{archive} is not an OCI image-layout archive: index.json not found"
+                )
+            indexes.append((archive, json.load(index_file)))
+
+    for archive, index in indexes:
         for descriptor in index.get("manifests", []):
             if descriptor.get("digest") == digest:
                 return archive, descriptor

--- a/src/tools/genpolicy/nested-policy-compat/appliance/scripts/reference_oci_image.py
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/scripts/reference_oci_image.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import copy
+import io
+import json
+import re
+import tarfile
+from pathlib import Path
+
+
+DIGEST_REFERENCE = re.compile(r"^.+@(sha256:[0-9a-f]{64})$")
+REFERENCE_ANNOTATION = "org.opencontainers.image.ref.name"
+
+
+def find_archive(archives: list[Path], digest: str) -> tuple[Path, dict]:
+    for archive in archives:
+        with tarfile.open(archive) as layout:
+            index_file = layout.extractfile("index.json")
+            if index_file is None:
+                continue
+            index = json.load(index_file)
+        for descriptor in index.get("manifests", []):
+            if descriptor.get("digest") == digest:
+                return archive, descriptor
+    raise ValueError(f"no OCI archive contains requested manifest digest {digest}")
+
+
+def write_archive(source: Path, descriptor: dict, reference: str, output: Path) -> None:
+    selected = copy.deepcopy(descriptor)
+    selected.setdefault("annotations", {})[REFERENCE_ANNOTATION] = reference
+    index = json.dumps(
+        {"manifests": [selected], "schemaVersion": 2},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(source) as source_layout, tarfile.open(output, "w") as result:
+        index_info = tarfile.TarInfo("index.json")
+        index_info.size = len(index)
+        index_info.mode = 0o644
+        result.addfile(index_info, io.BytesIO(index))
+        for member in source_layout.getmembers():
+            if member.name == "index.json":
+                continue
+            result.addfile(member, source_layout.extractfile(member))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reference", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("archives", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    match = DIGEST_REFERENCE.fullmatch(args.reference)
+    if match is None:
+        parser.error("--reference must be digest-qualified with sha256")
+    try:
+        source, descriptor = find_archive(args.archives, match.group(1))
+    except ValueError as error:
+        parser.error(str(error))
+    write_archive(source, descriptor, args.reference, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/genpolicy/nested-policy-compat/appliance/scripts/submit_workload.py
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/scripts/submit_workload.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import copy
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+TEMPLATE_PATHS = {
+    "CronJob": ("spec", "jobTemplate", "spec", "template"),
+    "DaemonSet": ("spec", "template"),
+    "Deployment": ("spec", "template"),
+    "Job": ("spec", "template"),
+    "PodTemplate": ("template",),
+    "ReplicaSet": ("spec", "template"),
+    "ReplicationController": ("spec", "template"),
+    "StatefulSet": ("spec", "template"),
+}
+IMAGE_DIGEST = re.compile(
+    r"^(?:[a-z0-9]+(?:[.-][a-z0-9]+)*(?::[0-9]+)?/)?"
+    r"[a-z0-9]+(?:[._-][a-z0-9]+)*"
+    r"(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*"
+    r"(?::[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127})?"
+    r"@sha256:[0-9a-f]{64}$"
+)
+
+
+def kubectl_create(value: dict) -> dict:
+    result = subprocess.run(
+        ["kubectl", "create", "-f", "-", "-o", "json"],
+        input=json.dumps(value),
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"kubectl create failed: {message}")
+    return json.loads(result.stdout)
+
+
+def ensure_namespace(namespace: str) -> None:
+    subprocess.run(
+        ["kubectl", "create", "namespace", namespace],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def nested(value: dict, path: tuple[str, ...]) -> dict:
+    current = value
+    for element in path:
+        current = current[element]
+    return current
+
+
+def safe_name(name: str) -> str:
+    raw = name.lower()
+    value = re.sub(r"[^a-z0-9-]+", "-", raw)
+    return re.sub(r"-+", "-", value).strip("-")
+
+
+def controller_pod_metadata(kind: str, name: str) -> tuple[dict, bool]:
+    name = safe_name(name)
+    if kind == "StatefulSet":
+        return {"name": f"{name[:61]}-0"}, False
+    if kind == "Deployment":
+        prefix = f"{name}-bcdfghjklm-"
+    elif kind == "CronJob":
+        prefix = f"{name}-0-"
+    else:
+        prefix = f"{name}-"
+    return {"generateName": prefix[-58:]}, True
+
+
+def pod_from_workload(resource: dict, node_name: str) -> tuple[dict, bool]:
+    kind = resource["kind"]
+    if kind == "Pod":
+        pod = copy.deepcopy(resource)
+        pod.setdefault("spec", {})["nodeName"] = node_name
+        return pod, bool(pod.get("metadata", {}).get("generateName"))
+
+    template = copy.deepcopy(nested(resource, TEMPLATE_PATHS[kind]))
+    resource_metadata = resource.get("metadata", {})
+    template_metadata = template.get("metadata") or {}
+    source_name = resource_metadata.get("name", kind.lower())
+    pod_name, generated_name = controller_pod_metadata(kind, source_name)
+    pod = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "annotations": template_metadata.get("annotations", {}),
+            "labels": template_metadata.get("labels", {}),
+            "namespace": resource_metadata.get("namespace", "default"),
+            **pod_name,
+        },
+        "spec": template["spec"],
+    }
+    pod["spec"]["nodeName"] = node_name
+    return pod, generated_name
+
+
+def iter_documents(path: Path):
+    with path.open(encoding="utf-8") as source:
+        for document in yaml.safe_load_all(source):
+            if not document:
+                continue
+            if document.get("kind") == "List":
+                yield from document.get("items", [])
+            else:
+                yield document
+
+
+def validate_image_references(path: Path) -> set[str]:
+    errors = []
+    images = set()
+    for document in iter_documents(path):
+        kind = document.get("kind")
+        if kind == "Pod":
+            pod_spec = document.get("spec") or {}
+        elif kind in TEMPLATE_PATHS:
+            pod_spec = (nested(document, TEMPLATE_PATHS[kind]).get("spec") or {})
+        else:
+            continue
+        for field in ("initContainers", "containers", "ephemeralContainers"):
+            for container in pod_spec.get(field, []):
+                image = container.get("image", "")
+                if not IMAGE_DIGEST.fullmatch(image):
+                    errors.append(
+                        f"{kind} container {container.get('name', '<unnamed>')} "
+                        f"image is not digest-pinned: {image or '<missing>'}"
+                    )
+                else:
+                    images.add(image)
+    if errors:
+        raise ValueError("\n".join(errors))
+    return images
+
+
+def validate_guest_identity_delivery(path: Path) -> None:
+    errors = []
+    for document in iter_documents(path):
+        kind = document.get("kind")
+        if kind == "Pod":
+            pod_spec = document.get("spec") or {}
+        elif kind in TEMPLATE_PATHS:
+            pod_spec = (nested(document, TEMPLATE_PATHS[kind]).get("spec") or {})
+        else:
+            continue
+        if pod_spec.get("automountServiceAccountToken") is not False:
+            errors.append(
+                f"{kind} must set automountServiceAccountToken: false for Kata-CC"
+            )
+        for volume in pod_spec.get("volumes") or []:
+            name = volume.get("name", "<unnamed>")
+            if "downwardAPI" in volume:
+                errors.append(
+                    f"{kind} volume {name} uses unsupported Downward API delivery"
+                )
+            projected = volume.get("projected") or {}
+            for source in projected.get("sources") or []:
+                if "downwardAPI" in source:
+                    errors.append(
+                        f"{kind} projected volume {name} uses unsupported Downward API delivery"
+                    )
+                if "serviceAccountToken" in source:
+                    errors.append(
+                        f"{kind} projected volume {name} uses unsupported ServiceAccount token delivery"
+                    )
+    if errors:
+        raise ValueError("\n".join(errors))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument("--allow-unsafe-identity-delivery", action="store_true")
+    parser.add_argument("--images-output", type=Path)
+    parser.add_argument("--node-name")
+    parser.add_argument("--objects-output", type=Path)
+    parser.add_argument("--pods-output", type=Path)
+    parser.add_argument("--dynamic-output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        images = validate_image_references(args.input)
+        if not args.allow_unsafe_identity_delivery:
+            validate_guest_identity_delivery(args.input)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)
+    if args.images_output:
+        args.images_output.write_text(
+            "".join(f"{image}\n" for image in sorted(images)),
+            encoding="utf-8",
+        )
+    if args.validate_only:
+        return
+    for name in (
+        "node_name",
+        "objects_output",
+        "pods_output",
+        "dynamic_output",
+    ):
+        if getattr(args, name) is None:
+            parser.error(f"--{name.replace('_', '-')} is required")
+
+    defaulted_objects = []
+    pods = []
+    dynamic_values = [
+        {
+            "source": "profile",
+            "suggested_regex": "[a-z0-9](?:[-a-z0-9]*[a-z0-9])?",
+            "tag": "node.name",
+            "value": args.node_name,
+        }
+    ]
+
+    for document in iter_documents(args.input):
+        metadata = document.setdefault("metadata", {})
+        namespace = metadata.get("namespace", "default")
+        ensure_namespace(namespace)
+
+        kind = document.get("kind")
+        if kind == "Pod":
+            document.setdefault("spec", {})["nodeName"] = args.node_name
+
+        created = kubectl_create(document)
+        defaulted_objects.append(created)
+
+        if kind != "Pod" and kind not in TEMPLATE_PATHS:
+            continue
+
+        if kind == "Pod":
+            pod = created
+            generated_name = bool(document.get("metadata", {}).get("generateName"))
+        else:
+            pod_input, generated_name = pod_from_workload(created, args.node_name)
+            pod = kubectl_create(pod_input)
+
+        pods.append(pod)
+        metadata = pod["metadata"]
+        dynamic_values.append(
+            {
+                "source": "api-server",
+                "suggested_regex": (
+                    "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+                    "[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+                ),
+                "tag": "pod.uid",
+                "value": metadata["uid"],
+            }
+        )
+        if generated_name:
+            dynamic_values.append(
+                {
+                    "source": "api-server",
+                    "suggested_regex": (
+                        "[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
+                    ),
+                    "tag": "pod.name",
+                    "value": metadata["name"],
+                }
+            )
+
+    if not pods:
+        print("input did not contain a supported workload", file=sys.stderr)
+        raise SystemExit(1)
+
+    args.objects_output.write_text(
+        json.dumps(defaulted_objects, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.pods_output.write_text(
+        json.dumps(pods, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    args.dynamic_output.write_text(
+        json.dumps(dynamic_values, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/genpolicy/nested-policy-compat/appliance/scripts/watch_device_mapper_nodes.py
+++ b/src/tools/genpolicy/nested-policy-compat/appliance/scripts/watch_device_mapper_nodes.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import stat
+import time
+from pathlib import Path
+
+
+SYS_BLOCK = Path("/sys/block")
+DEV_ROOT = Path("/dev")
+DEV_MAPPER = DEV_ROOT / "mapper"
+
+
+def ensure_node(path: Path, device: int) -> None:
+    if os.path.lexists(path):
+        return
+    try:
+        os.mknod(path, stat.S_IFBLK | 0o600, device)
+    except FileExistsError:
+        pass
+
+
+def reconcile() -> None:
+    DEV_MAPPER.mkdir(parents=True, exist_ok=True)
+    active = set()
+    for device in SYS_BLOCK.glob("dm-*"):
+        try:
+            name = (device / "dm" / "name").read_text(encoding="utf-8").strip()
+            major, minor = (int(value) for value in (device / "dev").read_text().split(":"))
+        except (OSError, ValueError):
+            continue
+        if not name.startswith("containerd-erofs-"):
+            continue
+        active.add(name)
+        kernel_path = DEV_ROOT / device.name
+        ensure_node(kernel_path, os.makedev(major, minor))
+        path = DEV_MAPPER / name
+        ensure_node(path, os.makedev(major, minor))
+    for path in DEV_MAPPER.glob("containerd-erofs-*"):
+        if path.name not in active:
+            path.unlink(missing_ok=True)
+
+
+def main() -> None:
+    while True:
+        reconcile()
+        time.sleep(0.01)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/genpolicy/nested-policy-compat/config/containerd-erofs.toml.in
+++ b/src/tools/genpolicy/nested-policy-compat/config/containerd-erofs.toml.in
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version = 4
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.transfer.v1.local"]
+  [[plugins."io.containerd.transfer.v1.local".unpack_config]]
+    platform = "linux/amd64"
+    snapshotter = "erofs"
+    differ = "erofs"
+
+[plugins."io.containerd.cri.v1.images"]
+  snapshotter = "erofs"
+
+  [plugins."io.containerd.cri.v1.images".runtime_platforms.runc]
+    platform = "linux/amd64"
+    snapshotter = "native"
+
+  [plugins."io.containerd.cri.v1.images".runtime_platforms.kata]
+    platform = "linux/amd64"
+    snapshotter = "erofs"
+
+  [plugins."io.containerd.cri.v1.images".pinned_images]
+    sandbox = "@PAUSE_IMAGE@"
+
+  [plugins."io.containerd.cri.v1.images".registry]
+    config_path = "/etc/containerd/certs.d"
+
+[plugins."io.containerd.cri.v1.runtime"]
+  [plugins."io.containerd.cri.v1.runtime".cni]
+    bin_dirs = ["/opt/cni/bin"]
+    conf_dir = "/etc/cni/net.d"
+
+  [plugins."io.containerd.cri.v1.runtime".containerd]
+    default_runtime_name = "runc"
+
+    [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+      runtime_type = "io.containerd.runc.v2"
+
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+        BinaryName = "/usr/local/bin/runc.real"
+        SystemdCgroup = false
+
+    [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata]
+      runtime_type = "io.containerd.kata.v2"
+      snapshotter = "erofs"
+      pod_annotations = ["io.katacontainers.*"]
+      container_annotations = ["io.katacontainers.*"]
+
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata.options]
+        ConfigPath = "@KATA_CONFIG@"
+
+[plugins."io.containerd.differ.v1.erofs"]
+  mkfs_options = ["-T0", "--mkfs-time", "--sort=none"]
+  enable_tar_index = false
+  enable_dmverity = true
+
+[plugins."io.containerd.snapshotter.v1.erofs"]
+  # Let the Agent create the writable overlay upper under /run. A host-backed
+  # ext4 upper would add an unverified storage that GenPolicy cannot declare.
+  default_size = "0"
+  enable_fsverity = false
+  dmverity_mode = "on"
+
+[plugins."io.containerd.service.v1.diff-service"]
+  default = ["erofs", "walking"]

--- a/src/tools/genpolicy/nested-policy-compat/config/containerd-generation-v2.toml
+++ b/src/tools/genpolicy/nested-policy-compat/config/containerd-generation-v2.toml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.grpc.v1.cri"]
+  sandbox_image = "@PAUSE_IMAGE@"
+
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    snapshotter = "native"
+
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/src/tools/genpolicy/nested-policy-compat/config/containerd-generation.toml
+++ b/src/tools/genpolicy/nested-policy-compat/config/containerd-generation.toml
@@ -1,0 +1,21 @@
+version = 4
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.transfer.v1.local"]
+  [[plugins."io.containerd.transfer.v1.local".unpack_config]]
+    platform = "linux/amd64"
+    snapshotter = "native"
+    differ = "walking"
+
+[plugins."io.containerd.cri.v1.images"]
+  snapshotter = "native"
+
+  [plugins."io.containerd.cri.v1.images".pinned_images]
+    sandbox = "@PAUSE_IMAGE@"
+
+  [plugins."io.containerd.cri.v1.images".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/src/tools/genpolicy/nested-policy-compat/config/containerd-guest-pull-v2.toml.in
+++ b/src/tools/genpolicy/nested-policy-compat/config/containerd-guest-pull-v2.toml.in
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.grpc.v1.cri"]
+  sandbox_image = "@PAUSE_IMAGE@"
+
+  [plugins."io.containerd.grpc.v1.cri".cni]
+    bin_dir = "/opt/cni/bin"
+    conf_dir = "/etc/cni/net.d"
+
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    snapshotter = "native"
+    default_runtime_name = "runc"
+
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+      runtime_type = "io.containerd.runc.v2"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+        BinaryName = "/usr/local/bin/runc.real"
+        SystemdCgroup = false
+
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+      runtime_type = "io.containerd.kata.v2"
+      snapshotter = "native"
+      pod_annotations = ["io.katacontainers.*"]
+      container_annotations = ["io.katacontainers.*"]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
+        ConfigPath = "@KATA_CONFIG@"
+
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"

--- a/src/tools/genpolicy/nested-policy-compat/config/containerd-guest-pull-v4.toml.in
+++ b/src/tools/genpolicy/nested-policy-compat/config/containerd-guest-pull-v4.toml.in
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version = 4
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.cri.v1.images"]
+  snapshotter = "native"
+
+  [plugins."io.containerd.cri.v1.images".runtime_platforms.runc]
+    platform = "linux/amd64"
+    snapshotter = "native"
+
+  [plugins."io.containerd.cri.v1.images".runtime_platforms.kata]
+    platform = "linux/amd64"
+    snapshotter = "native"
+
+  [plugins."io.containerd.cri.v1.images".pinned_images]
+    sandbox = "@PAUSE_IMAGE@"
+
+  [plugins."io.containerd.cri.v1.images".registry]
+    config_path = "/etc/containerd/certs.d"
+
+[plugins."io.containerd.cri.v1.runtime"]
+  [plugins."io.containerd.cri.v1.runtime".cni]
+    bin_dirs = ["/opt/cni/bin"]
+    conf_dir = "/etc/cni/net.d"
+
+  [plugins."io.containerd.cri.v1.runtime".containerd]
+    default_runtime_name = "runc"
+
+    [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+      runtime_type = "io.containerd.runc.v2"
+
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+        BinaryName = "/usr/local/bin/runc.real"
+        SystemdCgroup = false
+
+    [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata]
+      runtime_type = "io.containerd.kata.v2"
+      snapshotter = "native"
+      pod_annotations = ["io.katacontainers.*"]
+      container_annotations = ["io.katacontainers.*"]
+
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata.options]
+        ConfigPath = "@KATA_CONFIG@"

--- a/src/tools/genpolicy/nested-policy-compat/scripts/compat_report.py
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/compat_report.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+
+DENIAL = re.compile(
+    r"(policy.{0,80}(?:denied|deny|not allowed|refused)|"
+    r"(?:denied|refused).{0,80}(?:request|policy)|"
+    r"AllowRequestsFailingPolicy)",
+    re.IGNORECASE,
+)
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def denial_excerpt(log_dir):
+    for path in sorted(log_dir.rglob("*.log")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        match = DENIAL.search(text)
+        if match:
+            start = max(0, text.rfind("\n", 0, match.start()) + 1)
+            end = text.find("\n", match.end())
+            if end < 0:
+                end = len(text)
+            return {"file": str(path), "text": text[start:end][:2000]}
+    return None
+
+
+def build_report(args):
+    capture_state = {}
+    if args.capture_state.exists():
+        capture_state = json.loads(args.capture_state.read_text(encoding="utf-8"))
+
+    denial = denial_excerpt(args.logs)
+    if args.ready:
+        result = "compatible"
+    elif denial:
+        result = "policy-incompatible"
+    else:
+        result = "infrastructure-failure"
+
+    return {
+        "base_appliance_exit_code": args.base_exit_code,
+        "capture": capture_state,
+        "denial": denial,
+        "kata_config": {
+            "path": str(args.kata_config),
+            "sha256": sha256(args.kata_config) if args.kata_config.is_file() else None,
+        },
+        "profile": args.profile,
+        "result": result,
+        "workload": {
+            "path": str(args.workload),
+            "sha256": sha256(args.workload),
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-exit-code", type=int, required=True)
+    parser.add_argument("--capture-state", type=Path, required=True)
+    parser.add_argument("--kata-config", type=Path, required=True)
+    parser.add_argument("--logs", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--ready", action="store_true")
+    parser.add_argument("--workload", type=Path, required=True)
+    args = parser.parse_args()
+
+    args.output.write_text(
+        json.dumps(build_report(args), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/genpolicy/nested-policy-compat/scripts/ensure_host_environment.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/ensure_host_environment.sh
@@ -34,7 +34,7 @@ if [[ -z "${container_engine}" || ! -x "${container_engine}" ]]; then
 	echo "Podman or Docker is required to install and run the compatibility environment" >&2
 	exit 1
 fi
-for command in cargo find git make python3 sha256sum tar; do
+for command in cargo find git make python3 sha256sum tar yq; do
 	if ! command -v "${command}" >/dev/null 2>&1; then
 		echo "required host command is unavailable: ${command}" >&2
 		exit 1

--- a/src/tools/genpolicy/nested-policy-compat/scripts/ensure_host_environment.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/ensure_host_environment.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 3 ]]; then
+	echo "usage: $0 KATA_ROOT KATA_CONFIG CONTAINER_ENGINE" >&2
+	exit 2
+fi
+
+kata_root=$1
+kata_config=$2
+container_engine=$3
+artifact_image=${KATA_ARTIFACT_IMAGE:-quay.io/kata-containers/kata-deploy-ci:kata-containers-latest}
+artifact_dir=${KATA_ARTIFACT_DIR:-}
+approval=${APPROVE_KATA_INSTALL:-no}
+rootfs_mode=${ROOTFS_MODE:-unknown}
+flat_vmdk_repo=${FLAT_VMDK_CLOUD_HYPERVISOR_REPO:-https://github.com/cloud-hypervisor/cloud-hypervisor.git}
+flat_vmdk_commit=${FLAT_VMDK_CLOUD_HYPERVISOR_COMMIT:-f50661fffd0fef38ddfec88c5fafa93f9779149a}
+
+required_devices=(/dev/kvm /dev/net/tun)
+for device in "${required_devices[@]}"; do
+	if [[ ! -c "${device}" ]]; then
+		echo "required device is unavailable: ${device}" >&2
+		exit 1
+	fi
+done
+if [[ -z "${container_engine}" || ! -x "${container_engine}" ]]; then
+	echo "Podman or Docker is required to install and run the compatibility environment" >&2
+	exit 1
+fi
+for command in cargo find git make python3 sha256sum tar; do
+	if ! command -v "${command}" >/dev/null 2>&1; then
+		echo "required host command is unavailable: ${command}" >&2
+		exit 1
+	fi
+done
+if ! tar --help 2>&1 | grep -F -- --zstd >/dev/null; then
+	echo "host tar does not support --zstd" >&2
+	exit 1
+fi
+if [[ "$(stat -fc %T /sys/fs/cgroup)" != cgroup2fs ]]; then
+	echo "cgroup v2 is required" >&2
+	exit 1
+fi
+if ! "${container_engine}" info >/dev/null 2>&1; then
+	echo "cannot access the selected container engine: ${container_engine}" >&2
+	exit 1
+fi
+if [[ "${rootfs_mode}" == erofs-dmverity ]]; then
+	for command in bison dmsetup flex losetup m4 modprobe pkg-config; do
+		if ! command -v "${command}" >/dev/null 2>&1; then
+			echo "EROFS dm-verity requires host command: ${command}" >&2
+			exit 1
+		fi
+	done
+	if [[ ! -c /dev/mapper/control ]]; then
+		echo "EROFS dm-verity requires /dev/mapper/control" >&2
+		exit 1
+	fi
+fi
+
+required_artifacts=(
+	"${kata_root}/bin/cloud-hypervisor"
+	"${kata_root}/share/kata-containers/vmlinux.container"
+	"${kata_root}/runtime-rs/bin/containerd-shim-kata-v2"
+	"${kata_root}/share/kata-containers/kata-containers-confidential.img"
+	"${kata_root}/share/kata-containers/root_hash_confidential.txt"
+)
+missing=()
+for artifact in "${required_artifacts[@]}"; do
+	[[ -e "${artifact}" ]] || missing+=("${artifact}")
+done
+vmm="${kata_root}/bin/cloud-hypervisor"
+if [[ "${rootfs_mode}" == erofs-dmverity && -f "${vmm}" ]] &&
+	! grep -aF 'FlatVmdk' "${vmm}" >/dev/null; then
+	missing+=("${vmm} (lacks flat-VMDK support)")
+fi
+if [[ "${rootfs_mode}" == erofs-dmverity ]] &&
+	! grep -qw erofs /proc/filesystems; then
+	missing+=("host EROFS filesystem support (module erofs is not loaded)")
+fi
+if [[ ! -f "${kata_config}" ]]; then
+	missing+=("${kata_config}")
+elif ! python3 - "${kata_config}" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as stream:
+    configuration = tomllib.load(stream)
+runtime = configuration.get("runtime", {})
+hypervisor_name = runtime.get("hypervisor_name")
+hypervisor = configuration.get("hypervisor", {}).get(hypervisor_name, {})
+annotations = hypervisor.get("enable_annotations", [])
+raise SystemExit(
+    0
+    if hypervisor_name == "clh"
+    and hypervisor.get("shared_fs") == "none"
+    and "cc_init_data" in annotations
+    else 1
+)
+PY
+then
+	missing+=("${kata_config} (must select clh, enable cc_init_data, and set shared_fs=none)")
+fi
+if [[ "${#missing[@]}" -eq 0 ]]; then
+	exit 0
+fi
+
+if [[ "${approval}" != yes ]]; then
+	echo "the nested compatibility host environment is incomplete:" >&2
+	printf '  missing %s\n' "${missing[@]}" >&2
+	cat >&2 <<EOF
+
+Installing it writes Kata binaries, the guest kernel, confidential image, root
+hash, and a dedicated runtime configuration under ${kata_root}. By default the
+artifacts are pulled from ${artifact_image}; set KATA_ARTIFACT_DIR to use
+previously downloaded tarballs instead.
+For EROFS, an artifact VMM without flat-VMDK support is replaced by a build of
+${flat_vmdk_repo} at pinned commit ${flat_vmdk_commit}.
+The approved path also loads the host EROFS kernel module.
+
+Review the image and destination, then approve the installation with:
+  make -C src/tools/genpolicy/nested-policy-compat fixture-e2e \\
+    APPROVE_KATA_INSTALL=yes \\
+    KATA_ROOT=${kata_root} \\
+    KATA_CONFIG=${kata_config} \\
+    OUTPUT_ROOT=/path/to/test-results
+EOF
+	exit 1
+fi
+
+if [[ -e "${kata_root}" && ! -d "${kata_root}" ]]; then
+	echo "KATA_ROOT is not a directory: ${kata_root}" >&2
+	exit 1
+fi
+mkdir -p "${kata_root}"
+if [[ ! -w "${kata_root}" ]]; then
+	echo "KATA_ROOT is not writable: ${kata_root}" >&2
+	exit 1
+fi
+
+workdir=$(mktemp -d)
+container=
+cleanup() {
+	if [[ -n "${container}" ]]; then
+		"${container_engine}" rm -f "${container}" >/dev/null 2>&1 || true
+	fi
+	rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+if [[ -n "${artifact_dir}" ]]; then
+	artifact_dir=$(readlink -f "${artifact_dir}")
+	if [[ ! -d "${artifact_dir}" ]]; then
+		echo "KATA_ARTIFACT_DIR not found: ${artifact_dir}" >&2
+		exit 1
+	fi
+	echo "installing nested compatibility prerequisites from ${artifact_dir}"
+else
+	echo "installing nested compatibility prerequisites from ${artifact_image}"
+	"${container_engine}" pull "${artifact_image}"
+	container=$("${container_engine}" create "${artifact_image}")
+	"${container_engine}" cp \
+		"${container}:/opt/kata-artifacts/tarballs" "${workdir}/tarballs"
+	artifact_dir="${workdir}/tarballs"
+fi
+
+for archive in \
+	kata-static-cloud-hypervisor.tar.zst \
+	kata-static-kernel.tar.zst \
+	kata-static-shim-v2-rust.tar.zst \
+	kata-static-rootfs-image-confidential.tar.zst; do
+	path="${artifact_dir}/${archive}"
+	if [[ ! -f "${path}" ]]; then
+		echo "artifact image is missing required archive: ${archive}" >&2
+		exit 1
+	fi
+	tar --zstd -xf "${path}" -C "${kata_root}" --strip-components=3
+done
+
+source_config="${kata_root}/share/defaults/kata-containers/runtime-rs/configuration-clh-runtime-rs.toml"
+if [[ ! -f "${source_config}" ]]; then
+	echo "installed artifacts are missing the Cloud Hypervisor runtime-rs configuration" >&2
+	exit 1
+fi
+mkdir -p "$(dirname "${kata_config}")"
+python3 - "${source_config}" "${kata_config}" <<'PY'
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+with source.open("rb") as stream:
+    configuration = tomllib.load(stream)
+
+runtime = configuration.get("runtime", {})
+hypervisor_name = runtime.get("hypervisor_name")
+if hypervisor_name != "clh":
+    raise SystemExit(f"expected Cloud Hypervisor configuration, got {hypervisor_name!r}")
+
+lines = source.read_text(encoding="utf-8").splitlines()
+in_hypervisor = False
+annotations_replaced = False
+shared_fs_replaced = False
+header = f"[hypervisor.{hypervisor_name}]"
+for index, line in enumerate(lines):
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        in_hypervisor = stripped == header
+    elif in_hypervisor and stripped.startswith("enable_annotations"):
+        annotations = list(
+            configuration["hypervisor"][hypervisor_name].get(
+                "enable_annotations", []
+            )
+        )
+        if "cc_init_data" not in annotations:
+            annotations.append("cc_init_data")
+        lines[index] = f"enable_annotations = {json.dumps(annotations)}"
+        annotations_replaced = True
+    elif in_hypervisor and stripped.startswith("shared_fs"):
+        lines[index] = 'shared_fs = "none"'
+        shared_fs_replaced = True
+
+if not annotations_replaced or not shared_fs_replaced:
+    raise SystemExit(
+        f"{source} lacks enable_annotations or shared_fs in {header}"
+    )
+destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+
+if [[ "${rootfs_mode}" == erofs-dmverity ]] &&
+	! grep -aF 'FlatVmdk' "${vmm}" >/dev/null; then
+	echo "building flat-VMDK Cloud Hypervisor ${flat_vmdk_commit}"
+	vmm_source="${workdir}/cloud-hypervisor"
+	git init --quiet "${vmm_source}"
+	git -C "${vmm_source}" remote add origin "${flat_vmdk_repo}"
+	git -C "${vmm_source}" fetch --quiet --depth 1 origin "${flat_vmdk_commit}"
+	if [[ "$(git -C "${vmm_source}" rev-parse FETCH_HEAD)" != "${flat_vmdk_commit}" ]]; then
+		echo "fetched Cloud Hypervisor commit does not match the pinned revision" >&2
+		exit 1
+	fi
+	git -C "${vmm_source}" checkout --quiet --detach FETCH_HEAD
+	cargo build --locked --release \
+		--manifest-path "${vmm_source}/Cargo.toml" \
+		--package cloud-hypervisor
+	install -D -m 0755 \
+		"${vmm_source}/target/release/cloud-hypervisor" "${vmm}.new"
+	mv -f "${vmm}.new" "${vmm}"
+	if ! grep -aF 'FlatVmdk' "${vmm}" >/dev/null; then
+		echo "rebuilt Cloud Hypervisor still lacks flat-VMDK support" >&2
+		exit 1
+	fi
+fi
+
+if [[ "${rootfs_mode}" == erofs-dmverity ]] &&
+	! grep -qw erofs /proc/filesystems; then
+	if ! modprobe erofs; then
+		echo "the running host kernel does not provide a loadable EROFS module" >&2
+		exit 1
+	fi
+	if ! grep -qw erofs /proc/filesystems; then
+		echo "EROFS is still unavailable after loading the host module" >&2
+		exit 1
+	fi
+fi
+
+echo "installed nested compatibility host environment under ${kata_root}"

--- a/src/tools/genpolicy/nested-policy-compat/scripts/ensure_kata_source_provenance.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/ensure_kata_source_provenance.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 4 ]]; then
+	echo "usage: $0 REPO_ROOT KATA_ROOT KATA_CONFIG CONTAINER_ENGINE" >&2
+	exit 2
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+if "${script_dir}/verify_kata_source_provenance.sh" "$1" "$2" "$3"; then
+	exit 0
+fi
+
+echo "installed Kata components are stale; rebuilding from the current checkout"
+"${script_dir}/rebuild_kata_stack.sh" "$1" "$2" "$3" "$4"
+"${script_dir}/verify_kata_source_provenance.sh" "$1" "$2" "$3"

--- a/src/tools/genpolicy/nested-policy-compat/scripts/entrypoint.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/entrypoint.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly harness_root="${NESTED_POLICY_COMPAT_ROOT:-/opt/nested-policy-compat}"
+readonly appliance_root="${GENPOLICY_APPLIANCE_ROOT:-/opt/genpolicy/appliance}"
+readonly input_dir="${GENPOLICY_INPUT_DIR:-/input}"
+readonly output_dir="${GENPOLICY_OUTPUT_DIR:-/output}"
+readonly workload="${input_dir}/workload.yaml"
+readonly kata_root="${NESTED_KATA_ROOT:-/opt/kata}"
+readonly kata_config="${NESTED_KATA_CONFIG:-${kata_root}/share/defaults/kata-containers/runtime-rs/configuration.toml}"
+readonly timeout_seconds="${NESTED_POLICY_TIMEOUT_SECONDS:-240}"
+readonly profile="${GENPOLICY_PROFILE_NAME:-unknown}"
+readonly profile_path="${appliance_root}/profiles/${profile}.env"
+runtime_kata_config="${kata_config}"
+
+[[ -f "${profile_path}" ]] || {
+	echo "ERROR: unknown compatibility profile: ${profile}" >&2
+	exit 1
+}
+# shellcheck source=/dev/null
+source "${profile_path}"
+
+base_pid=
+relay_pid=
+
+cleanup() {
+	if [[ -n "${base_pid}" ]]; then
+		kill "${base_pid}" 2>/dev/null || true
+	fi
+	if [[ -n "${relay_pid}" ]]; then
+		kill "${relay_pid}" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT
+
+fail() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+
+[[ "$(id -u)" == "0" ]] || fail "the harness must run as root"
+[[ -f "${workload}" ]] || fail "${workload} is required"
+[[ -f "${kata_config}" ]] || fail "Kata configuration not found: ${kata_config}"
+[[ -c /dev/kvm ]] || fail "/dev/kvm is required; enable nested virtualization in the L1 VM"
+[[ -x "${appliance_root}/scripts/entrypoint.sh" ]] ||
+	fail "base appliance entrypoint is missing"
+
+export PATH="${kata_root}/runtime-rs/bin:${kata_root}/bin:${PATH}"
+command -v containerd-shim-kata-v2 >/dev/null ||
+	fail "containerd-shim-kata-v2 was not found under ${kata_root}"
+
+# ROOTFS_MODE is loaded from the selected profile.
+# shellcheck disable=SC2154
+python3 - "${workload}" "${kata_config}" "${ROOTFS_MODE}" <<'PY'
+import re
+import sys
+import tomllib
+import yaml
+from pathlib import Path
+
+annotation = "io.katacontainers.config.hypervisor.cc_init_data"
+annotation_name = "cc_init_data"
+paths = (
+    ("metadata", "annotations"),
+    ("spec", "template", "metadata", "annotations"),
+    ("spec", "jobTemplate", "spec", "template", "metadata", "annotations"),
+)
+
+def nested(value, path):
+    for part in path:
+        if not isinstance(value, dict):
+            return {}
+        value = value.get(part, {})
+    return value if isinstance(value, dict) else {}
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    documents = [value for value in yaml.safe_load_all(source) if value]
+
+if not any(annotation in nested(document, path) for document in documents for path in paths):
+    raise SystemExit(
+        f"workload does not contain externally generated {annotation} annotation"
+    )
+
+with open(sys.argv[2], "rb") as source:
+    configuration = tomllib.load(source)
+runtime = configuration.get("runtime", {})
+hypervisor_name = runtime.get("hypervisor_name")
+hypervisor = configuration.get("hypervisor", {}).get(hypervisor_name, {})
+enabled = hypervisor.get("enable_annotations", [])
+if not any(re.fullmatch(pattern, annotation_name) for pattern in enabled):
+    raise SystemExit(
+        f"Kata configuration does not enable the {annotation_name} annotation"
+    )
+
+if sys.argv[3] == "erofs-dmverity" and hypervisor.get("shared_fs") != "none":
+    raise SystemExit(
+        "EROFS dm-verity profile requires the selected Kata hypervisor "
+        'configuration to set shared_fs = "none"'
+    )
+
+if sys.argv[3] == "erofs-dmverity" and hypervisor_name == "clh":
+    vmm_path = Path(hypervisor.get("path", ""))
+    if not vmm_path.is_file():
+        raise SystemExit(f"Cloud Hypervisor binary not found: {vmm_path}")
+    if b"FlatVmdk" not in vmm_path.read_bytes():
+        raise SystemExit(
+            "EROFS dm-verity with Cloud Hypervisor requires flat VMDK support "
+            "(cloud-hypervisor/cloud-hypervisor PR #8599)"
+        )
+PY
+
+mkdir -p "${output_dir}/logs" "${output_dir}/agent-rpcs"
+chmod 0700 "${output_dir}/agent-rpcs"
+
+containerd_version=$(containerd --version)
+confidential_image="${kata_root}/share/kata-containers/kata-containers-confidential.img"
+confidential_hash="${kata_root}/share/kata-containers/root_hash_confidential.txt"
+[[ -f "${confidential_image}" ]] ||
+	fail "monolithic compatibility guest image not found: ${confidential_image}"
+[[ -f "${confidential_hash}" ]] ||
+	fail "monolithic compatibility guest image verity parameters not found: ${confidential_hash}"
+runtime_kata_config=/run/nested-policy-compat-kata.toml
+python3 - \
+	"${kata_config}" "${runtime_kata_config}" \
+	"${confidential_image}" "${confidential_hash}" "${ROOTFS_MODE}" <<'PY'
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+source, destination, confidential_image, confidential_hash = map(Path, sys.argv[1:5])
+rootfs_mode = sys.argv[5]
+with source.open("rb") as stream:
+    configuration = tomllib.load(stream)
+
+runtime = configuration.get("runtime", {})
+experimental = list(runtime.get("experimental", []))
+if rootfs_mode == "guest-pull" and "force_guest_pull" not in experimental:
+    experimental.append("force_guest_pull")
+if rootfs_mode != "guest-pull" and "force_guest_pull" in experimental:
+    experimental.remove("force_guest_pull")
+
+hypervisor_name = runtime.get("hypervisor_name")
+
+lines = source.read_text(encoding="utf-8").splitlines()
+in_runtime = False
+in_hypervisor = False
+runtime_replaced = False
+image_replaced = False
+verity_replaced = False
+hypervisor_header = f"[hypervisor.{hypervisor_name}]"
+hypervisor_end = None
+for index, line in enumerate(lines):
+    stripped = line.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        if in_hypervisor:
+            hypervisor_end = index
+        in_runtime = stripped == "[runtime]"
+        in_hypervisor = stripped == hypervisor_header
+    elif in_runtime and stripped.startswith("experimental"):
+        lines[index] = f"experimental = {json.dumps(experimental)}"
+        runtime_replaced = True
+    elif in_hypervisor and stripped.startswith("image ="):
+        lines[index] = f"image = {json.dumps(str(confidential_image))}"
+        image_replaced = True
+    elif in_hypervisor and stripped.startswith("kernel_verity_params ="):
+        lines[index] = (
+            "kernel_verity_params = "
+            f"{json.dumps(confidential_hash.read_text(encoding='utf-8').strip())}"
+        )
+        verity_replaced = True
+if not runtime_replaced:
+    raise SystemExit("Kata configuration has no runtime.experimental setting")
+if not image_replaced:
+    raise SystemExit(f"Kata configuration has no image setting in {hypervisor_header}")
+if not verity_replaced:
+    if hypervisor_end is None:
+        hypervisor_end = len(lines)
+    lines.insert(
+        hypervisor_end,
+        "kernel_verity_params = "
+        f"{json.dumps(confidential_hash.read_text(encoding='utf-8').strip())}",
+    )
+destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+
+case "${ROOTFS_MODE}" in
+erofs-dmverity)
+	case "${containerd_version}" in
+	*" v2."*) ;;
+	*) fail "EROFS dm-verity profile requires containerd 2.x: ${containerd_version}" ;;
+	esac
+	;;
+guest-pull)
+	;;
+*) fail "unsupported rootfs mode: ${ROOTFS_MODE}" ;;
+esac
+
+# RUNTIME_CONTAINERD_CONFIG and PAUSE_IMAGE are loaded from the selected profile.
+# shellcheck disable=SC2154
+python3 - \
+		"${harness_root}/config/${RUNTIME_CONTAINERD_CONFIG}" \
+		"${appliance_root}/config/nested-policy-compat.toml" \
+		"${runtime_kata_config}" "${PAUSE_IMAGE}" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+kata_config = Path(sys.argv[3])
+pause_image = sys.argv[4]
+text = source.read_text(encoding="utf-8")
+destination.write_text(
+    text.replace("@KATA_CONFIG@", str(kata_config)).replace(
+        "@PAUSE_IMAGE@",
+        pause_image,
+    ),
+    encoding="utf-8",
+)
+PY
+
+{
+	echo "profile=${profile}"
+	kubelet --version
+	containerd --version
+	containerd-shim-kata-v2 --version || true
+	uname -a
+} >"${output_dir}/component-versions.txt" 2>&1
+
+{
+	sha256sum "$(command -v containerd-shim-kata-v2)" "${runtime_kata_config}"
+	find "${kata_root}/share/kata-containers" -maxdepth 1 -type f \
+		-exec sha256sum {} +
+} >"${output_dir}/kata-artifacts.sha256" 2>"${output_dir}/logs/kata-artifacts.log"
+
+relay_args=(
+	--root /run/vc
+	--root /run/kata
+	--root /run/kata-containers
+	--name ch-vm.sock
+	--name kata.hvsock
+	--name vsock.sock
+	--output "${output_dir}/agent-rpcs"
+)
+python3 "${harness_root}/scripts/hvsock_capture.py" "${relay_args[@]}" \
+	>"${output_dir}/logs/hvsock-capture.log" 2>&1 &
+relay_pid=$!
+
+export CONTAINERD_CONFIG=nested-policy-compat.toml
+export GENPOLICY_NESTED_RUNTIME_ONLY=1
+
+"${appliance_root}/scripts/entrypoint.sh" \
+	>"${output_dir}/logs/base-appliance.log" 2>&1 &
+base_pid=$!
+
+ready=0
+base_exit=0
+deadline=$((SECONDS + timeout_seconds))
+while ((SECONDS < deadline)); do
+	if [[ -f "${output_dir}/runtime-operations.json" ]]; then
+		if python3 - "${output_dir}/runtime-operations.json" <<'PY'
+import json
+import sys
+
+report = json.load(open(sys.argv[1], encoding="utf-8"))
+raise SystemExit(0 if report.get("complete") is True else 1)
+PY
+		then
+			ready=1
+			break
+		fi
+	fi
+
+	if ! kill -0 "${base_pid}" 2>/dev/null; then
+		set +o errexit
+		wait "${base_pid}"
+		base_exit=$?
+		set -o errexit
+		base_pid=
+		break
+	fi
+	sleep 1
+done
+
+if [[ "${ready}" == "1" ]]; then
+	cp "${output_dir}/pod-status-ready.json" "${output_dir}/pod-status.json"
+	kubectl --kubeconfig /etc/kubernetes/kubeconfig get events --all-namespaces \
+		--sort-by=.metadata.creationTimestamp >"${output_dir}/events.txt" 2>&1 || true
+	kill "${base_pid}" 2>/dev/null || true
+	set +o errexit
+	wait "${base_pid}"
+	set -o errexit
+	base_pid=
+	base_exit=0
+elif [[ -n "${base_pid}" ]]; then
+	kill "${base_pid}" 2>/dev/null || true
+	set +o errexit
+	wait "${base_pid}"
+	base_exit=$?
+	set -o errexit
+	base_pid=
+	[[ "${base_exit}" -ne 0 ]] || base_exit=124
+fi
+
+sleep 1
+kill "${relay_pid}" 2>/dev/null || true
+set +o errexit
+wait "${relay_pid}"
+set -o errexit
+relay_pid=
+
+capture_state="${output_dir}/agent-rpcs/state.json"
+report_args=(
+	--base-exit-code "${base_exit}"
+	--capture-state "${capture_state}"
+	--kata-config "${kata_config}"
+	--logs "${output_dir}/logs"
+	--output "${output_dir}/compatibility.json"
+	--profile "${profile}"
+	--workload "${workload}"
+)
+[[ "${ready}" == "1" ]] && report_args+=(--ready)
+python3 "${harness_root}/scripts/compat_report.py" "${report_args[@]}"
+
+connections=$(python3 - "${capture_state}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+print(json.loads(path.read_text(encoding="utf-8")).get("connections", 0) if path.exists() else 0)
+PY
+)
+[[ "${connections}" -gt 0 ]] ||
+	fail "no hybrid-vsock connection was captured; use a supported hvsock Kata configuration"
+
+result=$(python3 - "${output_dir}/compatibility.json" <<'PY'
+import json
+import sys
+print(json.load(open(sys.argv[1], encoding="utf-8"))["result"])
+PY
+)
+echo "nested policy compatibility result: ${result}"
+[[ "${result}" == "compatible" ]]

--- a/src/tools/genpolicy/nested-policy-compat/scripts/entrypoint.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/entrypoint.sh
@@ -99,9 +99,9 @@ if not any(re.fullmatch(pattern, annotation_name) for pattern in enabled):
         f"Kata configuration does not enable the {annotation_name} annotation"
     )
 
-if sys.argv[3] == "erofs-dmverity" and hypervisor.get("shared_fs") != "none":
+if hypervisor.get("shared_fs") != "none":
     raise SystemExit(
-        "EROFS dm-verity profile requires the selected Kata hypervisor "
+        "nested policy compatibility profiles require the selected Kata hypervisor "
         'configuration to set shared_fs = "none"'
     )
 

--- a/src/tools/genpolicy/nested-policy-compat/scripts/generate_policy.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/generate_policy.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly input_dir="${GENPOLICY_INPUT_DIR:-/input}"
+readonly output_dir="${GENPOLICY_OUTPUT_DIR:-/output}"
+readonly workload="${input_dir}/workload.yaml"
+readonly appliance_root="${GENPOLICY_APPLIANCE_ROOT:-/opt/genpolicy/appliance}"
+readonly harness_root="${NESTED_POLICY_COMPAT_ROOT:-/opt/nested-policy-compat}"
+
+profile="${GENPOLICY_PROFILE_NAME:?GENPOLICY_PROFILE_NAME is required}"
+# shellcheck source=/dev/null
+source "${appliance_root}/profiles/${profile}.env"
+
+pids=()
+cleanup() {
+	local pid
+	for pid in "${pids[@]}"; do
+		kill "${pid}" 2>/dev/null || true
+	done
+}
+trap cleanup EXIT
+
+wait_for() {
+	local description=$1
+	shift
+	local _
+	for _ in $(seq 1 120); do
+		if "$@" >/dev/null 2>&1; then
+			return
+		fi
+		sleep 1
+	done
+	echo "timed out waiting for ${description}" >&2
+	exit 1
+}
+
+[[ -f "${workload}" ]] || {
+	echo "${workload} is required" >&2
+	exit 1
+}
+# LOCAL_REGISTRY is loaded from the selected profile.
+# shellcheck disable=SC2154
+mkdir -p "${output_dir}" /etc/containerd/certs.d/"${LOCAL_REGISTRY}" \
+	/etc/docker/registry /var/lib/registry /run/containerd /var/lib/containerd
+cp "${workload}" "${output_dir}/workload.yaml"
+readonly writable_workload="${output_dir}/workload.yaml"
+
+# Guest-pull profiles use the CNI bridge gateway as a registry address that is
+# reachable from both this isolated generator and the nested guest.
+# ROOTFS_MODE and LOCAL_REGISTRY are loaded from the selected profile.
+# shellcheck disable=SC2154
+if [[ "${ROOTFS_MODE}" == "guest-pull" ]]; then
+	registry_host=${LOCAL_REGISTRY%:*}
+	ip address add "${registry_host}/32" dev lo
+	python3 - \
+		"${writable_workload}" "${LOCAL_REGISTRY}" "${CONTAINERD_VERSION}" <<'PY'
+import sys
+from pathlib import Path
+
+import yaml
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8").replace("genpolicy.local:5000", sys.argv[2])
+documents = list(yaml.safe_load_all(text))
+if sys.argv[3].startswith("v1."):
+    for document in documents:
+        if not isinstance(document, dict):
+            continue
+        templates = [document]
+        if document.get("kind") in {"Deployment", "DaemonSet", "StatefulSet", "Job"}:
+            templates = [document.get("spec", {}).get("template", {})]
+        elif document.get("kind") == "CronJob":
+            templates = [
+                document.get("spec", {})
+                .get("jobTemplate", {})
+                .get("spec", {})
+                .get("template", {})
+            ]
+        for template in templates:
+            for container in template.get("spec", {}).get("containers", []):
+                lifecycle = container.get("lifecycle")
+                if isinstance(lifecycle, dict):
+                    lifecycle.pop("stopSignal", None)
+                    if not lifecycle:
+                        container.pop("lifecycle", None)
+path.write_text(yaml.safe_dump_all(documents, sort_keys=False), encoding="utf-8")
+PY
+else
+	printf '127.0.0.1 genpolicy.local\n' >>/etc/hosts
+fi
+
+cat >"/etc/containerd/certs.d/${LOCAL_REGISTRY}/hosts.toml" <<EOF
+server = "http://${LOCAL_REGISTRY}"
+
+[host."http://${LOCAL_REGISTRY}"]
+  capabilities = ["pull", "resolve", "push"]
+EOF
+cat >/etc/docker/registry/config.yml <<EOF
+version: 0.1
+storage:
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: ${LOCAL_REGISTRY}
+EOF
+
+registry serve /etc/docker/registry/config.yml \
+	>"${output_dir}/registry.log" 2>&1 &
+pids+=("$!")
+wait_for registry curl -fsS "http://${LOCAL_REGISTRY}/v2/"
+
+# GENPOLICY_CONTAINERD_CONFIG is loaded from the selected profile.
+# shellcheck disable=SC2154
+python3 - \
+	"${harness_root}/config/${GENPOLICY_CONTAINERD_CONFIG}" \
+	/run/containerd-generation.toml "${PAUSE_IMAGE}" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+destination.write_text(
+    source.read_text(encoding="utf-8").replace("@PAUSE_IMAGE@", sys.argv[3]),
+    encoding="utf-8",
+)
+PY
+containerd --config /run/containerd-generation.toml \
+	>"${output_dir}/containerd.log" 2>&1 &
+pids+=("$!")
+wait_for containerd ctr --address /run/containerd/containerd.sock version
+
+for image in /opt/genpolicy/images/*.tar; do
+	ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+		images import --digests "${image}" >/dev/null
+done
+if [[ "${PAUSE_IMAGE}" != "genpolicy.local:5000/pause:3.10" ]]; then
+	ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+		images tag "genpolicy.local:5000/pause:3.10" "${PAUSE_IMAGE}" >/dev/null
+fi
+if [[ -d "${input_dir}/images" ]]; then
+	while IFS= read -r -d '' image; do
+		ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+			images import --digests "${image}" >/dev/null
+	done < <(find "${input_dir}/images" -type f -name '*.tar' -print0)
+fi
+
+python3 "${appliance_root}/scripts/submit_workload.py" \
+	--input "${writable_workload}" \
+	--images-output "${output_dir}/requested-images.txt" \
+	--allow-unsafe-identity-delivery \
+	--validate-only
+
+while IFS= read -r image_ref; do
+	digest=${image_ref##*@}
+	if ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+		images list -q | grep -Fxq "${image_ref}"; then
+		continue
+	fi
+	source_ref=$(
+		ctr --address /run/containerd/containerd.sock --namespace k8s.io images list |
+			awk -v digest="${digest}" 'NR > 1 && $3 == digest { print $1; exit }'
+	)
+	[[ -n "${source_ref}" ]] || {
+		echo "no imported image has requested manifest digest ${digest}" >&2
+		exit 1
+	}
+	ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+		images tag "${source_ref}" "${image_ref}" >/dev/null
+done <"${output_dir}/requested-images.txt"
+
+while IFS= read -r image_ref; do
+	[[ "${image_ref}" == "${LOCAL_REGISTRY}/"* ]] || continue
+	ctr --address /run/containerd/containerd.sock --namespace k8s.io \
+		images push --plain-http "${image_ref}" >/dev/null
+done < <(ctr --address /run/containerd/containerd.sock --namespace k8s.io images list -q)
+
+settings_dir="${output_dir}/settings"
+mkdir -p "${settings_dir}/genpolicy-settings.d"
+cp /opt/genpolicy/policy/settings/genpolicy-settings.json "${settings_dir}/"
+cp /opt/genpolicy/policy/settings/genpolicy-settings.d/*.json \
+	"${settings_dir}/genpolicy-settings.d/"
+python3 - \
+	"${settings_dir}/genpolicy-settings.d/10-appliance.json" \
+	"${PAUSE_IMAGE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+patches = json.loads(path.read_text(encoding="utf-8"))
+for patch in patches:
+    if patch["path"] == "/cluster_config/pause_container_image":
+        patch["value"] = sys.argv[2]
+        break
+else:
+    raise SystemExit("appliance settings do not set pause_container_image")
+path.write_text(json.dumps(patches, indent=2) + "\n", encoding="utf-8")
+PY
+# GENPOLICY_SETTINGS is loaded from the selected profile.
+# shellcheck disable=SC2154
+profile_settings="${appliance_root}/profiles/${GENPOLICY_SETTINGS}"
+[[ -f "${profile_settings}" ]] || {
+	echo "profile settings not found: ${profile_settings}" >&2
+	exit 1
+}
+cp "${profile_settings}" "${settings_dir}/genpolicy-settings.d/20-profile.json"
+
+genpolicy \
+	--yaml-file "${writable_workload}" \
+	--rego-rules-path /opt/genpolicy/policy/rules.rego \
+	--json-settings-path "${settings_dir}" \
+	--containerd-socket-path=/run/containerd/containerd.sock \
+	--insecure-registry "${LOCAL_REGISTRY}" \
+	--silent-unsupported-fields \
+	--raw-out >"${output_dir}/policy.rego" \
+	2>"${output_dir}/genpolicy.log"
+
+test -s "${output_dir}/policy.rego"

--- a/src/tools/genpolicy/nested-policy-compat/scripts/hvsock_capture.py
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/hvsock_capture.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import socket
+import stat
+import threading
+import time
+from pathlib import Path
+
+
+BACKEND_SUFFIX = ".npc"
+
+
+class CaptureSupervisor:
+    def __init__(self, roots, names, output, poll_seconds=0.01):
+        self.roots = [Path(root) for root in roots]
+        self.names = set(names)
+        self.output = Path(output)
+        self.poll_seconds = poll_seconds
+        self.output.mkdir(parents=True, exist_ok=True, mode=0o700)
+        os.chmod(self.output, 0o700)
+        self.lock = threading.Lock()
+        self.stop_event = threading.Event()
+        self.listeners = {}
+        self.intercepted_paths = set()
+        self.active_connections = {}
+        self.connection_number = 0
+        self.errors = []
+        self.write_state()
+
+    def state(self):
+        with self.lock:
+            return {
+                "connections": self.connection_number,
+                "errors": list(self.errors),
+                "intercepted_sockets": sorted(
+                    str(path) for path in self.intercepted_paths
+                ),
+            }
+
+    def write_state(self):
+        state_path = self.output / "state.json"
+        temporary = state_path.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(self.state(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(state_path)
+
+    def add_error(self, message):
+        with self.lock:
+            self.errors.append(message)
+        self.write_state()
+
+    def candidate_paths(self):
+        for root in self.roots:
+            if not root.exists():
+                continue
+            for directory, _, files in os.walk(root):
+                for name in files:
+                    if name in self.names:
+                        yield Path(directory) / name
+
+    def scan_once(self):
+        for path in self.candidate_paths():
+            if path in self.listeners:
+                continue
+            try:
+                mode = path.stat().st_mode
+            except FileNotFoundError:
+                continue
+            if not stat.S_ISSOCK(mode):
+                continue
+            self.take_over(path, mode)
+
+    def take_over(self, path, mode):
+        backend = path.with_name(path.name + BACKEND_SUFFIX)
+        if backend.exists():
+            self.add_error(f"backend path already exists: {backend}")
+            return
+
+        try:
+            path.rename(backend)
+            listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            listener.bind(str(path))
+            os.chmod(path, stat.S_IMODE(mode))
+            listener.listen(16)
+            listener.settimeout(0.2)
+        except OSError as error:
+            if not path.exists() and backend.exists():
+                backend.rename(path)
+            self.add_error(f"failed to intercept {path}: {error}")
+            return
+
+        with self.lock:
+            self.listeners[path] = (listener, backend)
+            self.intercepted_paths.add(path)
+        self.write_state()
+        threading.Thread(
+            target=self.accept_connections,
+            args=(path, listener, backend),
+            daemon=True,
+        ).start()
+
+    def accept_connections(self, path, listener, backend):
+        while not self.stop_event.is_set():
+            try:
+                client, _ = listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+
+            try:
+                agent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                agent.connect(str(backend))
+            except OSError as error:
+                client.close()
+                self.add_error(f"failed to connect relay backend {backend}: {error}")
+                continue
+
+            with self.lock:
+                self.connection_number += 1
+                number = self.connection_number
+            self.write_state()
+            worker = threading.Thread(
+                target=self.capture_connection,
+                args=(number, path, client, agent),
+                daemon=True,
+            )
+            with self.lock:
+                self.active_connections[number] = (client, agent, worker)
+            worker.start()
+
+    def capture_connection(self, number, path, client, agent):
+        connection_dir = self.output / f"{number:06d}"
+        connection_dir.mkdir(mode=0o700)
+        metadata = {
+            "connection": number,
+            "socket": str(path),
+            "started_unix_ns": time.time_ns(),
+        }
+        (connection_dir / "metadata.json").write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        workers = [
+            threading.Thread(
+                target=self.copy_stream,
+                args=(
+                    client,
+                    agent,
+                    connection_dir / "shim-to-agent.bin",
+                ),
+            ),
+            threading.Thread(
+                target=self.copy_stream,
+                args=(
+                    agent,
+                    client,
+                    connection_dir / "agent-to-shim.bin",
+                ),
+            ),
+        ]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join()
+
+        try:
+            client.close()
+            agent.close()
+            metadata["finished_unix_ns"] = time.time_ns()
+            (connection_dir / "metadata.json").write_text(
+                json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        finally:
+            with self.lock:
+                self.active_connections.pop(number, None)
+
+    def copy_stream(self, source, destination, capture_path):
+        try:
+            with capture_path.open("wb") as capture:
+                while True:
+                    data = source.recv(1024 * 1024)
+                    if not data:
+                        break
+                    capture.write(data)
+                    capture.flush()
+                    destination.sendall(data)
+        except OSError as error:
+            self.add_error(f"relay stream failed: {error}")
+        finally:
+            try:
+                destination.shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+
+    def run(self):
+        while not self.stop_event.is_set():
+            self.scan_once()
+            self.stop_event.wait(self.poll_seconds)
+
+    def close(self):
+        self.stop_event.set()
+        with self.lock:
+            listeners = list(self.listeners.items())
+            self.listeners.clear()
+            connections = list(self.active_connections.values())
+        for path, (listener, backend) in listeners:
+            listener.close()
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            if backend.exists() and not path.exists():
+                try:
+                    backend.rename(path)
+                except OSError:
+                    pass
+        for client, agent, _ in connections:
+            for stream in (client, agent):
+                try:
+                    stream.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+        for _, _, worker in connections:
+            worker.join(timeout=2)
+        self.write_state()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", action="append", required=True)
+    parser.add_argument("--name", action="append", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--poll-ms", type=int, default=10)
+    args = parser.parse_args()
+
+    supervisor = CaptureSupervisor(
+        roots=args.root,
+        names=args.name,
+        output=args.output,
+        poll_seconds=args.poll_ms / 1000,
+    )
+
+    def stop(_signum, _frame):
+        supervisor.close()
+
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+    try:
+        supervisor.run()
+    finally:
+        supervisor.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/genpolicy/nested-policy-compat/scripts/image_input_fingerprint.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/image_input_fingerprint.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 4 ]]; then
+	echo "usage: $0 REPO_ROOT PROFILE_FILE KATA_ROOT KATA_CONFIG" >&2
+	exit 2
+fi
+
+repo_root=$1
+profile_file=$2
+kata_root=$3
+kata_config=$4
+staged_genpolicy="${repo_root}/src/tools/genpolicy/nested-policy-compat/build/genpolicy"
+
+if [[ ! -f "${profile_file}" ]]; then
+	echo "profile file not found: ${profile_file}" >&2
+	exit 1
+fi
+
+inputs=(
+	"${repo_root}/Cargo.lock"
+	"${repo_root}/Cargo.toml"
+	"${repo_root}/src/agent"
+	"${repo_root}/src/runtime-rs"
+	"${repo_root}/src/tools/genpolicy"
+)
+
+if [[ -n "${kata_config}" ]]; then
+	if [[ ! -f "${kata_config}" ]]; then
+		echo "Kata configuration not found: ${kata_config}" >&2
+		exit 1
+	fi
+	inputs+=("${kata_config}")
+fi
+
+if [[ -n "${kata_root}" ]]; then
+	for installed_input in \
+		"${kata_root}/runtime-rs/bin/containerd-shim-kata-v2" \
+		"${kata_root}/bin/kata-agent" \
+		"${kata_root}/share/kata-containers/kata-containers-confidential.img" \
+		"${kata_root}/share/kata-containers/root_hash_confidential.txt"; do
+		[[ ! -f "${installed_input}" ]] || inputs+=("${installed_input}")
+	done
+fi
+
+{
+	printf 'profile=%s\n' "${profile_file}"
+	printf 'staged-genpolicy\0'
+	if [[ -f "${staged_genpolicy}" ]]; then
+		sha256sum "${staged_genpolicy}"
+	else
+		printf 'missing\n'
+	fi
+	while IFS= read -r -d '' input; do
+		relative=${input#"${repo_root}/"}
+		printf '%s\0' "${relative}"
+		sha256sum "${input}"
+	done < <(
+		find "${inputs[@]}" \
+			-type d \( \
+				-name .git -o \
+				-name build -o \
+				-name target -o \
+				-name __pycache__ \
+			\) -prune -o \
+			-type f ! -name '*.pyc' ! -name '*.md' -print0 |
+			sort -z
+	)
+} | sha256sum | cut -d ' ' -f 1

--- a/src/tools/genpolicy/nested-policy-compat/scripts/kata_config_value.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/kata_config_value.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 3 ]]; then
+	echo "usage: $0 CONFIG SECTION KEY" >&2
+	exit 2
+fi
+
+value=$(
+	awk -v wanted_section="$2" -v wanted_key="$3" '
+		/^[[:space:]]*\[/ {
+			section = $0
+			sub(/^[[:space:]]*\[/, "", section)
+			sub(/\][[:space:]]*(#.*)?$/, "", section)
+			next
+		}
+		section == wanted_section {
+			line = $0
+			sub(/[[:space:]]*#.*$/, "", line)
+			if (line !~ "^[[:space:]]*" wanted_key "[[:space:]]*=") {
+				next
+			}
+			sub("^[[:space:]]*" wanted_key "[[:space:]]*=[[:space:]]*", "", line)
+			sub(/[[:space:]]*$/, "", line)
+			if (line ~ /^"[^"]*"$/) {
+				sub(/^"/, "", line)
+				sub(/"$/, "", line)
+				print line
+				exit
+			}
+		}
+	' "$1"
+)
+
+if [[ -z "${value}" ]]; then
+	echo "missing quoted TOML value [$2] $3 in $1" >&2
+	exit 1
+fi
+printf '%s\n' "${value}"

--- a/src/tools/genpolicy/nested-policy-compat/scripts/rebuild_kata_stack.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/rebuild_kata_stack.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 4 ]]; then
+	echo "usage: $0 REPO_ROOT KATA_ROOT KATA_CONFIG CONTAINER_ENGINE" >&2
+	exit 2
+fi
+
+repo_root=$1
+kata_root=$(readlink -f "$2")
+kata_config=$3
+container_engine=$4
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+local_build_dir="${repo_root}/tools/packaging/kata-deploy/local-build"
+build_dir="${local_build_dir}/build"
+
+if [[ ! -x "${container_engine}" ]]; then
+	echo "container engine not found or not executable: ${container_engine}" >&2
+	exit 1
+fi
+if [[ ! -d "${kata_root}" || ! -w "${kata_root}" ]]; then
+	echo "KATA_ROOT must exist and be writable for automatic installation: ${kata_root}" >&2
+	exit 1
+fi
+if [[ ! -f "${kata_config}" ]]; then
+	echo "Kata configuration not found: ${kata_config}" >&2
+	exit 1
+fi
+
+tool_dir=$(mktemp -d)
+stage_dir=$(mktemp -d)
+cleanup() {
+	rm -rf "${tool_dir}" "${stage_dir}"
+}
+trap cleanup EXIT
+
+cat >"${tool_dir}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+
+if [[ "${1:-}" == "run" && -n "${KATA_AGENT_MAKEFLAGS:-}" ]]; then
+	shift
+	exec "${REAL_CONTAINER_ENGINE}" run \
+		--env "MAKEFLAGS=${KATA_AGENT_MAKEFLAGS}" "$@"
+fi
+exec "${REAL_CONTAINER_ENGINE}" "$@"
+EOF
+chmod 0755 "${tool_dir}/docker"
+export REAL_CONTAINER_ENGINE="${container_engine}"
+if [[ "$(basename "${container_engine}")" == podman ]]; then
+	DOCKER_RUNTIME=$("${container_engine}" info --format '{{.Host.OCIRuntime.Name}}')
+	export DOCKER_RUNTIME
+fi
+if ! command -v yq >/dev/null 2>&1; then
+	INSTALL_IN_GOPATH=true "${repo_root}/ci/install_yq.sh"
+fi
+export PATH="${tool_dir}:${GOPATH:-${HOME}/go}/bin:${PATH}"
+
+mkdir -p "${build_dir}"
+"${local_build_dir}/kata-deploy-copy-libseccomp-installer.sh" agent
+rm -rf \
+	"${build_dir}/agent" \
+	"${build_dir}/coco-guest-components" \
+	"${build_dir}/pause-image" \
+	"${build_dir}/rootfs-image" \
+	"${build_dir}/rootfs-image-confidential" \
+	"${build_dir}/shim-v2-rust"
+rm -f \
+	"${build_dir}/kata-static-agent.tar.zst" \
+	"${build_dir}/kata-static-coco-guest-components.tar.zst" \
+	"${build_dir}/kata-static-pause-image.tar.zst" \
+	"${build_dir}/kata-static-rootfs-image.tar.zst" \
+	"${build_dir}/kata-static-rootfs-image-confidential.tar.zst" \
+	"${build_dir}/kata-static-shim-v2-rust.tar.zst"
+
+build_component() {
+	local component=$1
+	echo "building Kata ${component} from the current checkout"
+	(
+		cd "${local_build_dir}"
+		USE_CACHE=no \
+			AGENT_POLICY=yes \
+			STRICT_POLICY=yes \
+			INIT_DATA=yes \
+			USE_DEVMAPPER=yes \
+			MEASURED_ROOTFS=no \
+			./kata-deploy-binaries.sh --build="${component}"
+	)
+}
+
+export KATA_AGENT_MAKEFLAGS="EXTRA_RUSTFEATURES=allow-unattested-initdata"
+build_component agent
+unset KATA_AGENT_MAKEFLAGS
+build_component rootfs-image
+build_component coco-guest-components
+build_component pause-image
+build_component rootfs-image-confidential
+build_component shim-v2-rust
+
+for archive in \
+	"${build_dir}/kata-static-rootfs-image.tar.zst" \
+	"${build_dir}/kata-static-rootfs-image-confidential.tar.zst" \
+	"${build_dir}/kata-static-shim-v2-rust.tar.zst"; do
+	if [[ ! -f "${archive}" ]]; then
+		echo "Kata build did not produce ${archive}" >&2
+		exit 1
+	fi
+	tar --zstd -xf "${archive}" -C "${stage_dir}"
+done
+
+new_shim="${stage_dir}/opt/kata/runtime-rs/bin/containerd-shim-kata-v2"
+new_guest_image="${stage_dir}/opt/kata/share/kata-containers/kata-containers.img"
+new_confidential_image="${stage_dir}/opt/kata/share/kata-containers/kata-containers-confidential.img"
+new_confidential_hash="${stage_dir}/opt/kata/share/kata-containers/root_hash_confidential.txt"
+if [[ ! -x "${new_shim}" || ! -e "${new_guest_image}" ||
+	! -e "${new_confidential_image}" || ! -e "${new_confidential_hash}" ]]; then
+	echo "Kata build output is missing the runtime-rs shim, base image, or confidential image" >&2
+	exit 1
+fi
+
+configured_guest_image=$(
+	hypervisor_name=$("${script_dir}/kata_config_value.sh" \
+		"${kata_config}" runtime hypervisor_name)
+	"${script_dir}/kata_config_value.sh" \
+		"${kata_config}" "hypervisor.${hypervisor_name}" image
+)
+case "${configured_guest_image}" in
+/opt/kata/*)
+	configured_guest_image="${kata_root}${configured_guest_image#/opt/kata}"
+	;;
+*)
+	echo "guest image must be located under /opt/kata: ${configured_guest_image}" >&2
+	exit 1
+	;;
+esac
+configured_guest_image=$(readlink -f "${configured_guest_image}")
+case "${configured_guest_image}" in
+"${kata_root}"/*) ;;
+*)
+	echo "guest image resolves outside KATA_ROOT: ${configured_guest_image}" >&2
+	exit 1
+	;;
+esac
+
+shim_dir=$(readlink -f "${kata_root}/runtime-rs/bin")
+share_dir=$(readlink -f "${kata_root}/share/kata-containers")
+for install_dir in "${shim_dir}" "${share_dir}"; do
+	case "${install_dir}" in
+	"${kata_root}"/*) ;;
+	*)
+		echo "Kata installation directory resolves outside KATA_ROOT: ${install_dir}" >&2
+		exit 1
+		;;
+	esac
+done
+
+install -D -m 0755 "${new_shim}" \
+	"${shim_dir}/containerd-shim-kata-v2.new"
+mv -f "${shim_dir}/containerd-shim-kata-v2.new" \
+	"${shim_dir}/containerd-shim-kata-v2"
+install -D -m 0644 "${new_guest_image}" "${configured_guest_image}.new"
+mv -f "${configured_guest_image}.new" "${configured_guest_image}"
+install -D -m 0644 "${new_confidential_image}" \
+	"${share_dir}/kata-containers-confidential.img.new"
+mv -f "${share_dir}/kata-containers-confidential.img.new" \
+	"${share_dir}/kata-containers-confidential.img"
+install -m 0644 "${new_confidential_hash}" \
+	"${share_dir}/root_hash_confidential.txt"
+
+root_hash="${stage_dir}/opt/kata/share/kata-containers/root_hash_base.txt"
+if [[ -f "${root_hash}" ]]; then
+	install -m 0644 "${root_hash}" "${share_dir}/root_hash_base.txt"
+fi
+
+marker="${share_dir}/nested-policy-source-provenance"
+shim_sha=$(sha256sum "${shim_dir}/containerd-shim-kata-v2" | cut -d ' ' -f 1)
+guest_image_sha=$(sha256sum "${configured_guest_image}" | cut -d ' ' -f 1)
+confidential_image_sha=$(
+	sha256sum "${share_dir}/kata-containers-confidential.img" | cut -d ' ' -f 1
+)
+confidential_hash_sha=$(
+	sha256sum "${share_dir}/root_hash_confidential.txt" | cut -d ' ' -f 1
+)
+runtime_source=$(
+	"${script_dir}/source_tree_fingerprint.sh" "${repo_root}" \
+		Cargo.toml Cargo.lock VERSION versions.yaml ci/install_yq.sh src/libs \
+		src/dragonball src/runtime-rs \
+		src/tools/genpolicy/nested-policy-compat/scripts/rebuild_kata_stack.sh \
+		tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh \
+		tools/packaging/scripts tools/packaging/static-build/shim-v2
+)
+agent_source=$(
+	"${script_dir}/source_tree_fingerprint.sh" "${repo_root}" \
+		Cargo.toml Cargo.lock VERSION versions.yaml ci/install_libseccomp.sh \
+		ci/install_yq.sh src/libs src/agent tools/osbuilder \
+		src/tools/genpolicy/nested-policy-compat/scripts/rebuild_kata_stack.sh \
+		tools/packaging/guest-image \
+		tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh \
+		tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh \
+		tools/packaging/scripts tools/packaging/static-build/agent \
+		tools/packaging/static-build/coco-guest-components \
+		tools/packaging/static-build/pause-image
+)
+cat >"${marker}.new" <<EOF
+format=1
+runtime_rs_source=${runtime_source}
+agent_source=${agent_source}
+shim_sha256=${shim_sha}
+guest_image_sha256=${guest_image_sha}
+confidential_image_sha256=${confidential_image_sha}
+confidential_hash_sha256=${confidential_hash_sha}
+EOF
+mv -f "${marker}.new" "${marker}"
+echo "installed checkout-built runtime-rs shim, strict-Agent base image, and confidential guest-pull image under ${kata_root}"

--- a/src/tools/genpolicy/nested-policy-compat/scripts/rebuild_kata_stack.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/rebuild_kata_stack.sh
@@ -70,14 +70,12 @@ rm -rf \
 	"${build_dir}/agent" \
 	"${build_dir}/coco-guest-components" \
 	"${build_dir}/pause-image" \
-	"${build_dir}/rootfs-image" \
 	"${build_dir}/rootfs-image-confidential" \
 	"${build_dir}/shim-v2-rust"
 rm -f \
 	"${build_dir}/kata-static-agent.tar.zst" \
 	"${build_dir}/kata-static-coco-guest-components.tar.zst" \
 	"${build_dir}/kata-static-pause-image.tar.zst" \
-	"${build_dir}/kata-static-rootfs-image.tar.zst" \
 	"${build_dir}/kata-static-rootfs-image-confidential.tar.zst" \
 	"${build_dir}/kata-static-shim-v2-rust.tar.zst"
 
@@ -99,14 +97,12 @@ build_component() {
 export KATA_AGENT_MAKEFLAGS="EXTRA_RUSTFEATURES=allow-unattested-initdata"
 build_component agent
 unset KATA_AGENT_MAKEFLAGS
-build_component rootfs-image
 build_component coco-guest-components
 build_component pause-image
 build_component rootfs-image-confidential
 build_component shim-v2-rust
 
 for archive in \
-	"${build_dir}/kata-static-rootfs-image.tar.zst" \
 	"${build_dir}/kata-static-rootfs-image-confidential.tar.zst" \
 	"${build_dir}/kata-static-shim-v2-rust.tar.zst"; do
 	if [[ ! -f "${archive}" ]]; then
@@ -117,38 +113,13 @@ for archive in \
 done
 
 new_shim="${stage_dir}/opt/kata/runtime-rs/bin/containerd-shim-kata-v2"
-new_guest_image="${stage_dir}/opt/kata/share/kata-containers/kata-containers.img"
 new_confidential_image="${stage_dir}/opt/kata/share/kata-containers/kata-containers-confidential.img"
 new_confidential_hash="${stage_dir}/opt/kata/share/kata-containers/root_hash_confidential.txt"
-if [[ ! -x "${new_shim}" || ! -e "${new_guest_image}" ||
-	! -e "${new_confidential_image}" || ! -e "${new_confidential_hash}" ]]; then
-	echo "Kata build output is missing the runtime-rs shim, base image, or confidential image" >&2
+if [[ ! -x "${new_shim}" || ! -e "${new_confidential_image}" ||
+	! -e "${new_confidential_hash}" ]]; then
+	echo "Kata build output is missing the runtime-rs shim or confidential image" >&2
 	exit 1
 fi
-
-configured_guest_image=$(
-	hypervisor_name=$("${script_dir}/kata_config_value.sh" \
-		"${kata_config}" runtime hypervisor_name)
-	"${script_dir}/kata_config_value.sh" \
-		"${kata_config}" "hypervisor.${hypervisor_name}" image
-)
-case "${configured_guest_image}" in
-/opt/kata/*)
-	configured_guest_image="${kata_root}${configured_guest_image#/opt/kata}"
-	;;
-*)
-	echo "guest image must be located under /opt/kata: ${configured_guest_image}" >&2
-	exit 1
-	;;
-esac
-configured_guest_image=$(readlink -f "${configured_guest_image}")
-case "${configured_guest_image}" in
-"${kata_root}"/*) ;;
-*)
-	echo "guest image resolves outside KATA_ROOT: ${configured_guest_image}" >&2
-	exit 1
-	;;
-esac
 
 shim_dir=$(readlink -f "${kata_root}/runtime-rs/bin")
 share_dir=$(readlink -f "${kata_root}/share/kata-containers")
@@ -166,8 +137,6 @@ install -D -m 0755 "${new_shim}" \
 	"${shim_dir}/containerd-shim-kata-v2.new"
 mv -f "${shim_dir}/containerd-shim-kata-v2.new" \
 	"${shim_dir}/containerd-shim-kata-v2"
-install -D -m 0644 "${new_guest_image}" "${configured_guest_image}.new"
-mv -f "${configured_guest_image}.new" "${configured_guest_image}"
 install -D -m 0644 "${new_confidential_image}" \
 	"${share_dir}/kata-containers-confidential.img.new"
 mv -f "${share_dir}/kata-containers-confidential.img.new" \
@@ -175,20 +144,52 @@ mv -f "${share_dir}/kata-containers-confidential.img.new" \
 install -m 0644 "${new_confidential_hash}" \
 	"${share_dir}/root_hash_confidential.txt"
 
-root_hash="${stage_dir}/opt/kata/share/kata-containers/root_hash_base.txt"
-if [[ -f "${root_hash}" ]]; then
-	install -m 0644 "${root_hash}" "${share_dir}/root_hash_base.txt"
-fi
+resolve_config_path() {
+	local section=$1
+	local key=$2
+	local configured
+
+	configured=$("${script_dir}/kata_config_value.sh" "${kata_config}" "${section}" "${key}")
+	case "${configured}" in
+	/opt/kata/*)
+		configured="${kata_root}${configured#/opt/kata}"
+		;;
+	*)
+		echo "${key} must be located under /opt/kata: ${configured}" >&2
+		exit 1
+		;;
+	esac
+	configured=$(readlink -f "${configured}")
+	case "${configured}" in
+	"${kata_root}"/*) ;;
+	*)
+		echo "${key} resolves outside KATA_ROOT: ${configured}" >&2
+		exit 1
+		;;
+	esac
+	if [[ ! -f "${configured}" ]]; then
+		echo "${key} artifact not found: ${configured}" >&2
+		exit 1
+	fi
+	printf '%s\n' "${configured}"
+}
+
+hypervisor_name=$("${script_dir}/kata_config_value.sh" \
+	"${kata_config}" runtime hypervisor_name)
+vmm=$(resolve_config_path "hypervisor.${hypervisor_name}" path)
+kernel=$(resolve_config_path "hypervisor.${hypervisor_name}" kernel)
 
 marker="${share_dir}/nested-policy-source-provenance"
 shim_sha=$(sha256sum "${shim_dir}/containerd-shim-kata-v2" | cut -d ' ' -f 1)
-guest_image_sha=$(sha256sum "${configured_guest_image}" | cut -d ' ' -f 1)
 confidential_image_sha=$(
 	sha256sum "${share_dir}/kata-containers-confidential.img" | cut -d ' ' -f 1
 )
 confidential_hash_sha=$(
 	sha256sum "${share_dir}/root_hash_confidential.txt" | cut -d ' ' -f 1
 )
+vmm_sha=$(sha256sum "${vmm}" | cut -d ' ' -f 1)
+kernel_sha=$(sha256sum "${kernel}" | cut -d ' ' -f 1)
+kata_config_sha=$(sha256sum "${kata_config}" | cut -d ' ' -f 1)
 runtime_source=$(
 	"${script_dir}/source_tree_fingerprint.sh" "${repo_root}" \
 		Cargo.toml Cargo.lock VERSION versions.yaml ci/install_yq.sh src/libs \
@@ -210,13 +211,15 @@ agent_source=$(
 		tools/packaging/static-build/pause-image
 )
 cat >"${marker}.new" <<EOF
-format=1
+format=3
 runtime_rs_source=${runtime_source}
 agent_source=${agent_source}
 shim_sha256=${shim_sha}
-guest_image_sha256=${guest_image_sha}
 confidential_image_sha256=${confidential_image_sha}
 confidential_hash_sha256=${confidential_hash_sha}
+vmm_sha256=${vmm_sha}
+kernel_sha256=${kernel_sha}
+kata_config_sha256=${kata_config_sha}
 EOF
 mv -f "${marker}.new" "${marker}"
-echo "installed checkout-built runtime-rs shim, strict-Agent base image, and confidential guest-pull image under ${kata_root}"
+echo "installed checkout-built runtime-rs shim and strict-Agent confidential guest image with bound VMM, kernel, and configuration under ${kata_root}"

--- a/src/tools/genpolicy/nested-policy-compat/scripts/source_tree_fingerprint.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/source_tree_fingerprint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -lt 2 ]]; then
+	echo "usage: $0 REPO_ROOT SOURCE_PATH..." >&2
+	exit 2
+fi
+
+repo_root=$1
+shift
+
+git -C "${repo_root}" ls-files --cached --others --exclude-standard -z -- "$@" |
+	sort -z |
+	{
+		while IFS= read -r -d '' path; do
+			printf '%s\0' "${path}"
+			if [[ -L "${repo_root}/${path}" ]]; then
+				printf 'mode=120000\n'
+				readlink "${repo_root}/${path}"
+			elif [[ -f "${repo_root}/${path}" ]]; then
+				if [[ -x "${repo_root}/${path}" ]]; then
+					printf 'mode=100755\n'
+				else
+					printf 'mode=100644\n'
+				fi
+				sha256sum "${repo_root}/${path}" | cut -d ' ' -f 1
+			else
+				printf 'missing\n'
+			fi
+		done
+	} |
+	sha256sum |
+	cut -d ' ' -f 1

--- a/src/tools/genpolicy/nested-policy-compat/scripts/verify_kata_source_provenance.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/verify_kata_source_provenance.sh
@@ -25,46 +25,6 @@ for path in "${repo_root}/.git" "${kata_root}" "${kata_config}"; do
 	fi
 done
 
-extract_commit() {
-	local component=$1
-	local version_output=$2
-	local commit
-
-	commit=$(sed -nE 's/.*commit( version)?: ([^,)]*-)?([0-9a-f]{40}).*/\3/p' <<<"${version_output}" |
-		head -n 1)
-	if [[ -z "${commit}" ]]; then
-		echo "could not extract ${component} commit from version output:" >&2
-		printf '%s\n' "${version_output}" >&2
-		exit 1
-	fi
-	printf '%s\n' "${commit}"
-}
-
-verify_source_tree() {
-	local component=$1
-	local commit=$2
-	shift 2
-	local source_paths=("$@")
-	local untracked
-
-	if ! git -C "${repo_root}" cat-file -e "${commit}^{commit}" 2>/dev/null; then
-		echo "${component} commit is not available in this checkout: ${commit}" >&2
-		exit 1
-	fi
-	if ! git -C "${repo_root}" diff --quiet "${commit}" -- "${source_paths[@]}"; then
-		echo "${component} build inputs differ from installed commit ${commit}" >&2
-		git -C "${repo_root}" --no-pager diff --stat "${commit}" -- "${source_paths[@]}" >&2
-		exit 1
-	fi
-	untracked=$(git -C "${repo_root}" ls-files --others --exclude-standard -- "${source_paths[@]}")
-	if [[ -n "${untracked}" ]]; then
-		echo "${component} cannot represent untracked build inputs:" >&2
-		printf '%s\n' "${untracked}" >&2
-		exit 1
-	fi
-	printf '%s source matches installed commit %s\n' "${component}" "${commit}"
-}
-
 runtime_inputs=(
 	Cargo.toml
 	Cargo.lock
@@ -99,34 +59,6 @@ agent_inputs=(
 	tools/packaging/static-build/pause-image
 )
 
-guest_image=$(
-	hypervisor_name=$("${script_dir}/kata_config_value.sh" \
-		"${kata_config}" runtime hypervisor_name)
-	"${script_dir}/kata_config_value.sh" \
-		"${kata_config}" "hypervisor.${hypervisor_name}" image
-)
-case "${guest_image}" in
-/opt/kata/*)
-	guest_image="${kata_root}${guest_image#/opt/kata}"
-	;;
-*)
-	echo "guest image must be located under /opt/kata: ${guest_image}" >&2
-	exit 1
-	;;
-esac
-guest_image=$(readlink -f "${guest_image}")
-case "${guest_image}" in
-"${kata_root}"/*) ;;
-*)
-	echo "guest image resolves outside KATA_ROOT: ${guest_image}" >&2
-	exit 1
-	;;
-esac
-if [[ ! -f "${guest_image}" ]]; then
-	echo "guest image not found: ${guest_image}" >&2
-	exit 1
-fi
-
 confidential_image="${kata_root}/share/kata-containers/kata-containers-confidential.img"
 confidential_hash="${kata_root}/share/kata-containers/root_hash_confidential.txt"
 if [[ ! -f "${confidential_image}" ]]; then
@@ -137,6 +69,41 @@ if [[ ! -f "${confidential_hash}" ]]; then
 	echo "confidential guest-pull image verity parameters not found: ${confidential_hash}" >&2
 	exit 1
 fi
+
+resolve_config_path() {
+	local section=$1
+	local key=$2
+	local configured
+
+	configured=$("${script_dir}/kata_config_value.sh" "${kata_config}" "${section}" "${key}")
+	case "${configured}" in
+	/opt/kata/*)
+		configured="${kata_root}${configured#/opt/kata}"
+		;;
+	*)
+		echo "${key} must be located under /opt/kata: ${configured}" >&2
+		exit 1
+		;;
+	esac
+	configured=$(readlink -f "${configured}")
+	case "${configured}" in
+	"${kata_root}"/*) ;;
+	*)
+		echo "${key} resolves outside KATA_ROOT: ${configured}" >&2
+		exit 1
+		;;
+	esac
+	if [[ ! -f "${configured}" ]]; then
+		echo "${key} artifact not found: ${configured}" >&2
+		exit 1
+	fi
+	printf '%s\n' "${configured}"
+}
+
+hypervisor_name=$("${script_dir}/kata_config_value.sh" \
+	"${kata_config}" runtime hypervisor_name)
+vmm=$(resolve_config_path "hypervisor.${hypervisor_name}" path)
+kernel=$(resolve_config_path "hypervisor.${hypervisor_name}" kernel)
 
 shim_dir=$(readlink -f "${kata_root}/runtime-rs/bin")
 case "${shim_dir}" in
@@ -153,65 +120,36 @@ if [[ ! -x "${shim}" ]]; then
 fi
 
 marker="${kata_root}/share/kata-containers/nested-policy-source-provenance"
-if [[ -f "${marker}" ]]; then
-	declare -A provenance=()
-	while IFS='=' read -r key value; do
-		provenance["${key}"]=${value}
-	done <"${marker}"
-
-	runtime_source=$("${script_dir}/source_tree_fingerprint.sh" "${repo_root}" "${runtime_inputs[@]}")
-	agent_source=$("${script_dir}/source_tree_fingerprint.sh" "${repo_root}" "${agent_inputs[@]}")
-	shim_sha=$(sha256sum "${shim}" | cut -d ' ' -f 1)
-	guest_image_sha=$(sha256sum "${guest_image}" | cut -d ' ' -f 1)
-	confidential_image_sha=$(sha256sum "${confidential_image}" | cut -d ' ' -f 1)
-	confidential_hash_sha=$(sha256sum "${confidential_hash}" | cut -d ' ' -f 1)
-	if [[ "${provenance[format]:-}" == 1 &&
-		"${provenance[runtime_rs_source]:-}" == "${runtime_source}" &&
-		"${provenance[agent_source]:-}" == "${agent_source}" &&
-		"${provenance[shim_sha256]:-}" == "${shim_sha}" &&
-		"${provenance[guest_image_sha256]:-}" == "${guest_image_sha}" &&
-		"${provenance[confidential_image_sha256]:-}" == "${confidential_image_sha}" &&
-		"${provenance[confidential_hash_sha256]:-}" == "${confidential_hash_sha}" ]]; then
-		echo "installed runtime-rs shim, base Agent image, and confidential guest-pull image match the current source tree"
-		exit 0
-	fi
-	echo "installed Kata provenance marker does not match the current source tree or artifacts" >&2
+if [[ ! -f "${marker}" ]]; then
+	echo "installed Kata provenance marker not found: ${marker}" >&2
+	echo "rebuild the Kata stack so strict-Agent features and all guest artifacts can be verified" >&2
 	exit 1
 fi
 
-shim_commit=$(extract_commit "runtime-rs shim" "$("${shim}" --version 2>&1)")
-verify_source_tree "runtime-rs shim" "${shim_commit}" "${runtime_inputs[@]}"
+declare -A provenance=()
+while IFS='=' read -r key value; do
+	provenance["${key}"]=${value}
+done <"${marker}"
 
-workdir=$(mktemp -d)
-mount_dir="${workdir}/rootfs"
-agent_copy="${workdir}/kata-agent"
-loop_device=
-cleanup() {
-	if mountpoint -q "${mount_dir}" 2>/dev/null; then
-		umount "${mount_dir}"
-	fi
-	if [[ -n "${loop_device}" ]]; then
-		losetup -d "${loop_device}"
-	fi
-	rm -rf "${workdir}"
-}
-trap cleanup EXIT
-
-mkdir -p "${mount_dir}"
-loop_device=$(losetup --find --show --partscan --read-only "${guest_image}")
-if [[ ! -b "${loop_device}p1" ]]; then
-	echo "guest image has no readable first partition: ${guest_image}" >&2
-	exit 1
+runtime_source=$("${script_dir}/source_tree_fingerprint.sh" "${repo_root}" "${runtime_inputs[@]}")
+agent_source=$("${script_dir}/source_tree_fingerprint.sh" "${repo_root}" "${agent_inputs[@]}")
+shim_sha=$(sha256sum "${shim}" | cut -d ' ' -f 1)
+confidential_image_sha=$(sha256sum "${confidential_image}" | cut -d ' ' -f 1)
+confidential_hash_sha=$(sha256sum "${confidential_hash}" | cut -d ' ' -f 1)
+vmm_sha=$(sha256sum "${vmm}" | cut -d ' ' -f 1)
+kernel_sha=$(sha256sum "${kernel}" | cut -d ' ' -f 1)
+kata_config_sha=$(sha256sum "${kata_config}" | cut -d ' ' -f 1)
+if [[ "${provenance[format]:-}" == 3 &&
+	"${provenance[runtime_rs_source]:-}" == "${runtime_source}" &&
+	"${provenance[agent_source]:-}" == "${agent_source}" &&
+	"${provenance[shim_sha256]:-}" == "${shim_sha}" &&
+	"${provenance[confidential_image_sha256]:-}" == "${confidential_image_sha}" &&
+	"${provenance[confidential_hash_sha256]:-}" == "${confidential_hash_sha}" &&
+	"${provenance[vmm_sha256]:-}" == "${vmm_sha}" &&
+	"${provenance[kernel_sha256]:-}" == "${kernel_sha}" &&
+	"${provenance[kata_config_sha256]:-}" == "${kata_config_sha}" ]]; then
+	echo "installed VMM, kernel, runtime-rs shim, configuration, and strict-Agent confidential guest image match the provenance marker"
+	exit 0
 fi
-mount -o ro "${loop_device}p1" "${mount_dir}"
-if [[ ! -x "${mount_dir}/usr/bin/kata-agent" ]]; then
-	echo "guest Agent not found in ${guest_image}" >&2
-	exit 1
-fi
-cp "${mount_dir}/usr/bin/kata-agent" "${agent_copy}"
-umount "${mount_dir}"
-losetup -d "${loop_device}"
-loop_device=
-
-agent_commit=$(extract_commit "guest Agent" "$("${agent_copy}" --version 2>&1)")
-verify_source_tree "guest Agent" "${agent_commit}" "${agent_inputs[@]}"
+echo "installed Kata provenance marker does not match the current source tree or artifacts" >&2
+exit 1

--- a/src/tools/genpolicy/nested-policy-compat/scripts/verify_kata_source_provenance.sh
+++ b/src/tools/genpolicy/nested-policy-compat/scripts/verify_kata_source_provenance.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 3 ]]; then
+	echo "usage: $0 REPO_ROOT KATA_ROOT KATA_CONFIG" >&2
+	exit 2
+fi
+
+repo_root=$1
+kata_root=$(readlink -f "$2")
+kata_config=$3
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+for path in "${repo_root}/.git" "${kata_root}" "${kata_config}"; do
+	if [[ ! -e "${path}" ]]; then
+		echo "required provenance input not found: ${path}" >&2
+		exit 1
+	fi
+done
+
+extract_commit() {
+	local component=$1
+	local version_output=$2
+	local commit
+
+	commit=$(sed -nE 's/.*commit( version)?: ([^,)]*-)?([0-9a-f]{40}).*/\3/p' <<<"${version_output}" |
+		head -n 1)
+	if [[ -z "${commit}" ]]; then
+		echo "could not extract ${component} commit from version output:" >&2
+		printf '%s\n' "${version_output}" >&2
+		exit 1
+	fi
+	printf '%s\n' "${commit}"
+}
+
+verify_source_tree() {
+	local component=$1
+	local commit=$2
+	shift 2
+	local source_paths=("$@")
+	local untracked
+
+	if ! git -C "${repo_root}" cat-file -e "${commit}^{commit}" 2>/dev/null; then
+		echo "${component} commit is not available in this checkout: ${commit}" >&2
+		exit 1
+	fi
+	if ! git -C "${repo_root}" diff --quiet "${commit}" -- "${source_paths[@]}"; then
+		echo "${component} build inputs differ from installed commit ${commit}" >&2
+		git -C "${repo_root}" --no-pager diff --stat "${commit}" -- "${source_paths[@]}" >&2
+		exit 1
+	fi
+	untracked=$(git -C "${repo_root}" ls-files --others --exclude-standard -- "${source_paths[@]}")
+	if [[ -n "${untracked}" ]]; then
+		echo "${component} cannot represent untracked build inputs:" >&2
+		printf '%s\n' "${untracked}" >&2
+		exit 1
+	fi
+	printf '%s source matches installed commit %s\n' "${component}" "${commit}"
+}
+
+runtime_inputs=(
+	Cargo.toml
+	Cargo.lock
+	VERSION
+	versions.yaml
+	ci/install_yq.sh
+	src/libs
+	src/dragonball
+	src/runtime-rs
+	src/tools/genpolicy/nested-policy-compat/scripts/rebuild_kata_stack.sh
+	tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+	tools/packaging/scripts
+	tools/packaging/static-build/shim-v2
+)
+agent_inputs=(
+	Cargo.toml
+	Cargo.lock
+	VERSION
+	versions.yaml
+	ci/install_libseccomp.sh
+	ci/install_yq.sh
+	src/libs
+	src/agent
+	src/tools/genpolicy/nested-policy-compat/scripts/rebuild_kata_stack.sh
+	tools/osbuilder
+	tools/packaging/guest-image
+	tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+	tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh
+	tools/packaging/scripts
+	tools/packaging/static-build/agent
+	tools/packaging/static-build/coco-guest-components
+	tools/packaging/static-build/pause-image
+)
+
+guest_image=$(
+	hypervisor_name=$("${script_dir}/kata_config_value.sh" \
+		"${kata_config}" runtime hypervisor_name)
+	"${script_dir}/kata_config_value.sh" \
+		"${kata_config}" "hypervisor.${hypervisor_name}" image
+)
+case "${guest_image}" in
+/opt/kata/*)
+	guest_image="${kata_root}${guest_image#/opt/kata}"
+	;;
+*)
+	echo "guest image must be located under /opt/kata: ${guest_image}" >&2
+	exit 1
+	;;
+esac
+guest_image=$(readlink -f "${guest_image}")
+case "${guest_image}" in
+"${kata_root}"/*) ;;
+*)
+	echo "guest image resolves outside KATA_ROOT: ${guest_image}" >&2
+	exit 1
+	;;
+esac
+if [[ ! -f "${guest_image}" ]]; then
+	echo "guest image not found: ${guest_image}" >&2
+	exit 1
+fi
+
+confidential_image="${kata_root}/share/kata-containers/kata-containers-confidential.img"
+confidential_hash="${kata_root}/share/kata-containers/root_hash_confidential.txt"
+if [[ ! -f "${confidential_image}" ]]; then
+	echo "confidential guest-pull image not found: ${confidential_image}" >&2
+	exit 1
+fi
+if [[ ! -f "${confidential_hash}" ]]; then
+	echo "confidential guest-pull image verity parameters not found: ${confidential_hash}" >&2
+	exit 1
+fi
+
+shim_dir=$(readlink -f "${kata_root}/runtime-rs/bin")
+case "${shim_dir}" in
+"${kata_root}"/*) ;;
+*)
+	echo "runtime-rs binary directory resolves outside KATA_ROOT: ${shim_dir}" >&2
+	exit 1
+	;;
+esac
+shim="${shim_dir}/containerd-shim-kata-v2"
+if [[ ! -x "${shim}" ]]; then
+	echo "runtime-rs shim not found or not executable: ${shim}" >&2
+	exit 1
+fi
+
+marker="${kata_root}/share/kata-containers/nested-policy-source-provenance"
+if [[ -f "${marker}" ]]; then
+	declare -A provenance=()
+	while IFS='=' read -r key value; do
+		provenance["${key}"]=${value}
+	done <"${marker}"
+
+	runtime_source=$("${script_dir}/source_tree_fingerprint.sh" "${repo_root}" "${runtime_inputs[@]}")
+	agent_source=$("${script_dir}/source_tree_fingerprint.sh" "${repo_root}" "${agent_inputs[@]}")
+	shim_sha=$(sha256sum "${shim}" | cut -d ' ' -f 1)
+	guest_image_sha=$(sha256sum "${guest_image}" | cut -d ' ' -f 1)
+	confidential_image_sha=$(sha256sum "${confidential_image}" | cut -d ' ' -f 1)
+	confidential_hash_sha=$(sha256sum "${confidential_hash}" | cut -d ' ' -f 1)
+	if [[ "${provenance[format]:-}" == 1 &&
+		"${provenance[runtime_rs_source]:-}" == "${runtime_source}" &&
+		"${provenance[agent_source]:-}" == "${agent_source}" &&
+		"${provenance[shim_sha256]:-}" == "${shim_sha}" &&
+		"${provenance[guest_image_sha256]:-}" == "${guest_image_sha}" &&
+		"${provenance[confidential_image_sha256]:-}" == "${confidential_image_sha}" &&
+		"${provenance[confidential_hash_sha256]:-}" == "${confidential_hash_sha}" ]]; then
+		echo "installed runtime-rs shim, base Agent image, and confidential guest-pull image match the current source tree"
+		exit 0
+	fi
+	echo "installed Kata provenance marker does not match the current source tree or artifacts" >&2
+	exit 1
+fi
+
+shim_commit=$(extract_commit "runtime-rs shim" "$("${shim}" --version 2>&1)")
+verify_source_tree "runtime-rs shim" "${shim_commit}" "${runtime_inputs[@]}"
+
+workdir=$(mktemp -d)
+mount_dir="${workdir}/rootfs"
+agent_copy="${workdir}/kata-agent"
+loop_device=
+cleanup() {
+	if mountpoint -q "${mount_dir}" 2>/dev/null; then
+		umount "${mount_dir}"
+	fi
+	if [[ -n "${loop_device}" ]]; then
+		losetup -d "${loop_device}"
+	fi
+	rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+mkdir -p "${mount_dir}"
+loop_device=$(losetup --find --show --partscan --read-only "${guest_image}")
+if [[ ! -b "${loop_device}p1" ]]; then
+	echo "guest image has no readable first partition: ${guest_image}" >&2
+	exit 1
+fi
+mount -o ro "${loop_device}p1" "${mount_dir}"
+if [[ ! -x "${mount_dir}/usr/bin/kata-agent" ]]; then
+	echo "guest Agent not found in ${guest_image}" >&2
+	exit 1
+fi
+cp "${mount_dir}/usr/bin/kata-agent" "${agent_copy}"
+umount "${mount_dir}"
+losetup -d "${loop_device}"
+loop_device=
+
+agent_commit=$(extract_commit "guest Agent" "$("${agent_copy}" --version 2>&1)")
+verify_source_tree "guest Agent" "${agent_commit}" "${agent_inputs[@]}"

--- a/src/tools/genpolicy/nested-policy-compat/tests/annotate_workload.py
+++ b/src/tools/genpolicy/nested-policy-compat/tests/annotate_workload.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import base64
+import gzip
+from pathlib import Path
+
+import yaml
+
+
+ANNOTATION = "io.katacontainers.config.hypervisor.cc_init_data"
+
+
+def pod_metadata(document: dict) -> dict | None:
+    kind = document.get("kind")
+    if kind == "Pod":
+        return document.setdefault("metadata", {})
+    if kind in {"Deployment", "DaemonSet", "StatefulSet", "Job"}:
+        return document.setdefault("spec", {}).setdefault("template", {}).setdefault(
+            "metadata", {}
+        )
+    if kind == "CronJob":
+        return (
+            document.setdefault("spec", {})
+            .setdefault("jobTemplate", {})
+            .setdefault("spec", {})
+            .setdefault("template", {})
+            .setdefault("metadata", {})
+        )
+    return None
+
+
+def annotate(
+    workload: Path, policy: Path, output: Path, registry_ca: Path | None = None
+) -> None:
+    policy_text = policy.read_text(encoding="utf-8")
+    initdata = (
+        'version = "0.1.0"\n'
+        'algorithm = "sha256"\n\n'
+        "[data]\n"
+        '"policy.rego" = \'\'\'\n'
+        f"{policy_text}\n"
+        "'''\n"
+    )
+    if registry_ca is not None:
+        certificate = registry_ca.read_text(encoding="utf-8").strip()
+        initdata += (
+            '"cdh.toml" = \'\'\'\n'
+            "[kbc]\n"
+            'name = "offline_fs_kbc"\n'
+            'url = ""\n\n'
+            "[image]\n"
+            'extra_root_certificates = ["""\n'
+            f"{certificate}\n"
+            '"""]\n'
+            "'''\n"
+        )
+    value = base64.b64encode(
+        gzip.compress(initdata.encode("utf-8"), mtime=0)
+    ).decode("ascii")
+
+    documents = list(yaml.safe_load_all(workload.read_text(encoding="utf-8")))
+    annotated = 0
+    for document in documents:
+        if not isinstance(document, dict):
+            continue
+        metadata = pod_metadata(document)
+        if metadata is None:
+            continue
+        metadata.setdefault("annotations", {})[ANNOTATION] = value
+        annotated += 1
+    if annotated == 0:
+        raise ValueError("workload contains no supported Pod template")
+
+    output.write_text(
+        yaml.safe_dump_all(documents, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workload", type=Path, required=True)
+    parser.add_argument("--policy", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--registry-ca", type=Path)
+    args = parser.parse_args()
+    annotate(args.workload, args.policy, args.output, args.registry_ca)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixture-matrix-e2e.sh
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixture-matrix-e2e.sh
@@ -14,19 +14,25 @@ nested_image=${NESTED_IMAGE:?NESTED_IMAGE is required}
 kata_root=${KATA_ROOT:?KATA_ROOT is required}
 kata_config=${KATA_CONFIG:?KATA_CONFIG is required}
 output_root=${OUTPUT_ROOT:?OUTPUT_ROOT is required}
+output_marker="${output_root}/.nested-policy-compat-output"
 
 device_args=(--device /dev/kvm --device /dev/net/tun)
 if [[ -e /dev/vhost-vsock ]]; then
 	device_args+=(--device /dev/vhost-vsock)
 fi
 
-case "${output_root}" in
-/|"${HOME}")
-	echo "refusing unsafe matrix output directory: ${output_root}" >&2
+if [[ -e "${output_root}" && ! -d "${output_root}" ]]; then
+	echo "matrix output path is not a directory: ${output_root}" >&2
 	exit 2
-	;;
-esac
-rm -rf "${output_root}"
+fi
+mkdir -p "${output_root}"
+if [[ ! -f "${output_marker}" ]] &&
+	find "${output_root}" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+	echo "refusing nonempty matrix output directory without harness marker: ${output_root}" >&2
+	exit 2
+fi
+touch "${output_marker}"
+rm -rf "${output_root}/cases"
 mkdir -p "${output_root}/cases"
 
 default_fixtures=(

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixture-matrix-e2e.sh
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixture-matrix-e2e.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+engine=${CONTAINER_ENGINE:?CONTAINER_ENGINE is required}
+nested_image=${NESTED_IMAGE:?NESTED_IMAGE is required}
+kata_root=${KATA_ROOT:?KATA_ROOT is required}
+kata_config=${KATA_CONFIG:?KATA_CONFIG is required}
+output_root=${OUTPUT_ROOT:?OUTPUT_ROOT is required}
+
+device_args=(--device /dev/kvm --device /dev/net/tun)
+if [[ -e /dev/vhost-vsock ]]; then
+	device_args+=(--device /dev/vhost-vsock)
+fi
+
+case "${output_root}" in
+/|"${HOME}")
+	echo "refusing unsafe matrix output directory: ${output_root}" >&2
+	exit 2
+	;;
+esac
+rm -rf "${output_root}"
+mkdir -p "${output_root}/cases"
+
+default_fixtures=(
+	pod.yaml
+	policy-matrix-env-pod.yaml
+	policy-matrix-process-pod.yaml
+	complex-workload.yaml
+	service-account-workload.yaml
+	local-emptydir-workload.yaml
+	storage-classes-workload.yaml
+	runtime-operations-workload.yaml
+)
+if [[ -n "${FIXTURES:-}" ]]; then
+	read -r -a fixtures <<<"${FIXTURES}"
+else
+	fixtures=("${default_fixtures[@]}")
+fi
+
+failures=0
+for fixture in "${fixtures[@]}"; do
+	name=${fixture%.yaml}
+	case_dir="${output_root}/cases/${name}"
+	mkdir -p "${case_dir}/generation-input" "${case_dir}/generation-output" \
+		"${case_dir}/nested-input/images" "${case_dir}/nested-output"
+	cp "${script_dir}/fixtures/${fixture}" \
+		"${case_dir}/generation-input/workload.yaml"
+
+	set +o errexit
+	"${engine}" run --rm --privileged --network=none --cgroupns=host \
+		-v "${case_dir}/generation-input:/input:ro" \
+		-v "${case_dir}/generation-output:/output" \
+		--entrypoint /opt/nested-policy-compat/scripts/generate_policy.sh \
+		"${nested_image}" >"${case_dir}/generation.log" 2>&1
+	generation_status=$?
+	set -o errexit
+	if [[ "${generation_status}" -ne 0 ]]; then
+		printf '%s\t%s\tgeneration-failed\n' "${name}" "${generation_status}"
+		((failures += 1))
+		continue
+	fi
+	if ! grep -Fq "reason :=" \
+		"${case_dir}/generation-output/policy.rego"; then
+		printf '%s\t1\treason-rules-missing\n' "${name}"
+		((failures += 1))
+		continue
+	fi
+
+	python3 "${script_dir}/annotate_workload.py" \
+		--workload "${case_dir}/generation-output/workload.yaml" \
+		--policy "${case_dir}/generation-output/policy.rego" \
+		--registry-ca <(
+			"${engine}" run --rm --entrypoint /bin/cat "${nested_image}" \
+				/opt/genpolicy/registry-tls/registry.crt
+		) \
+		--output "${case_dir}/nested-input/workload.yaml"
+	"${engine}" run --rm --entrypoint /bin/cat "${nested_image}" \
+		/opt/genpolicy/images/busybox.tar \
+		>"${case_dir}/nested-input/images/busybox.tar"
+
+	set +o errexit
+	"${engine}" run --rm --privileged --cgroupns=host \
+		"${device_args[@]}" \
+		-e GENPOLICY_POD_READY_TIMEOUT="${POD_READY_TIMEOUT:-180s}" \
+		-e NESTED_KATA_CONFIG=/nested-policy-compat/configuration.toml \
+		-v "${kata_root}:/opt/kata:ro" \
+		-v "${kata_config}:/nested-policy-compat/configuration.toml:ro" \
+		-v "${case_dir}/nested-input:/input:ro" \
+		-v "${case_dir}/nested-output:/output" \
+		"${nested_image}" >"${case_dir}/nested.log" 2>&1
+	status=$?
+	set -o errexit
+
+	result=$(python3 - "${case_dir}/nested-output/compatibility.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+print(json.loads(path.read_text(encoding="utf-8"))["result"] if path.exists() else "missing")
+PY
+)
+	printf '%s\t%s\t%s\n' "${name}" "${status}" "${result}"
+	if [[ "${status}" -ne 0 || "${result}" != "compatible" ]]; then
+		((failures += 1))
+	fi
+done
+
+exit "${failures}"

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/complex-workload.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/complex-workload.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+spec:
+  selector:
+    app: balanced-mode
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: balanced-mode-config
+data:
+  LOG_LEVEL: info
+  FEATURE_MODE: safe
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: balanced-mode-secret
+data:
+  API_TOKEN: dGVzdC1vbmx5LXRva2Vu
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: balanced-mode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: balanced-mode
+  template:
+    metadata:
+      labels:
+        app: balanced-mode
+    spec:
+      automountServiceAccountToken: false
+      runtimeClassName: kata
+      securityContext:
+        supplementalGroups:
+          - 10
+      containers:
+        - name: workload
+          image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+          imagePullPolicy: Never
+          workingDir: /work
+          command: ["/bin/busybox"]
+          args: ["sh", "-c", "sleep 3600"]
+          envFrom:
+            - configMapRef:
+                name: balanced-mode-config
+            - secretRef:
+                name: balanced-mode-secret
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          readinessProbe:
+            exec:
+              command: ["/bin/busybox", "true"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+        - name: sidecar
+          image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+          imagePullPolicy: Never
+          command: ["/bin/busybox", "sleep", "3600"]

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/custom-service-account-workload.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/custom-service-account-workload.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: custom-service-account-workload
+spec:
+  runtimeClassName: kata
+  serviceAccountName: workload-identity
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      command: ["/bin/busybox", "sleep", "3600"]
+      env:
+        - name: SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/local-emptydir-workload.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/local-emptydir-workload.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: local-emptydir
+spec:
+  automountServiceAccountToken: false
+  runtimeClassName: kata
+  restartPolicy: Never
+  securityContext:
+    supplementalGroups:
+      - 10
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      command: ["/bin/busybox", "sleep", "3600"]
+      volumeMounts:
+        - name: scratch-disk
+          mountPath: /scratch-disk
+  volumes:
+    - name: scratch-disk
+      emptyDir: {}

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/pod.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/pod.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tagged-oci-test
+spec:
+  automountServiceAccountToken: false
+  runtimeClassName: kata
+  securityContext:
+    supplementalGroups:
+      - 10
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      workingDir: /work
+      command:
+        - /bin/busybox
+      args:
+        - sleep
+        - "3600"
+      env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/policy-matrix-env-pod.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/policy-matrix-env-pod.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: policy-matrix-config
+data:
+  LOG_LEVEL: info
+  FEATURE_MODE: safe
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: policy-matrix-secret
+data:
+  API_TOKEN: dGVzdC1vbmx5LXRva2Vu
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-matrix-env
+spec:
+  automountServiceAccountToken: false
+  runtimeClassName: kata
+  securityContext:
+    supplementalGroups:
+      - 10
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      command: ["/bin/busybox", "sleep", "3600"]
+      envFrom:
+        - configMapRef:
+            name: policy-matrix-config
+        - secretRef:
+            name: policy-matrix-secret
+      env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/policy-matrix-process-pod.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/policy-matrix-process-pod.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-matrix-process
+  annotations:
+    io.katacontainers.config.hypervisor.default_vcpus: "2"
+spec:
+  automountServiceAccountToken: false
+  runtimeClassName: kata
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups:
+      - 10
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      workingDir: /work
+      command: ["/bin/busybox"]
+      args: ["sleep", "3600"]
+      stdin: true
+      tty: true
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: STATIC_VALUE
+          value: containerd-2.3
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - NET_RAW

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/runtime-operations-workload.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/runtime-operations-workload.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: runtime-operations-
+  annotations:
+    test.katacontainers.io/runtime-operations: "true"
+  finalizers:
+    - test.katacontainers.io/observe-termination
+spec:
+  automountServiceAccountToken: false
+  runtimeClassName: kata
+  restartPolicy: Never
+  os:
+    name: linux
+  terminationGracePeriodSeconds: 10
+  securityContext:
+    supplementalGroups:
+      - 10
+    sysctls:
+      - name: net.ipv4.ip_forward
+        value: "1"
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      command:
+        - /bin/sh
+        - -c
+        - |
+          trap 'echo runtime-stop-sighup; exit 0' HUP
+          trap 'echo runtime-stop-sigterm; exit 0' TERM
+          sleep 2
+          touch /tmp/ready
+          while true; do sleep 1; done
+      lifecycle:
+        stopSignal: SIGHUP
+      readinessProbe:
+        exec:
+          command:
+            - /bin/busybox
+            - test
+            - -f
+            - /tmp/ready
+        periodSeconds: 1
+        timeoutSeconds: 1

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/service-account-workload.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/service-account-workload.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: service-account-workload
+spec:
+  runtimeClassName: kata
+  serviceAccountName: default
+  automountServiceAccountToken: false
+  securityContext:
+    supplementalGroups: [10]
+  restartPolicy: Never
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      command: ["/bin/busybox", "sleep", "3600"]
+      env:
+        - name: SERVICE_ACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/storage-classes-workload.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/storage-classes-workload.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: storage-classes-config
+data:
+  app.conf: |
+    log_level=info
+    mode=safe
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-classes-secret
+data:
+  token: dGVzdC1vbmx5LXRva2Vu
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: storage-classes
+spec:
+  automountServiceAccountToken: false
+  runtimeClassName: kata
+  restartPolicy: Never
+  securityContext:
+    fsGroup: 2000
+    supplementalGroups:
+      - 10
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      command: ["/bin/busybox", "sleep", "3600"]
+      volumeMounts:
+        - name: scratch-memory
+          mountPath: /scratch-memory
+        - name: configuration
+          mountPath: /etc/configuration
+          readOnly: true
+        - name: secret
+          mountPath: /etc/secret
+          readOnly: true
+        - name: podinfo
+          mountPath: /etc/podinfo
+          readOnly: true
+  volumes:
+    - name: scratch-memory
+      emptyDir:
+        medium: Memory
+    - name: configuration
+      configMap:
+        name: storage-classes-config
+    - name: secret
+      secret:
+        secretName: storage-classes-secret
+    - name: podinfo
+      downwardAPI:
+        items:
+          - path: name
+            fieldRef:
+              fieldPath: metadata.name

--- a/src/tools/genpolicy/nested-policy-compat/tests/fixtures/termination-log-workload.yaml
+++ b/src/tools/genpolicy/nested-policy-compat/tests/fixtures/termination-log-workload.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: termination-log-
+  annotations:
+    test.katacontainers.io/termination-log: "true"
+  finalizers:
+    - test.katacontainers.io/observe-termination
+spec:
+  automountServiceAccountToken: false
+  runtimeClassName: kata
+  restartPolicy: Never
+  os:
+    name: linux
+  terminationGracePeriodSeconds: 10
+  initContainers:
+    - name: termination-message
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      command:
+        - /bin/sh
+        - -c
+        - printf runtime-init-complete >/dev/termination-log
+  containers:
+    - name: workload
+      image: genpolicy.local:5000/busybox@sha256:330c0f71ee2f62aec2df2de066b2a9acef0039c70313965ab2d2451bbbdae945
+      imagePullPolicy: Never
+      command:
+        - /bin/sh
+        - -c
+        - |
+          trap 'echo runtime-stop-sighup; printf runtime-stop-sighup >/dev/termination-log; exit 0' HUP
+          touch /tmp/ready
+          while true; do sleep 1; done
+      lifecycle:
+        stopSignal: SIGHUP
+      readinessProbe:
+        exec:
+          command:
+            - /bin/busybox
+            - test
+            - -f
+            - /tmp/ready
+        periodSeconds: 1
+        timeoutSeconds: 1

--- a/src/tools/genpolicy/nested-policy-compat/tests/policy/create-sandbox-reasons.rego.inc
+++ b/src/tools/genpolicy/nested-policy-compat/tests/policy/create-sandbox-reasons.rego.inc
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Test-only, redaction-safe attribution for CreateSandboxRequest.
+#
+# GenPolicy appends this fragment to the repository rules module before embedding
+# it in fixture policies. Do not report field values here: strict-policy denials
+# cross the guest boundary and may be visible to the host.
+
+errors["guest hook path: the request specifies a guest hook path, but policy requires it to be empty"] if {
+    input.rule == "CreateSandboxRequest"
+    count(input.guest_hook_path) != 0
+}
+
+errors["kernel modules: the request specifies kernel modules, but policy requires none"] if {
+    input.rule == "CreateSandboxRequest"
+    count(input.kernel_modules) != 0
+}
+
+errors["sandbox PID namespace: the request enables a shared PID namespace, but policy requires it disabled"] if {
+    input.rule == "CreateSandboxRequest"
+    input.sandbox_pidns != false
+}
+
+sandbox_storage_matches_policy(storage) if {
+    some policy_storage in policy_data.sandbox.storages
+    storage == policy_storage
+}
+
+unmatched_sandbox_storage_indexes := {index |
+    some index, storage in input.storages
+    not sandbox_storage_matches_policy(storage)
+}
+
+errors[msg] if {
+    input.rule == "CreateSandboxRequest"
+    indexes := unmatched_sandbox_storage_indexes
+    count(indexes) > 0
+    msg := sprintf("sandbox storages: request entries at indexes %v do not match any policy storage", [indexes])
+}
+
+storage_field_matches_policy(storage, field) if {
+    some policy_storage in policy_data.sandbox.storages
+    storage[field] == policy_storage[field]
+}
+
+errors[msg] if {
+    input.rule == "CreateSandboxRequest"
+    some index, storage in input.storages
+    some field in [
+        "driver",
+        "driver_options",
+        "source",
+        "fstype",
+        "options",
+        "mount_point",
+        "fs_group",
+        "shared",
+    ]
+    not storage_field_matches_policy(storage, field)
+    msg := sprintf("sandbox storage %v: field %v does not match any policy storage", [index, field])
+}
+
+errors["sandbox storages: the request contains duplicate storage entries"] if {
+    input.rule == "CreateSandboxRequest"
+    storage_set := {storage | some storage in input.storages}
+    count(storage_set) != count(input.storages)
+}
+
+candidate_matches_bundle_mounts_and_storages if {
+    some entry in all_policy_container_entries
+    allow_by_bundle_or_sandbox_id(
+        entry.container.OCI,
+        input.OCI,
+        entry.container.storages,
+        input.storages,
+    )
+}
+
+errors["container root path, mounts, or storages do not match any policy container"] if {
+    input.rule == "CreateContainerRequest"
+    count(all_policy_container_entries) > 0
+    not candidate_matches_bundle_mounts_and_storages
+}

--- a/src/tools/genpolicy/nested-policy-compat/tests/test_annotate_workload.py
+++ b/src/tools/genpolicy/nested-policy-compat/tests/test_annotate_workload.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import gzip
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from annotate_workload import ANNOTATION, annotate
+
+
+class AnnotateWorkloadTests(unittest.TestCase):
+    def test_annotates_pod_and_deployment_templates(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            workload = root / "workload.yaml"
+            policy = root / "policy.rego"
+            output = root / "annotated.yaml"
+            workload.write_text(
+                """apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    metadata: {}
+    spec:
+      containers: []
+""",
+                encoding="utf-8",
+            )
+            policy.write_text("package agent_policy\n", encoding="utf-8")
+
+            annotate(workload, policy, output)
+
+            documents = list(yaml.safe_load_all(output.read_text(encoding="utf-8")))
+            values = [
+                documents[0]["metadata"]["annotations"][ANNOTATION],
+                documents[1]["spec"]["template"]["metadata"]["annotations"][ANNOTATION],
+            ]
+            self.assertEqual(values[0], values[1])
+            initdata = gzip.decompress(base64.b64decode(values[0])).decode("utf-8")
+            self.assertIn('"policy.rego"', initdata)
+            self.assertIn("package agent_policy", initdata)
+
+    def test_rejects_workload_without_pod_template(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            workload = root / "workload.yaml"
+            policy = root / "policy.rego"
+            workload.write_text(
+                "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: config\n",
+                encoding="utf-8",
+            )
+            policy.write_text("package agent_policy\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "no supported Pod template"):
+                annotate(workload, policy, root / "annotated.yaml")
+
+    def test_adds_registry_ca_to_cdh_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            workload = root / "workload.yaml"
+            policy = root / "policy.rego"
+            registry_ca = root / "registry.crt"
+            output = root / "annotated.yaml"
+            workload.write_text(
+                "apiVersion: v1\nkind: Pod\nmetadata:\n  name: pod\n",
+                encoding="utf-8",
+            )
+            policy.write_text("package agent_policy\n", encoding="utf-8")
+            registry_ca.write_text(
+                "-----BEGIN CERTIFICATE-----\ncertificate\n"
+                "-----END CERTIFICATE-----\n",
+                encoding="utf-8",
+            )
+
+            annotate(workload, policy, output, registry_ca)
+
+            document = yaml.safe_load(output.read_text(encoding="utf-8"))
+            value = document["metadata"]["annotations"][ANNOTATION]
+            initdata = gzip.decompress(base64.b64decode(value)).decode("utf-8")
+            self.assertIn('"cdh.toml"', initdata)
+            self.assertIn('name = "offline_fs_kbc"', initdata)
+            self.assertIn("extra_root_certificates", initdata)
+            self.assertIn("-----BEGIN CERTIFICATE-----", initdata)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tools/genpolicy/nested-policy-compat/tests/test_compat_report.py
+++ b/src/tools/genpolicy/nested-policy-compat/tests/test_compat_report.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "compat_report.py"
+SPEC = importlib.util.spec_from_file_location("compat_report", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class CompatibilityReportTest(unittest.TestCase):
+    def arguments(self, root, ready=False):
+        workload = root / "workload.yaml"
+        workload.write_text("kind: Pod\n", encoding="utf-8")
+        kata_config = root / "configuration.toml"
+        kata_config.write_text("[hypervisor]\n", encoding="utf-8")
+        capture_state = root / "state.json"
+        capture_state.write_text('{"connections": 1}\n', encoding="utf-8")
+        logs = root / "logs"
+        logs.mkdir()
+        return Namespace(
+            base_exit_code=0,
+            capture_state=capture_state,
+            kata_config=kata_config,
+            logs=logs,
+            profile="test-profile",
+            ready=ready,
+            workload=workload,
+        )
+
+    def test_ready_is_compatible(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            args = self.arguments(Path(temporary), ready=True)
+            self.assertEqual(MODULE.build_report(args)["result"], "compatible")
+
+    def test_policy_denial_is_incompatible(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            args = self.arguments(root)
+            (args.logs / "agent.log").write_text(
+                "CreateContainer request denied by policy\n",
+                encoding="utf-8",
+            )
+            report = MODULE.build_report(args)
+            self.assertEqual(report["result"], "policy-incompatible")
+            self.assertIn("denied", report["denial"]["text"])
+
+    def test_other_failure_is_infrastructure(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            args = self.arguments(Path(temporary))
+            self.assertEqual(
+                MODULE.build_report(args)["result"],
+                "infrastructure-failure",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tools/genpolicy/nested-policy-compat/tests/test_hvsock_capture.py
+++ b/src/tools/genpolicy/nested-policy-compat/tests/test_hvsock_capture.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import socket
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "hvsock_capture.py"
+SPEC = importlib.util.spec_from_file_location("hvsock_capture", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class CaptureSupervisorTest(unittest.TestCase):
+    def test_relays_and_captures_both_directions(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            socket_path = root / "ch-vm.sock"
+            output = root / "capture"
+            backend = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            backend.bind(str(socket_path))
+            backend.listen(1)
+
+            def serve():
+                connection, _ = backend.accept()
+                data = connection.recv(4096)
+                connection.sendall(b"OK\n" + data)
+                connection.close()
+
+            server = threading.Thread(target=serve)
+            server.start()
+
+            supervisor = MODULE.CaptureSupervisor(
+                roots=[root],
+                names=["ch-vm.sock"],
+                output=output,
+            )
+            supervisor.scan_once()
+
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.connect(str(socket_path))
+            client.sendall(b"CONNECT 1024\nrequest")
+            client.shutdown(socket.SHUT_WR)
+            response = client.recv(4096)
+            client.close()
+
+            server.join(timeout=2)
+            for _ in range(100):
+                capture = output / "000001" / "agent-to-shim.bin"
+                if capture.exists() and capture.read_bytes():
+                    break
+                time.sleep(0.01)
+            supervisor.close()
+            backend.close()
+
+            self.assertEqual(response, b"OK\nCONNECT 1024\nrequest")
+            self.assertEqual(
+                (output / "000001" / "shim-to-agent.bin").read_bytes(),
+                b"CONNECT 1024\nrequest",
+            )
+            self.assertEqual(
+                (output / "000001" / "agent-to-shim.bin").read_bytes(),
+                response,
+            )
+            self.assertEqual(
+                supervisor.state()["intercepted_sockets"],
+                [str(socket_path)],
+            )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tools/genpolicy/nested-policy-compat/tests/test_kata_config_value.py
+++ b/src/tools/genpolicy/nested-policy-compat/tests/test_kata_config_value.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1] / "scripts" / "kata_config_value.sh"
+)
+
+
+class KataConfigValueTests(unittest.TestCase):
+    def test_reads_quoted_value_from_selected_section(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "configuration.toml"
+            config.write_text(
+                """
+[hypervisor.clh]
+image = "/opt/kata/share/kata-containers/kata-containers.img" # selected
+
+[runtime]
+hypervisor_name = "clh"
+""",
+                encoding="utf-8",
+            )
+            value = subprocess.check_output(
+                [SCRIPT, config, "hypervisor.clh", "image"],
+                text=True,
+            ).strip()
+            self.assertEqual(
+                value,
+                "/opt/kata/share/kata-containers/kata-containers.img",
+            )
+
+    def test_rejects_missing_value(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "configuration.toml"
+            config.write_text("[runtime]\n", encoding="utf-8")
+            result = subprocess.run(
+                [SCRIPT, config, "runtime", "hypervisor_name"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tools/genpolicy/nested-policy-compat/tests/test_reference_oci_image.py
+++ b/src/tools/genpolicy/nested-policy-compat/tests/test_reference_oci_image.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import io
+import json
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "appliance"
+    / "scripts"
+    / "reference_oci_image.py"
+)
+SPEC = importlib.util.spec_from_file_location("reference_oci_image", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+reference_oci_image = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(reference_oci_image)
+
+
+class ReferenceOciImageTests(unittest.TestCase):
+    def test_docker_archive_is_rejected_with_clear_error(self):
+        digest = f"sha256:{'1' * 64}"
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            oci_archive = root / "oci.tar"
+            with tarfile.open(oci_archive, "w") as archive:
+                data = json.dumps(
+                    {
+                        "schemaVersion": 2,
+                        "manifests": [{"digest": digest, "size": 1}],
+                    }
+                ).encode()
+                info = tarfile.TarInfo("index.json")
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
+
+            docker_archive = root / "docker.tar"
+            with tarfile.open(docker_archive, "w") as archive:
+                data = b"[]"
+                info = tarfile.TarInfo("manifest.json")
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
+
+            with self.assertRaisesRegex(
+                ValueError, "is not an OCI image-layout archive: index.json not found"
+            ):
+                reference_oci_image.find_archive(
+                    [oci_archive, docker_archive], digest
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tools/genpolicy/nested-policy-compat/tests/test_source_tree_fingerprint.py
+++ b/src/tools/genpolicy/nested-policy-compat/tests/test_source_tree_fingerprint.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "source_tree_fingerprint.sh"
+)
+
+
+class SourceTreeFingerprintTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tempdir.name)
+        subprocess.run(["git", "init", "-q", self.repo], check=True)
+        source = self.repo / "src" / "component"
+        source.mkdir(parents=True)
+        (source / "tracked.txt").write_text("one\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", self.repo, "add", "src/component/tracked.txt"],
+            check=True,
+        )
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def fingerprint(self):
+        return subprocess.check_output(
+            [SCRIPT, self.repo, "src/component"],
+            text=True,
+        ).strip()
+
+    def test_tracked_change_changes_fingerprint(self):
+        original = self.fingerprint()
+        (self.repo / "src/component/tracked.txt").write_text(
+            "two\n", encoding="utf-8"
+        )
+        self.assertNotEqual(original, self.fingerprint())
+
+    def test_untracked_file_changes_fingerprint(self):
+        original = self.fingerprint()
+        (self.repo / "src/component/untracked.txt").write_text(
+            "new\n", encoding="utf-8"
+        )
+        self.assertNotEqual(original, self.fingerprint())
+
+    def test_tracked_deletion_changes_fingerprint(self):
+        original = self.fingerprint()
+        (self.repo / "src/component/tracked.txt").unlink()
+        self.assertNotEqual(original, self.fingerprint())
+
+    def test_mode_change_changes_fingerprint(self):
+        source = self.repo / "src/component/tracked.txt"
+        source.chmod(0o755)
+        executable = self.fingerprint()
+        source.chmod(0o644)
+        self.assertNotEqual(executable, self.fingerprint())
+
+    def test_non_executable_umask_bits_do_not_change_fingerprint(self):
+        source = self.repo / "src/component/tracked.txt"
+        source.chmod(0o644)
+        standard = self.fingerprint()
+        source.chmod(0o664)
+        self.assertEqual(standard, self.fingerprint())
+
+    def test_checkout_path_does_not_affect_fingerprint(self):
+        alternate = subprocess.check_output(
+            [SCRIPT, f"{self.repo}/.", "src/component"],
+            text=True,
+        ).strip()
+        self.assertEqual(self.fingerprint(), alternate)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tools/genpolicy/nested-policy-compat/tests/validate.sh
+++ b/src/tools/genpolicy/nested-policy-compat/tests/validate.sh
@@ -11,6 +11,7 @@ set -o pipefail
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 bash -n "${root}/scripts/entrypoint.sh"
+bash -n "${root}/scripts/ensure_host_environment.sh"
 bash -n "${root}/scripts/ensure_kata_source_provenance.sh"
 bash -n "${root}/scripts/generate_policy.sh"
 bash -n "${root}/scripts/image_input_fingerprint.sh"
@@ -83,6 +84,7 @@ PY
 if command -v shellcheck >/dev/null 2>&1; then
 	shellcheck \
 		"${root}/scripts/entrypoint.sh" \
+		"${root}/scripts/ensure_host_environment.sh" \
 		"${root}/scripts/ensure_kata_source_provenance.sh" \
 		"${root}/scripts/generate_policy.sh" \
 		"${root}/scripts/image_input_fingerprint.sh" \

--- a/src/tools/genpolicy/nested-policy-compat/tests/validate.sh
+++ b/src/tools/genpolicy/nested-policy-compat/tests/validate.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+bash -n "${root}/scripts/entrypoint.sh"
+bash -n "${root}/scripts/ensure_kata_source_provenance.sh"
+bash -n "${root}/scripts/generate_policy.sh"
+bash -n "${root}/scripts/image_input_fingerprint.sh"
+bash -n "${root}/scripts/kata_config_value.sh"
+bash -n "${root}/scripts/rebuild_kata_stack.sh"
+bash -n "${root}/scripts/source_tree_fingerprint.sh"
+bash -n "${root}/scripts/verify_kata_source_provenance.sh"
+bash -n "${root}/appliance/scripts/entrypoint.sh"
+python3 -m py_compile \
+	"${root}/appliance/scripts/exercise_runtime_operations.py" \
+	"${root}/scripts/hvsock_capture.py" \
+	"${root}/scripts/compat_report.py"
+python3 -m unittest discover -s "${root}/tests" -p 'test_*.py'
+grep -Fq 'input.rule == "CreateSandboxRequest"' \
+	"${root}/tests/policy/create-sandbox-reasons.rego.inc"
+grep -Fq 'KATA_AGENT_MAKEFLAGS="EXTRA_RUSTFEATURES=allow-unattested-initdata"' \
+	"${root}/scripts/rebuild_kata_stack.sh"
+grep -Fq 'MEASURED_ROOTFS=no' \
+	"${root}/scripts/rebuild_kata_stack.sh"
+for profile in "${root}"/appliance/profiles/*.env; do
+	(
+		# shellcheck source=/dev/null
+		source "${profile}"
+		# shellcheck disable=SC2154
+		case "${ROOTFS_MODE}:${CONTAINERD_VERSION#v}" in
+		erofs-dmverity:2.* | guest-pull:1.7.* | guest-pull:2.*) ;;
+		*)
+			echo "unsupported rootfs/containerd profile combination: ${profile}" >&2
+			exit 1
+			;;
+		esac
+		# Values are loaded from the selected profile.
+		# shellcheck disable=SC2154
+		for required_file in \
+			"${root}/appliance/profiles/${GENPOLICY_SETTINGS}" \
+			"${root}/config/${GENPOLICY_CONTAINERD_CONFIG}" \
+			"${root}/config/${RUNTIME_CONTAINERD_CONFIG}"; do
+			[[ -f "${required_file}" ]]
+		done
+	)
+done
+python3 - \
+	"${root}/appliance/profiles/erofs-dmverity.settings.json" \
+	"${root}/appliance/profiles/guest-pull.settings.json" \
+	"${root}/appliance/profiles/guest-pull-containerd-1.7.settings.json" <<'PY'
+import json
+import sys
+
+patches = {patch["path"]: patch["value"] for patch in json.load(open(sys.argv[1], encoding="utf-8"))}
+assert patches["/cluster_config/emptydir_type"] == "block-encrypted"
+assert patches["/volumes/emptyDir_encrypted/driver"] == "local"
+assert patches["/volumes/emptyDir_encrypted/source"] == "local"
+assert patches["/volumes/emptyDir_encrypted/fstype"] == "local"
+assert patches["/volumes/emptyDir_encrypted/mount_type"] == "local"
+assert patches["/volumes/emptyDir_encrypted/shared"] is False
+
+guest_pull = {patch["path"]: patch["value"] for patch in json.load(open(sys.argv[2], encoding="utf-8"))}
+assert guest_pull["/common/image_layer_verification"] == "none"
+assert guest_pull["/common/allow_guest_pull_images"] is True
+assert guest_pull["/common/require_pinned_image_digests"] is True
+assert guest_pull["/cluster_config/guest_pull"] is True
+
+guest_pull_17 = {patch["path"]: patch["value"] for patch in json.load(open(sys.argv[3], encoding="utf-8"))}
+assert guest_pull_17["/common/allow_guest_pull_images"] is True
+assert guest_pull_17["/common/require_pinned_image_digests"] is True
+assert guest_pull_17["/cluster_config/guest_pull"] is True
+assert guest_pull_17["/kata_config/oci_version"] == "1.1.0"
+PY
+
+if command -v shellcheck >/dev/null 2>&1; then
+	shellcheck \
+		"${root}/scripts/entrypoint.sh" \
+		"${root}/scripts/ensure_kata_source_provenance.sh" \
+		"${root}/scripts/generate_policy.sh" \
+		"${root}/scripts/image_input_fingerprint.sh" \
+		"${root}/scripts/kata_config_value.sh" \
+		"${root}/scripts/rebuild_kata_stack.sh" \
+		"${root}/scripts/source_tree_fingerprint.sh" \
+		"${root}/scripts/verify_kata_source_provenance.sh" \
+		"${root}/appliance/scripts/entrypoint.sh" \
+		"${root}/tests/fixture-matrix-e2e.sh" \
+		"${root}/tests/validate.sh"
+fi

--- a/tests/spellcheck/kata-dictionary.txt
+++ b/tests/spellcheck/kata-dictionary.txt
@@ -194,6 +194,8 @@ injectivity
 interleavings
 misissuance
 workstream
+worktree
+finalizer
 LUKS
 mountinfo
 bypassable

--- a/tools/packaging/static-build/coco-guest-components/Dockerfile
+++ b/tools/packaging/static-build/coco-guest-components/Dockerfile
@@ -42,12 +42,12 @@ ARG NVAT_VERSION
 RUN if [ "$(uname -m)" = "x86_64" ] && [ -n "${NVAT_VERSION}" ]; then \
 	apt-get update && apt-get --no-install-recommends install -y \
 	build-essential libxml2-dev zlib1g-dev && \
-	tmpdir=$(mktemp -d) && pushd "$tmpdir" && \
+	tmpdir=$(mktemp -d) && cd "$tmpdir" && \
 	git clone https://github.com/NVIDIA/attestation-sdk && \
-	pushd attestation-sdk && git fetch --depth=1 origin "${NVAT_VERSION}" && \
-	git checkout FETCH_HEAD && pushd nv-attestation-sdk-cpp && cmake . && make install && \
+	cd attestation-sdk && git fetch --depth=1 origin "${NVAT_VERSION}" && \
+	git checkout FETCH_HEAD && cd nv-attestation-sdk-cpp && cmake . && make install && \
 	mkdir -p /usr/include && ln -sf /usr/local/include/nvat.h /usr/include/nvat.h && ldconfig && \
-	popd && popd && popd && rm -rf "$tmpdir" && \
+	cd / && rm -rf "$tmpdir" && \
 	apt-get clean && rm -rf /var/lib/apt/lists/; fi
 
 ENV LIBC="gnu"


### PR DESCRIPTION
## Summary

Add a self-contained compatibility appliance that verifies GenPolicy output
against strict runtime-rs Agent enforcement across pinned Kubernetes,
containerd, and image-delivery combinations.

The retained profiles are:

| Profile | Kubernetes | containerd | Image delivery |
|---|---:|---:|---|
| `k8s-1.33-containerd-2.3-erofs-dmverity` | 1.33.13 | 2.3.5 | Host-prepared EROFS layers with dm-verity |
| `k8s-1.36-containerd-2.3-erofs-dmverity` | 1.36.3 | 2.3.5 | Host-prepared EROFS layers with dm-verity |
| `k8s-1.33-containerd-1.7-guest-pull` | 1.33.13 | 1.7.34 | Digest-pinned guest pull |
| `k8s-1.36-containerd-2.3-guest-pull` | 1.36.3 | 2.3.5 | Digest-pinned guest pull |

All profiles boot the same dm-verity-protected monolithic guest image
containing the strict Agent, Confidential Data Hub, and pause bundle. This
keeps profile comparisons focused on Kubernetes, containerd, policy, and
image-delivery differences rather than different guest environments.

## Guest-pull integrity

Guest-pull profiles require digest-qualified image references. GenPolicy
records the pinned reference in the policy, Agent Rego compares that expected
digest with the `image_guest_pull` storage source, and CDH/image-rs uses
rust-oci-client to hash downloaded manifest bytes and reject a mismatch. For
multi-platform images, both the digest-qualified index and selected platform
manifest are verified.

The appliance publishes deterministic fixture images to a guest-reachable TLS
registry at `10.188.0.1:5000`. Its certificate is supplied to CDH through
init-data. The dedicated `10.188.0.0/16` CNI subnet avoids Podman's default
`10.88.0.0/16`, and forwarded IPv4/IPv6 traffic is dropped so the appliance
cannot act as an external-network gateway.

The containerd 1.7 profile uses the legacy version-2 CRI configuration and OCI
1.1.0 policy setting. Containerd 2.3 uses configuration version 4 and OCI
1.3.0. Because containerd 1.7 predates CRI custom stop-signal support, that
generation path removes the unsupported field and verifies the runtime's
default graceful-stop behavior.

## Compatibility coverage

For each profile, the appliance builds GenPolicy from the current checkout,
generates policy from Kubernetes YAML, delivers it to the strict Agent through
init-data, and runs the workload in a nested Cloud Hypervisor/KVM guest.

The positive eight-fixture matrix covers:

- environment, process, security-context, supplementary-group, sysctl,
  service-account, and `generateName` policy paths;
- ConfigMap, Secret, encrypted local `emptyDir`, memory/projected volumes, and
  EROFS dm-verity storage;
- readiness probes and `kubectl exec`;
- version-appropriate stop behavior, graceful termination, finalizer removal,
  and Pod deletion.

Focused reproducers document known limitations for custom service-account
field references and Pod termination-log retrieval without including those
expected failures in the positive matrix.

## Appliance and provenance behavior

The privileged appliance runs a minimal Kubernetes control plane and
containerd inside a container, then starts nested Kata guests for
generated-policy tests. It captures Agent RPC traffic and records policy
denials with fixture attribution.

The harness verifies that the runtime-rs shim, strict Agent, base guest image,
monolithic confidential image, and confidential-image root hash match the
checked-out source and recorded artifacts. Local runs rebuild stale artifacts
automatically, while CI exposes separate artifact-production and verify-only
phases so a test cannot hide stale Kata artifacts through an implicit rebuild.

No runtime-rs source changes are included.

## Host requirements

The host must provide KVM, TUN, cgroup v2, loop/device-mapper support, Podman or
Docker, and a Kata installation containing runtime-rs, a compatible Cloud
Hypervisor build, the guest kernel, and guest-image build prerequisites.

The checkout rebuild path creates a non-confidential development guest. It
enables `allow-unattested-initdata` so synthetic test policy and CDH registry
trust can be delivered without a TEE launch measurement; this mode is not
intended for confidential production guests.

## Validation

- Kubernetes 1.33.13 + containerd 1.7.34 guest pull: 8/8 fixtures compatible
- Kubernetes 1.36.3 + containerd 2.3.5 guest pull: 8/8 fixtures compatible
- Kubernetes 1.33.13 + containerd 2.3.5 EROFS/dm-verity: 8/8 fixtures compatible
- Kubernetes 1.36.3 + containerd 2.3.5 EROFS/dm-verity: 8/8 fixtures compatible
- Nested appliance validation: 15 tests passed
- License-header and diff checks passed
